### PR TITLE
Initialize FastMCP with configured host/port and log level; add test

### DIFF
--- a/src/proxmox_mcp/server.py
+++ b/src/proxmox_mcp/server.py
@@ -105,8 +105,13 @@ class ProxmoxMCPServer:
         self.iso_tools = ISOTools(self.proxmox)
         self.backup_tools = BackupTools(self.proxmox)
 
-        # Initialize MCP server
-        self.mcp = FastMCP("ProxmoxMCP")
+        # Initialize MCP server with configured network settings for HTTP transports
+        self.mcp = FastMCP(
+            "ProxmoxMCP",
+            host=self.config.mcp.host,
+            port=self.config.mcp.port,
+            log_level=self.config.logging.level.upper(),
+        )
         self._setup_tools()
 
     def _setup_tools(self) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -73,6 +73,23 @@ def test_server_initialization(server, mock_proxmox):
 
     mock_proxmox.assert_called_once()
 
+
+def test_server_applies_configured_http_host_and_port(mock_proxmox, tmp_path):
+    """Test FastMCP receives configured host/port for HTTP transports."""
+    config_path = tmp_path / "config_http.json"
+    config_path.write_text(json.dumps({
+        "proxmox": {"host": "test.proxmox.com", "port": 8006, "verify_ssl": True, "service": "PVE"},
+        "auth": {"user": "test@pve", "token_name": "test_token", "token_value": "test_value"},
+        "logging": {"level": "INFO"},
+        "mcp": {"host": "0.0.0.0", "port": 9000, "transport": "SSE"},
+    }))
+
+    http_server = ProxmoxMCPServer(str(config_path))
+
+    assert http_server.mcp.settings.host == "0.0.0.0"
+    assert http_server.mcp.settings.port == 9000
+
+
 @pytest.mark.asyncio
 async def test_list_tools(server):
     """Test listing available tools. Config has no ssh section, so execute_container_command must be absent."""


### PR DESCRIPTION
### Motivation
- Allow the MCP server to be configured from the application config so HTTP transports bind to the expected host/port and the MCP logging level is derived from configuration.

### Description
- Pass `host`, `port`, and `log_level` from `self.config.mcp` / `self.config.logging` into the `FastMCP` constructor in `ProxmoxMCPServer.__init__`.
- Update the initialization comment to reflect that MCP is started with configured network settings for HTTP transports.
- Add unit test `test_server_applies_configured_http_host_and_port` in `tests/test_server.py` to assert `FastMCP` receives the configured `host` and `port`.

### Testing
- Ran the updated unit tests in `tests/test_server.py` with `pytest`, including the new `test_server_applies_configured_http_host_and_port`, and they passed.
- Ran the full test suite with `pytest` and observed no failures.

------
