### PR TITLE
Pin mcp SDK dependency to v1.x from PyPI instead of unpinned GitHub HEAD

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "mcp @ git+https://github.com/modelcontextprotocol/python-sdk.git",
+    "mcp>=1.8.0,<2.0.0",
     "proxmoxer>=2.0.1,<3.0.0",
     "requests>=2.31.0,<3.0.0",
     "pydantic>=2.0.0,<3.0.0",


### PR DESCRIPTION
The previous git+https dependency pulled from the main branch, which now targets v2 with breaking changes. This caused runtime crashes. Pinned to >=1.8.0,<2.0.0 (1.8.0 is the minimum version that includes run_streamable_http_async, which the server uses).