### PR TITLE
Merge PR #18: add MCP transport config; fix FastMCP init and startup dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ Before starting, ensure you have:
            "level": "INFO",               # Optional: DEBUG for more detail
            "format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
            "file": "proxmox_mcp.log"      # Optional: Log to file
+       },
+       "mcp": {
+           "host": "127.0.0.1",           # Optional: Host for SSE/STREAMABLE transports
+           "port": 8000,                  # Optional: Port for SSE/STREAMABLE transports
+           "transport": "STDIO"           # Optional: STDIO, SSE, or STREAMABLE
        }
    }
    ```
@@ -177,6 +182,15 @@ source .venv/bin/activate  # Linux/macOS
 # Run the server
 python -m proxmox_mcp.server
 ```
+
+### MCP Transport Configuration
+
+The MCP server supports multiple transport modes. Configure these in the `mcp` section of
+your `proxmox-config/config.json`:
+
+- `STDIO`: Default. Run over stdio for MCP clients like Claude Desktop/Cline.
+- `SSE`: Serve MCP over Server-Sent Events (SSE).
+- `STREAMABLE`: Serve MCP over streamable HTTP.
 
 ### OpenAPI Deployment (Production Ready)
 

--- a/proxmox-config/config.example.json
+++ b/proxmox-config/config.example.json
@@ -14,5 +14,10 @@
         "level": "DEBUG",
         "format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         "file": "proxmox_mcp.log"
+    },
+    "mcp": {
+        "host": "127.0.0.1",
+        "port": 8000,
+        "transport": "STDIO"
     }
 }


### PR DESCRIPTION
### Motivation
- PR #18 introduced MCP configuration (host/port/transport) and added SSE / streamable HTTP transports, but merge conflicts and bugs caused duplicate FastMCP initialization and duplicate startup calls, and transport parsing could fail for lowercase values.
- The goal is to merge the new transport feature, resolve conflicts, and fix logic so the server initializes and starts exactly once and accepts backward-compatible transport values.

### Description
- Added `MCPConfig` to `src/proxmox_mcp/config/models.py` with `host`, `port`, and `transport` fields and a `field_validator` that normalizes transport strings (accepting e.g. "streamable" or "STREAMABLE_HTTP" and mapping to `STREAMABLE`), and attached `mcp` to the root `Config` with sensible defaults.
- Updated `src/proxmox_mcp/server.py` to initialize `FastMCP` a single time using `host`, `port`, and `log_level` from the new `mcp` config and replaced the previous duplicated startup logic with a single transport-dispatch that calls exactly one of `run_stdio_async`, `run_sse_async`, or `run_streamable_http_async` depending on the normalized transport value.
- Updated `proxmox-config/config.example.json` to include an `mcp` block (`host`, `port`, `transport`) and updated `README.md` to document the new `mcp` section and supported transports (`STDIO`, `SSE`, `STREAMABLE`).
- Kept changes minimal and backward-compatible by providing defaults and transport normalization so existing configs without `mcp` still work.

### Testing
- Compiled the package sources with `python -m compileall src`, which completed successfully and produced bytecode for the modified modules.
- Attempted to start the server with `PYTHONPATH=src PROXMOX_MCP_CONFIG=proxmox-config/config.example.json python -m proxmox_mcp.server`, which failed with `ModuleNotFoundError: No module named 'mcp'` because the external `mcp` SDK (MCP Python SDK) is not installed in this environment; this indicates runtime dependencies are required but does not affect the compile-time correctness of the changes.
- Git status after changes is clean on branch `fix/merge-pr18` and the commit made was: `Add MCP transport configuration`.

Files modified:
- `src/proxmox_mcp/config/models.py`: added `MCPConfig` and validator; attached `mcp` to `Config`.
- `src/proxmox_mcp/server.py`: single `FastMCP` initialization with host/port/log_level and single transport-dispatch startup logic.
- `proxmox-config/config.example.json`: added `mcp` example block.
- `README.md`: documented `mcp` config and transport options.

Suggested final commit message
- `Merge PR #18: add MCP transport config; fix FastMCP init and startup dispatch`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cb179049883288dd6f4967f582fe8)