### PR TITLE
feat: add snapshot, ISO, and backup management tools

### DIFF
--- a/src/proxmox_mcp/tools/backup.py
+++ b/src/proxmox_mcp/tools/backup.py
@@ -1,0 +1,342 @@
+"""Backup and restore tools for Proxmox MCP."""
+from typing import List, Dict, Optional, Any
+import json
+from datetime import datetime
+from mcp.types import TextContent as Content
+from .base import ProxmoxTool
+
+
+def _as_list(maybe: Any) -> List:
+    """Return list; unwrap {'data': list}; else []."""
+    if isinstance(maybe, list):
+        return maybe
+    if isinstance(maybe, dict):
+        data = maybe.get("data")
+        if isinstance(data, list):
+            return data
+    return []
+
+
+def _get(d: Any, key: str, default: Any = None) -> Any:
+    """dict.get with None guard."""
+    if isinstance(d, dict):
+        return d.get(key, default)
+    return default
+
+
+def _b2h(n: Any) -> str:
+    """bytes -> human readable."""
+    try:
+        n = float(n)
+    except Exception:
+        return "0 B"
+    units = ("B", "KiB", "MiB", "GiB", "TiB")
+    i = 0
+    while n >= 1024.0 and i < len(units) - 1:
+        n /= 1024.0
+        i += 1
+    return f"{n:.2f} {units[i]}"
+
+
+class BackupTools(ProxmoxTool):
+    """Backup and restore tools for VMs and containers."""
+
+    def _json_fmt(self, data: Any) -> List[Content]:
+        """Return raw JSON string."""
+        return [Content(type="text", text=json.dumps(data, indent=2, sort_keys=True))]
+
+    def _err(self, action: str, e: Exception) -> List[Content]:
+        """Handle errors."""
+        if hasattr(self, "_handle_error"):
+            self._handle_error(action, e)
+        return [Content(type="text", text=f"Error: {action} - {str(e)}")]
+
+    def list_backups(
+        self,
+        node: Optional[str] = None,
+        storage: Optional[str] = None,
+        vmid: Optional[str] = None,
+    ) -> List[Content]:
+        """List available backups across the cluster.
+
+        Parameters:
+            node: Filter by node (optional)
+            storage: Filter by storage pool (optional)
+            vmid: Filter by VM/container ID (optional)
+
+        Returns:
+            List[Content] with backup information
+        """
+        try:
+            results = []
+            nodes = _as_list(self.proxmox.nodes.get())
+
+            for n in nodes:
+                node_name = _get(n, "node")
+                if not node_name:
+                    continue
+                if node and node_name != node:
+                    continue
+
+                storages = _as_list(self.proxmox.nodes(node_name).storage.get())
+                for s in storages:
+                    storage_name = _get(s, "storage")
+                    if not storage_name:
+                        continue
+                    if storage and storage_name != storage:
+                        continue
+
+                    # Check if storage supports backups
+                    content_types = _get(s, "content", "")
+                    if "backup" not in content_types:
+                        continue
+
+                    try:
+                        params: Dict[str, Any] = {"content": "backup"}
+                        if vmid:
+                            params["vmid"] = int(vmid)
+
+                        content = _as_list(
+                            self.proxmox.nodes(node_name).storage(storage_name).content.get(**params)
+                        )
+                        for item in content:
+                            item["_node"] = node_name
+                            item["_storage"] = storage_name
+                            results.append(item)
+                    except Exception:
+                        continue
+
+            if not results:
+                msg = "No backups found"
+                if node:
+                    msg += f" on node {node}"
+                if storage:
+                    msg += f" in storage {storage}"
+                if vmid:
+                    msg += f" for VM/CT {vmid}"
+                return [Content(type="text", text=msg)]
+
+            # Sort by creation time (newest first)
+            results.sort(key=lambda x: _get(x, "ctime", 0), reverse=True)
+
+            lines = ["💾 Available Backups", ""]
+
+            for backup in results:
+                volid = _get(backup, "volid", "unknown")
+                size = _get(backup, "size", 0)
+                ctime = _get(backup, "ctime")
+                backup_vmid = _get(backup, "vmid", "?")
+                notes = _get(backup, "notes", "")
+                protected = _get(backup, "protected", False)
+                node_name = _get(backup, "_node", "?")
+                storage_name = _get(backup, "_storage", "?")
+                fmt = _get(backup, "format", "")
+
+                # Parse timestamp
+                time_str = "Unknown"
+                if ctime:
+                    try:
+                        dt = datetime.fromtimestamp(ctime)
+                        time_str = dt.strftime("%Y-%m-%d %H:%M:%S")
+                    except Exception:
+                        time_str = str(ctime)
+
+                lines.append(f"  💾 VM/CT {backup_vmid} - {time_str}")
+                lines.append(f"     Size: {_b2h(size)}")
+                lines.append(f"     Format: {fmt}")
+                lines.append(f"     Storage: {storage_name} @ {node_name}")
+                lines.append(f"     Volume ID: {volid}")
+                if notes:
+                    lines.append(f"     Notes: {notes}")
+                if protected:
+                    lines.append(f"     🔒 Protected")
+                lines.append("")
+
+            lines.append("Use the Volume ID with restore_backup to restore.")
+
+            return [Content(type="text", text="\n".join(lines).rstrip())]
+
+        except Exception as e:
+            return self._err("list backups", e)
+
+    def create_backup(
+        self,
+        node: str,
+        vmid: str,
+        storage: str,
+        compress: str = "zstd",
+        mode: str = "snapshot",
+        notes: Optional[str] = None,
+    ) -> List[Content]:
+        """Create a backup of a VM or container.
+
+        Parameters:
+            node: Node where VM/container runs
+            vmid: VM or container ID to backup
+            storage: Target backup storage
+            compress: Compression (0, gzip, lz4, zstd)
+            mode: Backup mode (snapshot, suspend, stop)
+            notes: Optional notes/description
+
+        Returns:
+            List[Content] with backup result
+        """
+        try:
+            params: Dict[str, Any] = {
+                "vmid": vmid,
+                "storage": storage,
+                "compress": compress,
+                "mode": mode,
+            }
+
+            if notes:
+                params["notes-template"] = notes
+
+            result = self.proxmox.nodes(node).vzdump.post(**params)
+
+            lines = [
+                "💾 Backup Started",
+                "",
+                f"  • VM/CT ID: {vmid}",
+                f"  • Node: {node}",
+                f"  • Storage: {storage}",
+                f"  • Compression: {compress}",
+                f"  • Mode: {mode}",
+            ]
+
+            if notes:
+                lines.append(f"  • Notes: {notes}")
+
+            lines.extend([
+                "",
+                f"Task ID: {result}",
+                "",
+                "The backup is running in the background.",
+                "Use list_backups to verify when complete.",
+            ])
+
+            return [Content(type="text", text="\n".join(lines))]
+
+        except Exception as e:
+            return self._err(f"create backup for {vmid}", e)
+
+    def restore_backup(
+        self,
+        node: str,
+        archive: str,
+        vmid: str,
+        storage: Optional[str] = None,
+        unique: bool = True,
+    ) -> List[Content]:
+        """Restore a VM or container from a backup.
+
+        Parameters:
+            node: Target node for restore
+            archive: Backup volume ID (from list_backups)
+            vmid: New VM/container ID for the restored machine
+            storage: Target storage for disks (optional)
+            unique: Generate unique MAC addresses (default: true)
+
+        Returns:
+            List[Content] with restore result
+        """
+        try:
+            # Determine if this is a VM or container backup
+            is_lxc = "/ct/" in archive.lower() or "vzdump-lxc" in archive.lower()
+
+            params: Dict[str, Any] = {
+                "archive": archive,
+                "vmid": int(vmid),
+            }
+
+            if storage:
+                params["storage"] = storage
+
+            if unique:
+                params["unique"] = 1
+
+            if is_lxc:
+                result = self.proxmox.nodes(node).lxc.post(**params)
+                vm_type = "Container"
+            else:
+                result = self.proxmox.nodes(node).qemu.post(**params)
+                vm_type = "VM"
+
+            lines = [
+                f"♻️ {vm_type} Restore Started",
+                "",
+                f"  • New ID: {vmid}",
+                f"  • From: {archive}",
+                f"  • Target Node: {node}",
+            ]
+
+            if storage:
+                lines.append(f"  • Target Storage: {storage}")
+
+            lines.append(f"  • Unique MACs: {'Yes' if unique else 'No'}")
+
+            lines.extend([
+                "",
+                f"Task ID: {result}",
+                "",
+                "The restore is running in the background.",
+                f"The {vm_type.lower()} will be available once the task completes.",
+            ])
+
+            return [Content(type="text", text="\n".join(lines))]
+
+        except Exception as e:
+            return self._err(f"restore backup to {vmid}", e)
+
+    def delete_backup(
+        self,
+        node: str,
+        storage: str,
+        volid: str,
+    ) -> List[Content]:
+        """Delete a backup file from storage.
+
+        Parameters:
+            node: Node name
+            storage: Storage pool name
+            volid: Backup volume ID to delete
+
+        Returns:
+            List[Content] with deletion result
+        """
+        try:
+            # Check if backup is protected
+            content = _as_list(
+                self.proxmox.nodes(node).storage(storage).content.get(content="backup")
+            )
+
+            backup_info = None
+            for item in content:
+                if _get(item, "volid") == volid:
+                    backup_info = item
+                    break
+
+            if backup_info and _get(backup_info, "protected"):
+                return [Content(
+                    type="text",
+                    text=f"Error: Backup '{volid}' is protected and cannot be deleted.\n"
+                         f"Remove protection first if you want to delete it."
+                )]
+
+            result = self.proxmox.nodes(node).storage(storage).content(volid).delete()
+
+            lines = [
+                "🗑️ Backup Deleted",
+                "",
+                f"  • Volume: {volid}",
+                f"  • Storage: {storage}",
+                f"  • Node: {node}",
+            ]
+
+            if result:
+                lines.extend(["", f"Task ID: {result}"])
+
+            return [Content(type="text", text="\n".join(lines))]
+
+        except Exception as e:
+            return self._err(f"delete backup '{volid}'", e)

--- a/src/proxmox_mcp/tools/iso.py
+++ b/src/proxmox_mcp/tools/iso.py
@@ -1,0 +1,305 @@
+"""ISO and template management tools for Proxmox MCP."""
+from typing import List, Dict, Optional, Any
+import json
+from mcp.types import TextContent as Content
+from .base import ProxmoxTool
+
+
+def _as_list(maybe: Any) -> List:
+    """Return list; unwrap {'data': list}; else []."""
+    if isinstance(maybe, list):
+        return maybe
+    if isinstance(maybe, dict):
+        data = maybe.get("data")
+        if isinstance(data, list):
+            return data
+    return []
+
+
+def _get(d: Any, key: str, default: Any = None) -> Any:
+    """dict.get with None guard."""
+    if isinstance(d, dict):
+        return d.get(key, default)
+    return default
+
+
+def _b2h(n: Any) -> str:
+    """bytes -> human readable."""
+    try:
+        n = float(n)
+    except Exception:
+        return "0 B"
+    units = ("B", "KiB", "MiB", "GiB", "TiB")
+    i = 0
+    while n >= 1024.0 and i < len(units) - 1:
+        n /= 1024.0
+        i += 1
+    return f"{n:.2f} {units[i]}"
+
+
+class ISOTools(ProxmoxTool):
+    """ISO and template management tools."""
+
+    def _json_fmt(self, data: Any) -> List[Content]:
+        """Return raw JSON string."""
+        return [Content(type="text", text=json.dumps(data, indent=2, sort_keys=True))]
+
+    def _err(self, action: str, e: Exception) -> List[Content]:
+        """Handle errors."""
+        if hasattr(self, "_handle_error"):
+            self._handle_error(action, e)
+        return [Content(type="text", text=f"Error: {action} - {str(e)}")]
+
+    def _get_storage_content(
+        self, content_type: str, node: Optional[str] = None, storage: Optional[str] = None
+    ) -> List[Dict]:
+        """Get storage content filtered by type across nodes/storages."""
+        results = []
+        nodes = _as_list(self.proxmox.nodes.get())
+
+        for n in nodes:
+            node_name = _get(n, "node")
+            if not node_name:
+                continue
+            if node and node_name != node:
+                continue
+
+            storages = _as_list(self.proxmox.nodes(node_name).storage.get())
+            for s in storages:
+                storage_name = _get(s, "storage")
+                if not storage_name:
+                    continue
+                if storage and storage_name != storage:
+                    continue
+
+                # Check if storage supports this content type
+                content_types = _get(s, "content", "")
+                if content_type not in content_types:
+                    continue
+
+                try:
+                    content = _as_list(
+                        self.proxmox.nodes(node_name).storage(storage_name).content.get(
+                            content=content_type
+                        )
+                    )
+                    for item in content:
+                        item["_node"] = node_name
+                        item["_storage"] = storage_name
+                        results.append(item)
+                except Exception:
+                    continue
+
+        return results
+
+    def list_isos(
+        self,
+        node: Optional[str] = None,
+        storage: Optional[str] = None,
+    ) -> List[Content]:
+        """List available ISO images.
+
+        Parameters:
+            node: Filter by node (optional)
+            storage: Filter by storage pool (optional)
+
+        Returns:
+            List[Content] with ISO information
+        """
+        try:
+            isos = self._get_storage_content("iso", node, storage)
+
+            if not isos:
+                msg = "No ISO images found"
+                if node:
+                    msg += f" on node {node}"
+                if storage:
+                    msg += f" in storage {storage}"
+                return [Content(type="text", text=msg)]
+
+            lines = ["💿 Available ISO Images", ""]
+
+            for iso in sorted(isos, key=lambda x: _get(x, "volid", "")):
+                volid = _get(iso, "volid", "unknown")
+                size = _get(iso, "size", 0)
+                node_name = _get(iso, "_node", "?")
+                storage_name = _get(iso, "_storage", "?")
+
+                # Extract filename from volid (format: storage:iso/filename.iso)
+                filename = volid.split("/")[-1] if "/" in volid else volid
+
+                lines.append(f"  💿 {filename}")
+                lines.append(f"     Size: {_b2h(size)}")
+                lines.append(f"     Storage: {storage_name} @ {node_name}")
+                lines.append(f"     Volume ID: {volid}")
+                lines.append("")
+
+            return [Content(type="text", text="\n".join(lines).rstrip())]
+
+        except Exception as e:
+            return self._err("list ISOs", e)
+
+    def list_templates(
+        self,
+        node: Optional[str] = None,
+        storage: Optional[str] = None,
+    ) -> List[Content]:
+        """List available OS templates for containers.
+
+        Parameters:
+            node: Filter by node (optional)
+            storage: Filter by storage pool (optional)
+
+        Returns:
+            List[Content] with template information
+        """
+        try:
+            templates = self._get_storage_content("vztmpl", node, storage)
+
+            if not templates:
+                msg = "No OS templates found"
+                if node:
+                    msg += f" on node {node}"
+                if storage:
+                    msg += f" in storage {storage}"
+                return [Content(type="text", text=msg)]
+
+            lines = ["📦 Available OS Templates", ""]
+
+            for tmpl in sorted(templates, key=lambda x: _get(x, "volid", "")):
+                volid = _get(tmpl, "volid", "unknown")
+                size = _get(tmpl, "size", 0)
+                node_name = _get(tmpl, "_node", "?")
+                storage_name = _get(tmpl, "_storage", "?")
+
+                # Extract filename from volid
+                filename = volid.split("/")[-1] if "/" in volid else volid
+
+                lines.append(f"  📦 {filename}")
+                lines.append(f"     Size: {_b2h(size)}")
+                lines.append(f"     Storage: {storage_name} @ {node_name}")
+                lines.append(f"     Volume ID: {volid}")
+                lines.append("")
+
+            lines.append("Use the Volume ID with create_container's ostemplate parameter.")
+
+            return [Content(type="text", text="\n".join(lines).rstrip())]
+
+        except Exception as e:
+            return self._err("list templates", e)
+
+    def download_iso(
+        self,
+        node: str,
+        storage: str,
+        url: str,
+        filename: str,
+        checksum: Optional[str] = None,
+        checksum_algorithm: str = "sha256",
+    ) -> List[Content]:
+        """Download an ISO image from a URL to Proxmox storage.
+
+        Parameters:
+            node: Target node name
+            storage: Target storage pool
+            url: URL to download from
+            filename: Target filename (e.g., 'ubuntu-22.04.iso')
+            checksum: Optional checksum for verification
+            checksum_algorithm: Algorithm (sha256, sha512, md5)
+
+        Returns:
+            List[Content] with download result
+        """
+        try:
+            params: Dict[str, Any] = {
+                "url": url,
+                "filename": filename,
+                "content": "iso",
+            }
+
+            if checksum:
+                params["checksum"] = checksum
+                params["checksum-algorithm"] = checksum_algorithm
+
+            result = self.proxmox.nodes(node).storage(storage)("download-url").post(**params)
+
+            lines = [
+                "⬇️ ISO Download Started",
+                "",
+                f"  • Filename: {filename}",
+                f"  • URL: {url}",
+                f"  • Storage: {storage} @ {node}",
+            ]
+
+            if checksum:
+                lines.append(f"  • Checksum: {checksum_algorithm.upper()}")
+
+            lines.extend([
+                "",
+                f"Task ID: {result}",
+                "",
+                "The download is running in the background.",
+                "Use list_isos to verify when complete.",
+            ])
+
+            return [Content(type="text", text="\n".join(lines))]
+
+        except Exception as e:
+            return self._err(f"download ISO '{filename}'", e)
+
+    def delete_iso(
+        self,
+        node: str,
+        storage: str,
+        filename: str,
+    ) -> List[Content]:
+        """Delete an ISO or template from storage.
+
+        Parameters:
+            node: Node name
+            storage: Storage pool name
+            filename: ISO/template filename or full volume ID
+
+        Returns:
+            List[Content] with deletion result
+        """
+        try:
+            # Construct volume ID if just filename provided
+            if ":" not in filename:
+                # Try to find the volume ID
+                content = _as_list(
+                    self.proxmox.nodes(node).storage(storage).content.get()
+                )
+                volid = None
+                for item in content:
+                    item_volid = _get(item, "volid", "")
+                    if filename in item_volid:
+                        volid = item_volid
+                        break
+
+                if not volid:
+                    return [Content(
+                        type="text",
+                        text=f"Error: Could not find '{filename}' in {storage} on {node}"
+                    )]
+            else:
+                volid = filename
+
+            # Delete the content
+            result = self.proxmox.nodes(node).storage(storage).content(volid).delete()
+
+            lines = [
+                "🗑️ ISO/Template Deleted",
+                "",
+                f"  • Volume: {volid}",
+                f"  • Storage: {storage}",
+                f"  • Node: {node}",
+            ]
+
+            if result:
+                lines.extend(["", f"Task ID: {result}"])
+
+            return [Content(type="text", text="\n".join(lines))]
+
+        except Exception as e:
+            return self._err(f"delete ISO/template '{filename}'", e)

--- a/src/proxmox_mcp/tools/snapshots.py
+++ b/src/proxmox_mcp/tools/snapshots.py
@@ -1,0 +1,283 @@
+"""Snapshot management tools for Proxmox MCP."""
+from typing import List, Dict, Optional, Any
+import json
+from mcp.types import TextContent as Content
+from .base import ProxmoxTool
+
+
+def _as_list(maybe: Any) -> List:
+    """Return list; unwrap {'data': list}; else []."""
+    if isinstance(maybe, list):
+        return maybe
+    if isinstance(maybe, dict):
+        data = maybe.get("data")
+        if isinstance(data, list):
+            return data
+    return []
+
+
+def _get(d: Any, key: str, default: Any = None) -> Any:
+    """dict.get with None guard."""
+    if isinstance(d, dict):
+        return d.get(key, default)
+    return default
+
+
+class SnapshotTools(ProxmoxTool):
+    """Snapshot management tools for VMs and containers."""
+
+    def _json_fmt(self, data: Any) -> List[Content]:
+        """Return raw JSON string."""
+        return [Content(type="text", text=json.dumps(data, indent=2, sort_keys=True))]
+
+    def _err(self, action: str, e: Exception) -> List[Content]:
+        """Handle errors."""
+        if hasattr(self, "_handle_error"):
+            self._handle_error(action, e)
+        return [Content(type="text", text=f"Error: {action} - {str(e)}")]
+
+    def list_snapshots(
+        self,
+        node: str,
+        vmid: str,
+        vm_type: str = "qemu",
+    ) -> List[Content]:
+        """List all snapshots for a VM or container.
+
+        Parameters:
+            node: Host node name (e.g., 'pve')
+            vmid: VM or container ID
+            vm_type: 'qemu' for VMs, 'lxc' for containers
+
+        Returns:
+            List[Content] with snapshot information
+        """
+        try:
+            if vm_type == "lxc":
+                snapshots = _as_list(
+                    self.proxmox.nodes(node).lxc(vmid).snapshot.get()
+                )
+            else:
+                snapshots = _as_list(
+                    self.proxmox.nodes(node).qemu(vmid).snapshot.get()
+                )
+
+            if not snapshots:
+                return [Content(
+                    type="text",
+                    text=f"No snapshots found for {vm_type.upper()} {vmid} on node {node}"
+                )]
+
+            lines = [
+                f"📸 Snapshots for {vm_type.upper()} {vmid} on {node}",
+                ""
+            ]
+
+            for snap in snapshots:
+                name = _get(snap, "name", "unknown")
+                description = _get(snap, "description", "")
+                snaptime = _get(snap, "snaptime")
+                parent = _get(snap, "parent", "")
+                vmstate = _get(snap, "vmstate", False)
+
+                # Skip 'current' pseudo-snapshot
+                if name == "current":
+                    continue
+
+                lines.append(f"  📷 {name}")
+                if description:
+                    lines.append(f"     Description: {description}")
+                if snaptime:
+                    from datetime import datetime
+                    try:
+                        dt = datetime.fromtimestamp(snaptime)
+                        lines.append(f"     Created: {dt.strftime('%Y-%m-%d %H:%M:%S')}")
+                    except Exception:
+                        lines.append(f"     Created: {snaptime}")
+                if parent:
+                    lines.append(f"     Parent: {parent}")
+                if vmstate:
+                    lines.append(f"     RAM State: Included")
+                lines.append("")
+
+            return [Content(type="text", text="\n".join(lines).rstrip())]
+
+        except Exception as e:
+            return self._err(f"list snapshots for {vm_type} {vmid}", e)
+
+    def create_snapshot(
+        self,
+        node: str,
+        vmid: str,
+        snapname: str,
+        description: Optional[str] = None,
+        vmstate: bool = False,
+        vm_type: str = "qemu",
+    ) -> List[Content]:
+        """Create a snapshot of a VM or container.
+
+        Parameters:
+            node: Host node name
+            vmid: VM or container ID
+            snapname: Snapshot name (no spaces)
+            description: Optional description
+            vmstate: Include RAM state (VMs only)
+            vm_type: 'qemu' for VMs, 'lxc' for containers
+
+        Returns:
+            List[Content] with creation result
+        """
+        try:
+            params: Dict[str, Any] = {"snapname": snapname}
+
+            if description:
+                params["description"] = description
+
+            if vm_type == "lxc":
+                result = self.proxmox.nodes(node).lxc(vmid).snapshot.post(**params)
+            else:
+                if vmstate:
+                    params["vmstate"] = 1
+                result = self.proxmox.nodes(node).qemu(vmid).snapshot.post(**params)
+
+            lines = [
+                "📸 Snapshot Created Successfully",
+                "",
+                f"  • Name: {snapname}",
+                f"  • {vm_type.upper()} ID: {vmid}",
+                f"  • Node: {node}",
+            ]
+            if description:
+                lines.append(f"  • Description: {description}")
+            if vmstate and vm_type == "qemu":
+                lines.append(f"  • RAM State: Included")
+
+            lines.extend([
+                "",
+                f"Task ID: {result}",
+                "",
+                "Next steps:",
+                f"  • List snapshots: list_snapshots node='{node}' vmid='{vmid}' vm_type='{vm_type}'",
+                f"  • Rollback: rollback_snapshot node='{node}' vmid='{vmid}' snapname='{snapname}' vm_type='{vm_type}'",
+            ])
+
+            return [Content(type="text", text="\n".join(lines))]
+
+        except Exception as e:
+            return self._err(f"create snapshot '{snapname}' for {vm_type} {vmid}", e)
+
+    def delete_snapshot(
+        self,
+        node: str,
+        vmid: str,
+        snapname: str,
+        vm_type: str = "qemu",
+    ) -> List[Content]:
+        """Delete a snapshot.
+
+        Parameters:
+            node: Host node name
+            vmid: VM or container ID
+            snapname: Snapshot name to delete
+            vm_type: 'qemu' for VMs, 'lxc' for containers
+
+        Returns:
+            List[Content] with deletion result
+        """
+        try:
+            if vm_type == "lxc":
+                result = self.proxmox.nodes(node).lxc(vmid).snapshot(snapname).delete()
+            else:
+                result = self.proxmox.nodes(node).qemu(vmid).snapshot(snapname).delete()
+
+            lines = [
+                "🗑️ Snapshot Deleted",
+                "",
+                f"  • Name: {snapname}",
+                f"  • {vm_type.upper()} ID: {vmid}",
+                f"  • Node: {node}",
+                "",
+                f"Task ID: {result}",
+            ]
+
+            return [Content(type="text", text="\n".join(lines))]
+
+        except Exception as e:
+            return self._err(f"delete snapshot '{snapname}' for {vm_type} {vmid}", e)
+
+    def rollback_snapshot(
+        self,
+        node: str,
+        vmid: str,
+        snapname: str,
+        vm_type: str = "qemu",
+    ) -> List[Content]:
+        """Rollback to a snapshot.
+
+        WARNING: This will stop the VM/container and restore to the snapshot state!
+        NOTE: For ZFS storage, this will delete any snapshots newer than the target.
+
+        Parameters:
+            node: Host node name
+            vmid: VM or container ID
+            snapname: Snapshot name to restore
+            vm_type: 'qemu' for VMs, 'lxc' for containers
+
+        Returns:
+            List[Content] with rollback result
+        """
+        try:
+            # For ZFS-based storage, we may need to delete newer snapshots first
+            # Get current snapshots to check if target is most recent
+            if vm_type == "lxc":
+                snapshots = _as_list(self.proxmox.nodes(node).lxc(vmid).snapshot.get())
+            else:
+                snapshots = _as_list(self.proxmox.nodes(node).qemu(vmid).snapshot.get())
+
+            # Find snapshots that are children of our target (newer snapshots)
+            # These need to be deleted for ZFS rollback to work
+            deleted_snaps = []
+            for snap in snapshots:
+                parent = _get(snap, "parent", "")
+                snap_name = _get(snap, "name", "")
+                if snap_name != "current" and parent == snapname:
+                    # This snapshot is a child of our target, delete it
+                    try:
+                        if vm_type == "lxc":
+                            self.proxmox.nodes(node).lxc(vmid).snapshot(snap_name).delete()
+                        else:
+                            self.proxmox.nodes(node).qemu(vmid).snapshot(snap_name).delete()
+                        deleted_snaps.append(snap_name)
+                    except Exception:
+                        pass
+
+            # Now perform the rollback
+            if vm_type == "lxc":
+                result = self.proxmox.nodes(node).lxc(vmid).snapshot(snapname).rollback.post()
+            else:
+                result = self.proxmox.nodes(node).qemu(vmid).snapshot(snapname).rollback.post()
+
+            lines = [
+                "⏪ Snapshot Rollback Initiated",
+                "",
+                f"  • Restoring to: {snapname}",
+                f"  • {vm_type.upper()} ID: {vmid}",
+                f"  • Node: {node}",
+            ]
+
+            if deleted_snaps:
+                lines.append(f"  • Deleted newer snapshots: {', '.join(deleted_snaps)}")
+
+            lines.extend([
+                "",
+                "⚠️  WARNING: VM/container will be stopped during rollback!",
+                "",
+                f"Task ID: {result}",
+                "",
+                "The VM/container will be restored to its state at the time of the snapshot.",
+            ])
+
+            return [Content(type="text", text="\n".join(lines))]
+
+        except Exception as e:
+            return self._err(f"rollback to snapshot '{snapname}' for {vm_type} {vmid}", e)


### PR DESCRIPTION
## Summary

This PR adds **14 new MCP tools** for comprehensive Proxmox management:

### Snapshot Management (4 tools)
- `list_snapshots` - List snapshots for VMs and containers
- `create_snapshot` - Create snapshots with optional RAM state (VMs)
- `delete_snapshot` - Remove snapshots
- `rollback_snapshot` - Restore to snapshot (auto-handles ZFS limitations)

### ISO & Template Management (4 tools)
- `list_isos` - List available ISO images across cluster
- `list_templates` - List OS templates for container creation
- `download_iso` - Download ISO from URL with checksum verification
- `delete_iso` - Remove ISO/template from storage

### Backup & Restore (4 tools)
- `list_backups` - List available backups with node/storage/vmid filters
- `create_backup` - Create backup with compression options (zstd, lz4, gzip)
- `restore_backup` - Restore VM/container from backup
- `delete_backup` - Remove backup files

### Container Management (2 tools)
- `create_container` - Register existing implementation as MCP tool
- `delete_container` - Delete containers with force option

## Technical Details

- All snapshot tools support both VMs (`qemu`) and containers (`lxc`)
- ZFS rollback automatically deletes newer snapshots (required by ZFS)
- Backup tools support all Proxmox compression modes
- ISO download includes optional checksum verification

## Test plan

- [x] Tested connection to Proxmox server
- [x] Tested template download
- [x] Tested container create/start/stop/delete
- [x] Tested snapshot create/list/rollback/delete
- [x] Tested backup create/list
- [x] Verified all tools register correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)