### PR TITLE
Add uvx entry point for direct GitHub installation

### DIFF
--- a/proxmox-config/opencode/README.md
+++ b/proxmox-config/opencode/README.md
@@ -1,0 +1,53 @@
+# OpenCode Configuration
+
+This folder contains example configuration files for OpenCode with Proxmox MCP.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `opencode.jsonc.example` | OpenCode configuration template |
+| `proxmox-mcp.env.example` | Proxmox MCP environment variables template |
+
+## Setup Instructions
+
+### 1. Copy Examples to Project Root
+
+```bash
+# From project root
+cp proxmox-config/opencode/opencode.jsonc.example opencode.jsonc
+cp proxmox-config/opencode/proxmox-mcp.env.example proxmox-mcp.env
+```
+
+### 2. Configure Environment Variables
+
+Edit `proxmox-mcp.env` with your Proxmox credentials:
+
+```bash
+export PROXMOX_HOST=your-proxmox-host
+export PROXMOX_PORT=8006
+export PROXMOX_USER=user@pam
+export PROXMOX_TOKEN_NAME=your-token-name
+export PROXMOX_TOKEN_VALUE=your-token-secret-value
+export PROXMOX_VERIFY_SSL=false
+export PROXMOX_SERVICE=PVE
+export LOG_LEVEL=INFO
+```
+
+### 3. How MCP Loads Environment
+
+The MCP command in `opencode.jsonc` sources the environment file automatically:
+
+```json
+"command": ["sh", "-c", ". ./proxmox-mcp.env && uvx --from git+https://github.com/NewsRx/ProxmoxMCP-Plus.git proxmox-mcp"]
+```
+
+**No manual sourcing needed** - OpenCode runs the MCP, and the MCP command sources `proxmox-mcp.env` before starting.
+
+## Security
+
+**Never commit files with real credentials to version control!**
+
+Both `opencode.jsonc` and `proxmox-mcp.env` are excluded via `.git/info/exclude`.
+
+*Co-authored with AI: OpenCode (ollama-cloud/glm-5)*

--- a/proxmox-config/opencode/README.md
+++ b/proxmox-config/opencode/README.md
@@ -39,7 +39,7 @@ export LOG_LEVEL=INFO
 The MCP command in `opencode.jsonc` sources the environment file automatically:
 
 ```json
-"command": ["sh", "-c", ". ./proxmox-mcp.env && uvx --from git+https://github.com/NewsRx/ProxmoxMCP-Plus.git proxmox-mcp"]
+"command": ["sh", "-c", ". ./proxmox-mcp.env && uvx --from git+https://github.com/RekklesNA/ProxmoxMCP-Plus.git proxmox-mcp"]
 ```
 
 **No manual sourcing needed** - OpenCode runs the MCP, and the MCP command sources `proxmox-mcp.env` before starting.

--- a/proxmox-config/opencode/opencode.jsonc.example
+++ b/proxmox-config/opencode/opencode.jsonc.example
@@ -7,7 +7,7 @@
   "mcp": {
     "proxmox-mcp-plus": {
       "type": "local",
-      "command": ["sh", "-c", ". ./proxmox-mcp.env && uvx --from git+https://github.com/NewsRx/ProxmoxMCP-Plus.git proxmox-mcp"],
+      "command": ["sh", "-c", ". ./proxmox-mcp.env && uvx --from git+https://github.com/RekklesNA/ProxmoxMCP-Plus.git proxmox-mcp"],
       "enabled": true
     }
   }

--- a/proxmox-config/opencode/opencode.jsonc.example
+++ b/proxmox-config/opencode/opencode.jsonc.example
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": [
+    "AGENTS.md",
+    ".opencode/guidelines/*.md"
+  ],
+  "mcp": {
+    "proxmox-mcp-plus": {
+      "type": "local",
+      "command": ["sh", "-c", ". ./proxmox-mcp.env && uvx --from git+https://github.com/NewsRx/ProxmoxMCP-Plus.git proxmox-mcp"],
+      "enabled": true
+    }
+  }
+}

--- a/proxmox-config/opencode/proxmox-mcp.env.example
+++ b/proxmox-config/opencode/proxmox-mcp.env.example
@@ -1,0 +1,17 @@
+# Proxmox MCP Environment Variables
+# 
+# Copy this file to your project root as `proxmox-mcp.env`
+# Then source it before running OpenCode:
+#   source ./proxmox-mcp.env
+#
+# IMPORTANT: Never commit files with real credentials to version control!
+# Add `proxmox-mcp.env` to .git/info/exclude or .gitignore
+
+export PROXMOX_HOST=your-proxmox-host
+export PROXMOX_PORT=8006
+export PROXMOX_USER=user@pam
+export PROXMOX_TOKEN_NAME=your-token-name
+export PROXMOX_TOKEN_VALUE=your-token-secret-value
+export PROXMOX_VERIFY_SSL=false
+export PROXMOX_SERVICE=PVE
+export LOG_LEVEL=INFO

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ dependencies = [
     "anyio>=4.0.0",
 ]
 
+[project.scripts]
+proxmox-mcp = "proxmox_mcp.server:main"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
## Summary

Add `uvx` entry point support, enabling users to run ProxmoxMCP-Plus directly from GitHub without cloning.

## Changes

1. **pyproject.toml** - Added `[project.scripts]` entry point:
   ```toml
   [project.scripts]
   proxmox-mcp = "proxmox_mcp.server:main"
   ```

2. **proxmox-config/opencode/** - OpenCode configuration examples:
   - `opencode.jsonc.example` - MCP server configuration template
   - `proxmox-mcp.env.example` - Environment variables template
   - `README.md` - Setup instructions

## Usage

```bash
uvx --from git+https://github.com/RekklesNA/ProxmoxMCP-Plus.git proxmox-mcp
```

## OpenCode Configuration

```json
{
  "mcp": {
    "proxmox-mcp-plus": {
      "type": "local",
      "command": ["uvx", "--from", "git+https://github.com/RekklesNA/ProxmoxMCP-Plus.git", "proxmox-mcp"],
      "enabled": true
    }
  }
}
```

Closes #41

*Co-authored with AI: OpenCode (ollama-cloud/glm-5)*
