### PR TITLE
Allow for specifying network bridge in `create_vm`

### DIFF
--- a/src/proxmox_mcp/server.py
+++ b/src/proxmox_mcp/server.py
@@ -147,9 +147,12 @@ class ProxmoxMCPServer:
             memory: Annotated[int, Field(description="Memory size in MB (e.g. 2048 for 2GB)", ge=512, le=131072)],
             disk_size: Annotated[int, Field(description="Disk size in GB (e.g. 10, 20, 50)", ge=5, le=1000)],
             storage: Annotated[Optional[str], Field(description="Storage name (optional, will auto-detect)", default=None)] = None,
-            ostype: Annotated[Optional[str], Field(description="OS type (optional, default: 'l26' for Linux)", default=None)] = None
+            ostype: Annotated[Optional[str], Field(description="OS type (optional, default: 'l26' for Linux)", default=None)] = None,
+            network_bridge: Annotated[Optional[str], Field(description="Network bridge name (optional, default: 'vmbr0')", default=None)] = None,
         ):
-            return self.vm_tools.create_vm(node, vmid, name, cpus, memory, disk_size, storage, ostype)
+            return self.vm_tools.create_vm(
+                node, vmid, name, cpus, memory, disk_size, storage, ostype, network_bridge
+            )
 
         @self.mcp.tool(description=EXECUTE_VM_COMMAND_DESC)
         async def execute_vm_command(

--- a/src/proxmox_mcp/tools/definitions.py
+++ b/src/proxmox_mcp/tools/definitions.py
@@ -33,6 +33,7 @@ memory* - Memory size in MB (e.g. 2048 for 2GB, 4096 for 4GB)
 disk_size* - Disk size in GB (e.g. 10, 20, 50)
 storage - Storage name (optional, will auto-detect if not specified)
 ostype - OS type (optional, default: 'l26' for Linux)
+network_bridge - Network bridge name (optional, default: 'vmbr0')
 
 Examples:
 - Create VM with 1 CPU, 2GB RAM, 10GB disk: node='pve', vmid='200', name='test-vm', cpus=1, memory=2048, disk_size=10

--- a/src/proxmox_mcp/tools/vm.py
+++ b/src/proxmox_mcp/tools/vm.py
@@ -134,8 +134,18 @@ class VMTools(ProxmoxTool):
 
         return self._format_response(result, "vms")
 
-    def create_vm(self, node: str, vmid: str, name: str, cpus: int, memory: int, 
-                  disk_size: int, storage: Optional[str] = None, ostype: Optional[str] = None) -> List[Content]:
+    def create_vm(
+        self,
+        node: str,
+        vmid: str,
+        name: str,
+        cpus: int,
+        memory: int,
+        disk_size: int,
+        storage: Optional[str] = None,
+        ostype: Optional[str] = None,
+        network_bridge: Optional[str] = None,
+    ) -> List[Content]:
         """Create a new virtual machine with specified configuration.
         
         Args:
@@ -147,6 +157,7 @@ class VMTools(ProxmoxTool):
             disk_size: Disk size in GB (e.g., 10, 20, 50)
             storage: Storage name (e.g., 'local-lvm', 'vm-storage'). If None, will auto-detect
             ostype: OS type (e.g., 'l26' for Linux, 'win10' for Windows). Default: 'l26'
+            network_bridge: Network bridge name (e.g., 'vmbr0'). If None, defaults to 'vmbr0'
             
         Returns:
             List of Content objects containing creation result
@@ -225,6 +236,9 @@ class VMTools(ProxmoxTool):
             # Set default OS type
             if ostype is None:
                 ostype = "l26"  # Linux 2.6+ kernel
+
+            if not network_bridge:
+                network_bridge = "vmbr0"
             
             # Prepare VM configuration
             vm_config = {
@@ -237,7 +251,7 @@ class VMTools(ProxmoxTool):
                 "boot": "order=scsi0",
                 "agent": "1",  # Enable QEMU guest agent
                 "vga": "std",
-                "net0": "virtio,bridge=vmbr0",
+                "net0": f"virtio,bridge={network_bridge}",
             }
             
             # Add storage configuration
@@ -261,7 +275,7 @@ class VMTools(ProxmoxTool):
   • Disk: {disk_size} GB ({storage}, {disk_format} format)
   • Storage Type: {storage_type}
   • OS Type: {ostype}
-  • Network: virtio (bridge=vmbr0)
+  • Network: virtio (bridge={network_bridge})
   • QEMU Agent: Enabled{cloudinit_note}
 
 🔧 Task ID: {task_result}


### PR DESCRIPTION
This PR allows creating a VM with a custom network bridge. The default is still `vmbr0` if none is specified. I believe I added all the documentation for it as well, but let me know if I missed anything.

I didn't run ruff on the code because it made a lot of formatting changes to the files that were not related to what I added. Also, many of the pytest tests are not passing on the latest commit in `main` (using Python 3.14), so I didn't touch the tests. But I'm happy to add a test for this if the tests are still desired.