### PR TITLE
feat: add LXC onboot and nesting options to create_container

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,8 @@ Create a new LXC container with specified configuration.
 - `ssh_public_keys` (string, optional): SSH public keys for root user
 - `network_bridge` (string, optional): Network bridge name (default: 'vmbr0')
 - `start_after_create` (boolean, optional): Start container after creation (default: false)
+- `onboot` (boolean, optional): Start container automatically when host boots (default: false)
+- `nesting` (boolean, optional): Enable LXC nesting by setting `features=nesting=1` (default: false)
 - `unprivileged` (boolean, optional): Create unprivileged container (default: true)
 
 **API Endpoint:**
@@ -524,7 +526,9 @@ Content-Type: application/json
     "hostname": "my-container",
     "cores": 2,
     "memory": 1024,
-    "disk_size": 10
+    "disk_size": 10,
+    "onboot": true,
+    "nesting": true
 }
 ```
 

--- a/src/proxmox_mcp/server.py
+++ b/src/proxmox_mcp/server.py
@@ -297,6 +297,8 @@ class ProxmoxMCPServer:
             ssh_public_keys: Annotated[Optional[str], Field(description="SSH public keys for root", default=None)] = None,
             network_bridge: Annotated[str, Field(description="Network bridge", default="vmbr0")] = "vmbr0",
             start_after_create: Annotated[bool, Field(description="Start container after creation", default=False)] = False,
+            onboot: Annotated[bool, Field(description="Start container automatically when node boots", default=False)] = False,
+            nesting: Annotated[bool, Field(description="Enable LXC nesting (features: nesting=1)", default=False)] = False,
             unprivileged: Annotated[bool, Field(description="Create unprivileged container", default=True)] = True,
         ):
             return self.container_tools.create_container(
@@ -304,6 +306,7 @@ class ProxmoxMCPServer:
                 cores=cores, memory=memory, swap=swap, disk_size=disk_size,
                 storage=storage, password=password, ssh_public_keys=ssh_public_keys,
                 network_bridge=network_bridge, start_after_create=start_after_create,
+                onboot=onboot, nesting=nesting,
                 unprivileged=unprivileged,
             )
 

--- a/src/proxmox_mcp/tools/containers.py
+++ b/src/proxmox_mcp/tools/containers.py
@@ -492,6 +492,8 @@ class ContainerTools(ProxmoxTool):
         ssh_public_keys: Optional[str] = None,
         network_bridge: str = "vmbr0",
         start_after_create: bool = False,
+        onboot: bool = False,
+        nesting: bool = False,
         unprivileged: bool = True,
     ) -> List[Content]:
         """Create a new LXC container.
@@ -510,6 +512,8 @@ class ContainerTools(ProxmoxTool):
             ssh_public_keys: SSH public keys for root (optional)
             network_bridge: Network bridge (default: 'vmbr0')
             start_after_create: Start container after creation (default: False)
+            onboot: Start container automatically when node boots (default: False)
+            nesting: Enable LXC nesting feature (default: False)
             unprivileged: Create unprivileged container (default: True)
 
         Returns:
@@ -570,6 +574,7 @@ class ContainerTools(ProxmoxTool):
                 "net0": f"name=eth0,bridge={network_bridge},ip=dhcp",
                 "unprivileged": 1 if unprivileged else 0,
                 "start": 1 if start_after_create else 0,
+                "onboot": 1 if onboot else 0,
             }
 
             # Add optional parameters
@@ -577,6 +582,8 @@ class ContainerTools(ProxmoxTool):
                 ct_config["password"] = password
             if ssh_public_keys:
                 ct_config["ssh-public-keys"] = ssh_public_keys
+            if nesting:
+                ct_config["features"] = "nesting=1"
 
             # Create the container
             result = self.proxmox.nodes(node).lxc.create(**ct_config)
@@ -596,6 +603,8 @@ class ContainerTools(ProxmoxTool):
                 f"  • Network: {network_bridge} (DHCP)",
                 f"  • Unprivileged: {'Yes' if unprivileged else 'No'}",
                 f"  • Auto-start: {'Yes' if start_after_create else 'No'}",
+                f"  • Start on boot: {'Yes' if onboot else 'No'}",
+                f"  • Nesting enabled: {'Yes' if nesting else 'No'}",
                 "",
                 f"Task ID: {result}",
                 "",

--- a/src/proxmox_mcp/tools/definitions.py
+++ b/src/proxmox_mcp/tools/definitions.py
@@ -160,6 +160,8 @@ password - Root password (optional)
 ssh_public_keys - SSH public keys for root user (optional)
 network_bridge - Network bridge name (optional, default: 'vmbr0')
 start_after_create - Start container after creation (optional, default: false)
+onboot - Start container automatically on host boot (optional, default: false)
+nesting - Enable LXC nesting (optional, sets features='nesting=1', default: false)
 unprivileged - Create unprivileged container (optional, default: true)
 
 Examples:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -274,6 +274,67 @@ async def test_get_containers_skips_offline_node(server, mock_proxmox):
     assert "node2" not in text
 
 @pytest.mark.asyncio
+async def test_create_container_with_lxc_options(server, mock_proxmox):
+    """Test create_container supports onboot and nesting options."""
+    proxmox = mock_proxmox.return_value
+    proxmox.nodes.get.return_value = [{"node": "node1", "status": "online"}]
+    proxmox.nodes.return_value.lxc.get.return_value = []
+    proxmox.storage.get.return_value = [{"storage": "local-lvm", "content": "rootdir"}]
+    proxmox.nodes.return_value.lxc.create.return_value = "UPID:ct-create-1"
+
+    response = await server.mcp.call_tool(
+        "create_container",
+        {
+            "node": "node1",
+            "vmid": "200",
+            "ostemplate": "local:vztmpl/alpine-3.19-default_20240207_amd64.tar.xz",
+            "hostname": "ct200",
+            "onboot": True,
+            "nesting": True,
+        },
+    )
+    text = response[0].text
+
+    proxmox.nodes.return_value.lxc.create.assert_called_once_with(
+        vmid=200,
+        ostemplate="local:vztmpl/alpine-3.19-default_20240207_amd64.tar.xz",
+        hostname="ct200",
+        cores=1,
+        memory=512,
+        swap=512,
+        rootfs="local-lvm:8",
+        net0="name=eth0,bridge=vmbr0,ip=dhcp",
+        unprivileged=1,
+        start=0,
+        onboot=1,
+        features="nesting=1",
+    )
+    assert "Start on boot: Yes" in text
+    assert "Nesting enabled: Yes" in text
+
+@pytest.mark.asyncio
+async def test_create_container_default_lxc_options(server, mock_proxmox):
+    """Test create_container default values keep onboot disabled and omit nesting feature."""
+    proxmox = mock_proxmox.return_value
+    proxmox.nodes.get.return_value = [{"node": "node1", "status": "online"}]
+    proxmox.nodes.return_value.lxc.get.return_value = []
+    proxmox.storage.get.return_value = [{"storage": "local-lvm", "content": "rootdir"}]
+    proxmox.nodes.return_value.lxc.create.return_value = "UPID:ct-create-2"
+
+    await server.mcp.call_tool(
+        "create_container",
+        {
+            "node": "node1",
+            "vmid": "201",
+            "ostemplate": "local:vztmpl/alpine-3.19-default_20240207_amd64.tar.xz",
+        },
+    )
+
+    create_kwargs = proxmox.nodes.return_value.lxc.create.call_args.kwargs
+    assert create_kwargs["onboot"] == 0
+    assert "features" not in create_kwargs
+
+@pytest.mark.asyncio
 async def test_update_container_resources(server, mock_proxmox):
     """Test update_container_resources tool."""
     mock_proxmox.return_value.nodes.get.return_value = [{"node": "node1", "status": "online"}]


### PR DESCRIPTION
## Summary
This PR implements issue #45 by adding LXC option support to `create_container` for:
- `onboot` (start container automatically when node boots)
- `nesting` (sets `features=nesting=1`)

## Changes
- Added `onboot` and `nesting` arguments to the MCP `create_container` tool.
- Passed both arguments through to container creation logic.
- Updated Proxmox LXC payload:
  - always sets `onboot` (`1` or `0`)
  - sets `features: nesting=1` when `nesting=true`
- Updated tool descriptions and README usage examples.
- Added output lines in the create result showing:
  - Start on boot
  - Nesting enabled

## Tests
- Added `test_create_container_with_lxc_options`
- Added `test_create_container_default_lxc_options`
- Ran full test suite locally: `43 passed`

Closes #45
