### PR TITLE
Add test_start_vm

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -222,3 +222,14 @@ async def test_execute_vm_command_with_error(server, mock_proxmox):
     assert result["output"] == ""
     assert result["error"] == "command not found"
     assert result["exit_code"] == 1
+
+@pytest.mark.asyncio
+async def test_start_vm(server, mock_proxmox):
+    """Test start_vm tool."""
+    mock_proxmox.return_value.nodes.return_value.qemu.return_value.status.current.get.return_value = {
+        "status": "stopped"
+    }
+    mock_proxmox.return_value.nodes.return_value.qemu.return_value.status.start.post.return_value = "UPID:taskid"
+
+    response = await server.mcp.call_tool("start_vm", {"node": "node1", "vmid": "100"})
+    assert "start initiated successfully" in response[0].text


### PR DESCRIPTION
## Summary
- test VM start via FastMCP server

## Testing
- `PYTHONPATH=src pytest -q` *(fails: AttributeError: ProxmoxAPI)*

------
https://chatgpt.com/codex/tasks/task_e_684d09f654a08328a727336226eb6c98