### PR TITLE
Add OpenCode example configs and CLI entrypoint (`proxmox-mcp`)

### DIFF
--- a/proxmox-config/opencode/README.md
+++ b/proxmox-config/opencode/README.md
@@ -1,0 +1,53 @@
+# OpenCode Configuration
+
+This folder contains example configuration files for OpenCode with Proxmox MCP.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `opencode.jsonc.example` | OpenCode configuration template |
+| `proxmox-mcp.env.example` | Proxmox MCP environment variables template |
+
+## Setup Instructions
+
+### 1. Copy Examples to Project Root
+
+```bash
+# From project root
+cp proxmox-config/opencode/opencode.jsonc.example opencode.jsonc
+cp proxmox-config/opencode/proxmox-mcp.env.example proxmox-mcp.env
+```
+
+### 2. Configure Environment Variables
+
+Edit `proxmox-mcp.env` with your Proxmox credentials:
+
+```bash
+export PROXMOX_HOST=your-proxmox-host
+export PROXMOX_PORT=8006
+export PROXMOX_USER=user@pam
+export PROXMOX_TOKEN_NAME=your-token-name
+export PROXMOX_TOKEN_VALUE=your-token-secret-value
+export PROXMOX_VERIFY_SSL=false
+export PROXMOX_SERVICE=PVE
+export LOG_LEVEL=INFO
+```
+
+### 3. How MCP Loads Environment
+
+The MCP command in `opencode.jsonc` sources the environment file automatically:
+
+```json
+"command": ["sh", "-c", ". ./proxmox-mcp.env && uvx --from git+https://github.com/RekklesNA/ProxmoxMCP-Plus.git proxmox-mcp"]
+```
+
+**No manual sourcing needed** - OpenCode runs the MCP, and the MCP command sources `proxmox-mcp.env` before starting.
+
+## Security
+
+**Never commit files with real credentials to version control!**
+
+Both `opencode.jsonc` and `proxmox-mcp.env` are excluded via `.git/info/exclude`.
+
+*Co-authored with AI: OpenCode (ollama-cloud/glm-5)*

--- a/proxmox-config/opencode/opencode.jsonc.example
+++ b/proxmox-config/opencode/opencode.jsonc.example
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": [
+    "AGENTS.md",
+    ".opencode/guidelines/*.md"
+  ],
+  "mcp": {
+    "proxmox-mcp-plus": {
+      "type": "local",
+      "command": ["sh", "-c", ". ./proxmox-mcp.env && uvx --from git+https://github.com/RekklesNA/ProxmoxMCP-Plus.git proxmox-mcp"],
+      "enabled": true
+    }
+  }
+}

--- a/proxmox-config/opencode/proxmox-mcp.env.example
+++ b/proxmox-config/opencode/proxmox-mcp.env.example
@@ -1,0 +1,17 @@
+# Proxmox MCP Environment Variables
+# 
+# Copy this file to your project root as `proxmox-mcp.env`
+# Then source it before running OpenCode:
+#   source ./proxmox-mcp.env
+#
+# IMPORTANT: Never commit files with real credentials to version control!
+# Add `proxmox-mcp.env` to .git/info/exclude or .gitignore
+
+export PROXMOX_HOST=your-proxmox-host
+export PROXMOX_PORT=8006
+export PROXMOX_USER=user@pam
+export PROXMOX_TOKEN_NAME=your-token-name
+export PROXMOX_TOKEN_VALUE=your-token-secret-value
+export PROXMOX_VERIFY_SSL=false
+export PROXMOX_SERVICE=PVE
+export LOG_LEVEL=INFO

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ dependencies = [
     "anyio>=4.0.0",
 ]
 
+[project.scripts]
+proxmox-mcp = "proxmox_mcp.server:main"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
### Motivation

- Provide example OpenCode integration files so the MCP can be run via OpenCode and users have a template for environment variables.
- Add a proper package console entry so `proxmox-mcp` can be installed and executed directly as a CLI tool.
- Surface an obvious supply-chain risk in the example command that should be fixed before trusting the example in production.

### Description

- Added OpenCode examples under `proxmox-config/opencode/`: `README.md`, `opencode.jsonc.example`, and `proxmox-mcp.env.example` which document setup and environment variables.
- Added a console script entry in `pyproject.toml` as `proxmox-mcp = "proxmox_mcp.server:main"` to expose the `main()` CLI entrypoint.
- The `opencode.jsonc.example` example uses `uvx --from git+https://github.com/RekklesNA/ProxmoxMCP-Plus.git proxmox-mcp`, which installs directly from the repository without pinning a tag or commit and is a supply-chain/reproducibility concern.
- Documentation warns not to commit real credentials but references `.git/info/exclude`, which is a local-only mechanism and should be replaced or complemented by `.gitignore` in the examples.

### Testing

- Attempted tests with the system Python (3.10) failed due to the package `requires-python = ">=3.11"` which prevented editable install.
- Installed and tested with `PYENV_VERSION=3.11.14` and ran `python -m pip install -e .` which successfully built and installed the package and dependencies.
- After installing `pytest-asyncio` the test suite was run with `PYENV_VERSION=3.11.14 pytest -q` and the entire test suite passed (`41 passed, 1 warning`).
- Confirmed the CLI entrypoint is callable with a small runtime check of `from proxmox_mcp.server import main` which returned a callable `main`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce7c420f1c8328ac06cf8a2d1e97c5)