### PR TITLE
Fix node memory usage fallback

### DIFF
--- a/src/proxmox_mcp/tools/node.py
+++ b/src/proxmox_mcp/tools/node.py
@@ -86,7 +86,12 @@ class NodeTools(ProxmoxTool):
                         "uptime": 0,
                         "maxcpu": "N/A",
                         "memory": {
-                            "used": node.get("maxmem", 0) - node.get("mem", 0),
+                            # The nodes.get() API already returns memory usage
+                            # in the "mem" field, so use that directly. The
+                            # previous implementation subtracted this value
+                            # from "maxmem" which actually produced the amount
+                            # of *free* memory instead of the used memory.
+                            "used": node.get("mem", 0),
                             "total": node.get("maxmem", 0)
                         }
                     })


### PR DESCRIPTION
## Summary
- correct fallback memory calculation for nodes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mcp')*

------
https://chatgpt.com/codex/tasks/task_e_684d072946c08328bae31a65221d0b91