### PR TITLE
Fix proxmox patch path in tests

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -27,7 +27,7 @@ def mock_env_vars():
 @pytest.fixture
 def mock_proxmox():
     """Fixture to mock ProxmoxAPI."""
-    with patch("proxmox_mcp.server.ProxmoxAPI") as mock:
+    with patch("proxmox_mcp.core.proxmox.ProxmoxAPI") as mock:
         mock.return_value.nodes.get.return_value = [
             {"node": "node1", "status": "online"},
             {"node": "node2", "status": "online"}


### PR DESCRIPTION
## Summary
- fix `ProxmoxAPI` patch path in test fixture
- run tests (failures expected from missing config)

## Testing
- `pip install -e .`
- `pytest -q` *(fails: PROXMOX_MCP_CONFIG environment variable must be set)*

------
https://chatgpt.com/codex/tasks/task_e_684d09ed1f5c8328afa6e40c0255609b