### PR TITLE
Feature/security hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: pip-audit
       run: |
-        pip-audit
+        pip-audit -r requirements.txt
 
     - name: Validate Manifest JSON
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,29 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install -r requirements-dev.in
+        pip install pip-audit
         pip install .
 
     - name: Smoke Test (Import Server)
       run: |
         python -c "from proxmox_mcp.server import ProxmoxMCPServer; print('Successfully imported ProxmoxMCPServer')"
+
+    - name: Run tests
+      run: |
+        pytest -q
+
+    - name: Ruff
+      run: |
+        ruff check . --select E9,F63,F7,F82
+
+    - name: Mypy
+      run: |
+        mypy src --ignore-missing-imports
+
+    - name: pip-audit
+      run: |
+        pip-audit
 
     - name: Validate Manifest JSON
       run: |

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Before starting, ensure you have:
        "proxmox": {
            "host": "PROXMOX_HOST",        # Required: Your Proxmox server address
            "port": 8006,                  # Optional: Default is 8006
-           "verify_ssl": false,           # Optional: Set false for self-signed certs
+           "verify_ssl": true,            # Required in production; only disable with security.dev_mode=true
            "service": "PVE"               # Optional: Default is PVE
        },
        "auth": {
@@ -122,6 +122,14 @@ Before starting, ensure you have:
            "host": "127.0.0.1",           # Optional: Host for SSE/STREAMABLE transports
            "port": 8000,                  # Optional: Port for SSE/STREAMABLE transports
            "transport": "STDIO"           # Optional: STDIO, SSE, or STREAMABLE
+       },
+       "security": {
+           "dev_mode": false              # Optional: true allows insecure TLS for local development only
+       },
+       "command_policy": {
+           "mode": "deny_all",            # deny_all | allowlist | audit_only
+           "allow_patterns": [],          # e.g. ["^uname\\s+-a$"]
+           "require_approval_token": false
        }
    }
    ```
@@ -145,7 +153,7 @@ This project supports the `.mcpb` (MCP Bundle) format for easy, one-click distri
    - `PROXMOX_TOKEN_NAME`: API Token Name (Required)
    - `PROXMOX_TOKEN_VALUE`: API Token Value (Required)
    - `PROXMOX_PORT`: API Port (Default: `8006`)
-   - `PROXMOX_VERIFY_SSL`: Set to `true` or `false` (Default: `false`)
+   - `PROXMOX_VERIFY_SSL`: Set to `true` or `false` (Default: `true`; `false` requires `PROXMOX_DEV_MODE=true`)
    - `PROXMOX_SERVICE`: Service type (Default: `PVE`)
    - `LOG_LEVEL`: Set to `INFO` or `DEBUG` (Default: `INFO`)
 4. **Execution Settings**:

--- a/docs/container-command-execution.md
+++ b/docs/container-command-execution.md
@@ -89,10 +89,10 @@ which is the same surface that already exists if an attacker compromises a conta
 
 ### SSH host key checking
 
-The implementation uses `paramiko.AutoAddPolicy`, which accepts host keys on first connect
-(trust-on-first-use). This is appropriate for use within a private cluster network. If your
-security requirements demand strict host key pinning, you can pre-populate `~/.ssh/known_hosts`
-on the MCP VM for each Proxmox node before starting the server.
+The implementation now uses strict host key checking by default (`RejectPolicy`), which means
+unknown hosts are rejected unless the host key is present in `known_hosts` (system-level or
+configured `known_hosts_file`). This is the recommended production posture. You can explicitly
+disable strict checking only for local development.
 
 ### Key management
 

--- a/main.py
+++ b/main.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import sys
 import os
-import subprocess
 import traceback
 import time
 
@@ -10,18 +9,7 @@ print("MCP Bundle: Bootstrapping process...", file=sys.stderr)
 sys.stderr.flush()
 
 def ensure_dependencies():
-    """Checks for required libraries and installs them if missing."""
-    # Complete list of runtime dependencies
-    required = [
-        "mcp>=1.2.0", 
-        "proxmoxer", 
-        "requests", 
-        "pydantic>=2.0.0", 
-        "fastapi", 
-        "uvicorn", 
-        "anyio"
-    ]
-    
+    """Checks for required libraries and fails fast if missing."""
     missing = []
     for pkg in ["mcp", "proxmoxer", "pydantic", "fastapi", "uvicorn", "anyio"]:
         try:
@@ -34,15 +22,11 @@ def ensure_dependencies():
         sys.stderr.flush()
         return
 
-    print(f"MCP Bundle: Missing dependencies ({', '.join(missing)}). Installing...", file=sys.stderr)
-    sys.stderr.flush()
-    try:
-        # Use --no-cache-dir to prevent LXC disk space issues
-        subprocess.check_call([sys.executable, "-m", "pip", "install", "--no-cache-dir", "--user"] + required)
-        print("MCP Bundle: Auto-install successful!", file=sys.stderr)
-    except Exception as e:
-        print(f"MCP Bundle: ERROR during auto-install: {e}", file=sys.stderr)
-    sys.stderr.flush()
+    raise RuntimeError(
+        "Missing runtime dependencies: "
+        + ", ".join(missing)
+        + ". Install dependencies during build/deploy time instead of runtime."
+    )
 
 # 2. Setup Environment
 base_dir = os.path.dirname(os.path.abspath(__file__))

--- a/proxmox-config/config.example.json
+++ b/proxmox-config/config.example.json
@@ -2,7 +2,7 @@
     "proxmox": {
         "host": "your-proxmox-host-ip",
         "port": 8006,
-        "verify_ssl": false,
+        "verify_ssl": true,
         "service": "PVE"
     },
     "auth": {
@@ -19,5 +19,18 @@
         "host": "127.0.0.1",
         "port": 8000,
         "transport": "STDIO"
+    },
+    "security": {
+        "dev_mode": false
+    },
+    "command_policy": {
+        "mode": "deny_all",
+        "allow_patterns": [],
+        "deny_patterns": [
+            "(^|\\s)rm\\s+-rf(\\s|$)",
+            ":\\(\\)\\{:\\|:\\&\\};:"
+        ],
+        "require_approval_token": false,
+        "approval_token": null
     }
 }

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -6,7 +6,7 @@ pytest>=7.0.0,<8.0.0
 pytest-asyncio>=0.21.0,<0.22.0
 
 # Code quality
-black>=23.0.0,<24.0.0
+black>=24.3.0,<27.0.0
 mypy>=1.0.0,<2.0.0
 ruff>=0.1.0,<0.2.0
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     extras_require={
         "dev": [
             "pytest>=7.0.0,<8.0.0",
-            "black>=23.0.0,<24.0.0",
+            "black>=24.3.0,<27.0.0",
             "mypy>=1.0.0,<2.0.0",
             "pytest-asyncio>=0.21.0,<0.22.0",
             "ruff>=0.1.0,<0.2.0",

--- a/src/proxmox_mcp/config/loader.py
+++ b/src/proxmox_mcp/config/loader.py
@@ -65,7 +65,7 @@ def load_config(config_path: Optional[str] = None) -> Config:
             'proxmox': {
                 'host': os.getenv("PROXMOX_HOST"),
                 'port': int(os.getenv("PROXMOX_PORT", "8006")),
-                'verify_ssl': os.getenv("PROXMOX_VERIFY_SSL", "false").lower() == "true",
+                'verify_ssl': os.getenv("PROXMOX_VERIFY_SSL", "true").lower() == "true",
                 'service': os.getenv("PROXMOX_SERVICE", "PVE")
             },
             'auth': {
@@ -80,7 +80,17 @@ def load_config(config_path: Optional[str] = None) -> Config:
                 'host': os.getenv("MCP_HOST", "0.0.0.0"),
                 'port': int(os.getenv("MCP_PORT", "8000")),
                 'transport': os.getenv("MCP_TRANSPORT", "stdio").upper() if os.getenv("MCP_TRANSPORT") else "STDIO"
-            }
+            },
+            'security': {
+                'dev_mode': os.getenv("PROXMOX_DEV_MODE", "false").lower() == "true",
+            },
+            'command_policy': {
+                'mode': os.getenv("COMMAND_POLICY_MODE", "deny_all"),
+                'allow_patterns': [p.strip() for p in os.getenv("COMMAND_POLICY_ALLOW_PATTERNS", "").split(",") if p.strip()],
+                'deny_patterns': [p.strip() for p in os.getenv("COMMAND_POLICY_DENY_PATTERNS", "").split(",") if p.strip()],
+                'require_approval_token': os.getenv("COMMAND_POLICY_REQUIRE_APPROVAL_TOKEN", "false").lower() == "true",
+                'approval_token': os.getenv("COMMAND_POLICY_APPROVAL_TOKEN"),
+            },
         }
         
         # Handle the internal "STREAMABLE" vs "STREAMABLE_HTTP" naming
@@ -102,6 +112,12 @@ def load_config(config_path: Optional[str] = None) -> Config:
         raise ValueError("Authentication credentials must be provided")
 
     try:
-        return Config(**config_data)
+        config = Config(**config_data)
+        if not config.proxmox.verify_ssl and not config.security.dev_mode:
+            raise ValueError(
+                "Insecure TLS configuration blocked: set proxmox.verify_ssl=true. "
+                "Only dev_mode=true can allow verify_ssl=false."
+            )
+        return config
     except Exception as e:
         raise ValueError(f"Configuration validation failed: {e}")

--- a/src/proxmox_mcp/config/loader.py
+++ b/src/proxmox_mcp/config/loader.py
@@ -12,7 +12,7 @@ and valid before the server starts operation.
 """
 import json
 import os
-from typing import Optional
+from typing import Any, Dict, Optional
 from proxmox_mcp.config.models import Config
 
 def load_config(config_path: Optional[str] = None) -> Config:
@@ -59,8 +59,10 @@ def load_config(config_path: Optional[str] = None) -> Config:
                  - Required fields are missing
                  - Field values are invalid
     """
+    config_data: Dict[str, Any]
     if not config_path or not os.path.exists(config_path):
         # Fallback to environment variables
+        log_level_raw = os.getenv("LOG_LEVEL")
         config_data = {
             'proxmox': {
                 'host': os.getenv("PROXMOX_HOST"),
@@ -74,7 +76,7 @@ def load_config(config_path: Optional[str] = None) -> Config:
                 'token_value': os.getenv("PROXMOX_TOKEN_VALUE")
             },
             'logging': {
-                'level': os.getenv("LOG_LEVEL", "INFO").upper() if os.getenv("LOG_LEVEL") and not os.getenv("LOG_LEVEL").startswith("${") else "INFO"
+                'level': log_level_raw.upper() if log_level_raw and not log_level_raw.startswith("${") else "INFO"
             },
             'mcp': {
                 'host': os.getenv("MCP_HOST", "0.0.0.0"),
@@ -94,12 +96,15 @@ def load_config(config_path: Optional[str] = None) -> Config:
         }
         
         # Handle the internal "STREAMABLE" vs "STREAMABLE_HTTP" naming
-        if config_data['mcp']['transport'] == "STREAMABLE_HTTP":
-            config_data['mcp']['transport'] = "STREAMABLE"
+        mcp_config = config_data.get("mcp")
+        if isinstance(mcp_config, dict) and mcp_config.get("transport") == "STREAMABLE_HTTP":
+            mcp_config["transport"] = "STREAMABLE"
     else:
         try:
             with open(config_path) as f:
                 config_data = json.load(f)
+                if not isinstance(config_data, dict):
+                    raise ValueError("Config root must be a JSON object")
         except json.JSONDecodeError as e:
             raise ValueError(f"Invalid JSON in config file: {e}")
         except Exception as e:
@@ -112,7 +117,7 @@ def load_config(config_path: Optional[str] = None) -> Config:
         raise ValueError("Authentication credentials must be provided")
 
     try:
-        config = Config(**config_data)
+        config = Config.model_validate(config_data)
         if not config.proxmox.verify_ssl and not config.security.dev_mode:
             raise ValueError(
                 "Insecure TLS configuration blocked: set proxmox.verify_ssl=true. "

--- a/src/proxmox_mcp/config/models.py
+++ b/src/proxmox_mcp/config/models.py
@@ -13,7 +13,7 @@ The models provide:
 - Field descriptions
 - Required vs optional field handling
 """
-from typing import Optional, Annotated, Literal, Dict
+from typing import Optional, Annotated, Literal, Dict, List
 from pydantic import BaseModel, Field, field_validator
 
 class NodeStatus(BaseModel):
@@ -79,6 +79,24 @@ class SSHConfig(BaseModel):
     password: Optional[str] = None   # fallback if no key_file
     host_overrides: Dict[str, str] = Field(default_factory=dict)
     use_sudo: bool = False  # prefix pct with sudo (for non-root SSH users)
+    known_hosts_file: Optional[str] = None
+    strict_host_key_checking: bool = True
+
+
+class SecurityConfig(BaseModel):
+    """Security behavior toggles for runtime hardening."""
+    dev_mode: bool = False
+
+
+class CommandPolicyConfig(BaseModel):
+    """Policy controls for execute_* command tools."""
+    mode: Literal["deny_all", "allowlist", "audit_only"] = "deny_all"
+    allow_patterns: List[str] = Field(default_factory=list)
+    deny_patterns: List[str] = Field(
+        default_factory=lambda: [r"(^|\\s)rm\\s+-rf(\\s|$)", r":\\(\\)\\{:\\|:\\&\\};:"]
+    )
+    require_approval_token: bool = False
+    approval_token: Optional[str] = None
 
 class MCPConfig(BaseModel):
     """Model for MCP server configuration.
@@ -113,3 +131,5 @@ class Config(BaseModel):
     logging: LoggingConfig  # Required: Logging configuration
     mcp: MCPConfig = Field(default_factory=MCPConfig)
     ssh: Optional[SSHConfig] = None
+    security: SecurityConfig = Field(default_factory=SecurityConfig)
+    command_policy: CommandPolicyConfig = Field(default_factory=CommandPolicyConfig)

--- a/src/proxmox_mcp/core/logging.py
+++ b/src/proxmox_mcp/core/logging.py
@@ -16,7 +16,6 @@ The logging system supports:
 """
 import logging
 import os
-from typing import Optional
 from proxmox_mcp.config.models import LoggingConfig
 
 def setup_logging(config: LoggingConfig) -> logging.Logger:
@@ -60,7 +59,7 @@ def setup_logging(config: LoggingConfig) -> logging.Logger:
         log_file = os.path.join(os.getcwd(), log_file)
         
     # Create handlers
-    handlers = []
+    handlers: list[logging.Handler] = []
     
     if log_file:
         try:

--- a/src/proxmox_mcp/core/proxmox.py
+++ b/src/proxmox_mcp/core/proxmox.py
@@ -97,8 +97,7 @@ class ProxmoxManager:
             return api
         except Exception as e:
             self.logger.error(f"Failed to initialize Proxmox API client: {e}")
-            # Still return the API object; it will raise useful errors during tool calls
-            return api
+            raise RuntimeError(f"Failed to initialize Proxmox API client: {e}") from e
 
     def get_api(self) -> ProxmoxAPI:
         """Get the initialized Proxmox API instance.

--- a/src/proxmox_mcp/formatting/components.py
+++ b/src/proxmox_mcp/formatting/components.py
@@ -56,21 +56,22 @@ class ProxmoxComponents:
         # Add rows with multi-line cell support
         for row in rows:
             # Split each cell into lines
-            cell_lines = [str(cell).split('\n') for cell in row]
-            max_lines = max(len(lines) for lines in cell_lines)
+            row_cell_lines = [str(cell).split('\n') for cell in row]
+            max_lines = max(len(lines) for lines in row_cell_lines)
             
             # Pad cells with fewer lines
-            padded_cells = []
-            for lines in cell_lines:
-                if len(lines) < max_lines:
-                    lines.extend([''] * (max_lines - len(lines)))
-                padded_cells.append(lines)
+            padded_cells: List[List[str]] = []
+            for cell_line_group in row_cell_lines:
+                normalized = list(cell_line_group)
+                if len(normalized) < max_lines:
+                    normalized.extend([''] * (max_lines - len(normalized)))
+                padded_cells.append(normalized)
             
             # Create row strings for each line
             for line_idx in range(max_lines):
                 line_parts = []
-                for col_idx, cell_lines in enumerate(padded_cells):
-                    line = cell_lines[line_idx]
+                for col_idx, padded_line_group in enumerate(padded_cells):
+                    line = padded_line_group[line_idx]
                     line_parts.append(f" {line:<{widths[col_idx]}} ")
                 result.append("|" + "|".join(line_parts) + "|")
             
@@ -114,13 +115,12 @@ class ProxmoxComponents:
             Formatted resource usage string
         """
         from proxmox_mcp.formatting.formatters import ProxmoxFormatters
-        percentage = (used / total * 100) if total > 0 else 0
         progress = ProxmoxComponents.create_progress_bar(used, total)
         
         return (
             f"{emoji} {label}:\n"
             f"  {progress}\n"
-            f"  {ProxmoxFormatters.format_bytes(used)} / {ProxmoxFormatters.format_bytes(total)}"
+            f"  {ProxmoxFormatters.format_bytes(int(used))} / {ProxmoxFormatters.format_bytes(int(total))}"
         )
     
     @staticmethod

--- a/src/proxmox_mcp/formatting/formatters.py
+++ b/src/proxmox_mcp/formatting/formatters.py
@@ -1,7 +1,5 @@
-"""
-Core formatting functions for Proxmox MCP output.
-"""
-from typing import List, Union, Dict, Any
+"""Core formatting functions for Proxmox MCP output."""
+from typing import Optional
 from proxmox_mcp.formatting.theme import ProxmoxTheme
 from proxmox_mcp.formatting.colors import ProxmoxColors
 
@@ -18,11 +16,12 @@ class ProxmoxFormatters:
         Returns:
             Formatted string with appropriate unit
         """
+        value = float(bytes_value)
         for unit in ['B', 'KB', 'MB', 'GB', 'TB']:
-            if bytes_value < 1024:
-                return f"{bytes_value:.2f} {unit}"
-            bytes_value /= 1024
-        return f"{bytes_value:.2f} TB"
+            if value < 1024:
+                return f"{value:.2f} {unit}"
+            value /= 1024
+        return f"{value:.2f} TB"
     
     @staticmethod
     def format_uptime(seconds: int) -> str:
@@ -126,7 +125,12 @@ class ProxmoxFormatters:
         return f"{prefix}{key_str}: {value}"
     
     @staticmethod
-    def format_command_output(success: bool, command: str, output: str, error: str = None) -> str:
+    def format_command_output(
+        success: bool,
+        command: str,
+        output: str,
+        error: Optional[str] = None,
+    ) -> str:
         """Format command execution output.
         
         Args:

--- a/src/proxmox_mcp/formatting/templates.py
+++ b/src/proxmox_mcp/formatting/templates.py
@@ -4,8 +4,6 @@ Output templates for Proxmox MCP resource types.
 from typing import Dict, List, Any
 from proxmox_mcp.formatting.formatters import ProxmoxFormatters
 from proxmox_mcp.formatting.theme import ProxmoxTheme
-from proxmox_mcp.formatting.colors import ProxmoxColors
-from proxmox_mcp.formatting.components import ProxmoxComponents
 
 class ProxmoxTemplates:
     """Output templates for different Proxmox resource types."""

--- a/src/proxmox_mcp/models/__init__.py
+++ b/src/proxmox_mcp/models/__init__.py
@@ -1,0 +1,5 @@
+"""Shared API-facing models."""
+
+from .tooling import ToolResult
+
+__all__ = ["ToolResult"]

--- a/src/proxmox_mcp/models/tooling.py
+++ b/src/proxmox_mcp/models/tooling.py
@@ -1,0 +1,14 @@
+"""Standardized tool result envelope."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ToolResult(BaseModel):
+    success: bool
+    code: str = Field(description="Stable machine-readable result code")
+    message: str
+    data: Any | None = None

--- a/src/proxmox_mcp/observability/__init__.py
+++ b/src/proxmox_mcp/observability/__init__.py
@@ -1,0 +1,5 @@
+"""Observability scaffolding."""
+
+from .metrics import ToolMetrics
+
+__all__ = ["ToolMetrics"]

--- a/src/proxmox_mcp/observability/metrics.py
+++ b/src/proxmox_mcp/observability/metrics.py
@@ -1,0 +1,19 @@
+"""Minimal metrics hooks with no-op fallback."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ToolMetrics:
+    """No-op metrics collector placeholder for future OTel/Prom integration."""
+
+    def record_call(self, tool_name: str) -> None:
+        return None
+
+    def record_error(self, tool_name: str) -> None:
+        return None
+
+    def record_latency_ms(self, tool_name: str, latency_ms: float) -> None:
+        return None

--- a/src/proxmox_mcp/security/__init__.py
+++ b/src/proxmox_mcp/security/__init__.py
@@ -1,0 +1,5 @@
+"""Security helpers for policy enforcement and hardening."""
+
+from .command_policy import CommandPolicyGate, CommandPolicyDecision
+
+__all__ = ["CommandPolicyGate", "CommandPolicyDecision"]

--- a/src/proxmox_mcp/security/command_policy.py
+++ b/src/proxmox_mcp/security/command_policy.py
@@ -1,0 +1,75 @@
+"""Command policy gateway for execute_* tools."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable, Pattern
+
+from proxmox_mcp.config.models import CommandPolicyConfig
+
+
+@dataclass(frozen=True)
+class CommandPolicyDecision:
+    allowed: bool
+    code: str
+    message: str
+
+
+class CommandPolicyGate:
+    """Evaluate command execution requests against configured policy."""
+
+    def __init__(self, config: CommandPolicyConfig):
+        self.config = config
+        self.allow_patterns = self._compile_patterns(config.allow_patterns)
+        deny_patterns = config.deny_patterns if config.deny_patterns else []
+        self.deny_patterns = self._compile_patterns(deny_patterns)
+
+    @staticmethod
+    def _compile_patterns(patterns: Iterable[str]) -> list[Pattern[str]]:
+        compiled: list[Pattern[str]] = []
+        for pattern in patterns:
+            compiled.append(re.compile(pattern, flags=re.IGNORECASE))
+        return compiled
+
+    @staticmethod
+    def _matches_any(command: str, patterns: list[Pattern[str]]) -> bool:
+        return any(pattern.search(command) for pattern in patterns)
+
+    def evaluate(self, command: str, approval_token: str | None = None) -> CommandPolicyDecision:
+        if not command or not command.strip():
+            return CommandPolicyDecision(False, "CMD_POLICY_EMPTY", "Command cannot be empty")
+
+        if self._matches_any(command, self.deny_patterns):
+            return CommandPolicyDecision(
+                False,
+                "CMD_POLICY_DENY_PATTERN",
+                "Command blocked by deny policy pattern",
+            )
+
+        mode = self.config.mode
+        if mode in {"deny_all", "allowlist"} and not self._matches_any(command, self.allow_patterns):
+            return CommandPolicyDecision(
+                False,
+                "CMD_POLICY_NOT_ALLOWLISTED",
+                "Command not allowlisted by policy",
+            )
+
+        if self.config.require_approval_token:
+            if not self.config.approval_token:
+                return CommandPolicyDecision(
+                    False,
+                    "CMD_POLICY_APPROVAL_NOT_CONFIGURED",
+                    "Approval token required but not configured on server",
+                )
+            if approval_token != self.config.approval_token:
+                return CommandPolicyDecision(
+                    False,
+                    "CMD_POLICY_APPROVAL_REQUIRED",
+                    "Approval token required for command execution",
+                )
+
+        if mode == "audit_only":
+            return CommandPolicyDecision(True, "CMD_POLICY_AUDIT_ALLOW", "Allowed (audit-only mode)")
+
+        return CommandPolicyDecision(True, "CMD_POLICY_ALLOW", "Allowed by policy")

--- a/src/proxmox_mcp/server.py
+++ b/src/proxmox_mcp/server.py
@@ -37,6 +37,7 @@ from proxmox_mcp.tools.containers import ContainerTools
 from proxmox_mcp.tools.snapshots import SnapshotTools
 from proxmox_mcp.tools.iso import ISOTools
 from proxmox_mcp.tools.backup import BackupTools
+from proxmox_mcp.security import CommandPolicyGate
 from proxmox_mcp.tools.definitions import (
     GET_NODES_DESC,
     GET_NODE_STATUS_DESC,
@@ -94,13 +95,18 @@ class ProxmoxMCPServer:
         # Initialize core components
         self.proxmox_manager = ProxmoxManager(self.config.proxmox, self.config.auth)
         self.proxmox = self.proxmox_manager.get_api()
+        self.command_policy = CommandPolicyGate(self.config.command_policy)
         
         # Initialize tools
         self.node_tools = NodeTools(self.proxmox)
-        self.vm_tools = VMTools(self.proxmox)
+        self.vm_tools = VMTools(self.proxmox, command_policy=self.command_policy)
         self.storage_tools = StorageTools(self.proxmox)
         self.cluster_tools = ClusterTools(self.proxmox)
-        self.container_tools = ContainerTools(self.proxmox, self.config.ssh)
+        self.container_tools = ContainerTools(
+            self.proxmox,
+            self.config.ssh,
+            command_policy=self.command_policy,
+        )
         self.snapshot_tools = SnapshotTools(self.proxmox)
         self.iso_tools = ISOTools(self.proxmox)
         self.backup_tools = BackupTools(self.proxmox)
@@ -163,9 +169,10 @@ class ProxmoxMCPServer:
         async def execute_vm_command(
             node: Annotated[str, Field(description="Host node name (e.g. 'pve1', 'proxmox-node2')")],
             vmid: Annotated[str, Field(description="VM ID number (e.g. '100', '101')")],
-            command: Annotated[str, Field(description="Shell command to run (e.g. 'uname -a', 'systemctl status nginx')")]
+            command: Annotated[str, Field(description="Shell command to run (e.g. 'uname -a', 'systemctl status nginx')")],
+            approval_token: Annotated[Optional[str], Field(description="Optional approval token if command policy requires it", default=None)] = None,
         ):
-            return await self.vm_tools.execute_command(node, vmid, command)
+            return await self.vm_tools.execute_command(node, vmid, command, approval_token=approval_token)
 
         # VM Power Management tools
         @self.mcp.tool(description=START_VM_DESC)
@@ -330,8 +337,13 @@ class ProxmoxMCPServer:
             def execute_container_command(
                 selector: Annotated[str, Field(description="Container selector: '123', 'pve1:123', 'pve1/name', or 'name'")],
                 command: Annotated[str, Field(description="Shell command to run (e.g. 'uname -a', 'df -h')")],
+                approval_token: Annotated[Optional[str], Field(description="Optional approval token if command policy requires it", default=None)] = None,
             ):
-                return self.container_tools.execute_command(selector=selector, command=command)
+                return self.container_tools.execute_command(
+                    selector=selector,
+                    command=command,
+                    approval_token=approval_token,
+                )
 
             @self.mcp.tool(description=UPDATE_CONTAINER_SSH_KEYS_DESC)
             def update_container_ssh_keys(

--- a/src/proxmox_mcp/server.py
+++ b/src/proxmox_mcp/server.py
@@ -14,15 +14,12 @@ The server exposes a set of tools for managing Proxmox resources including:
 - Storage management
 - Cluster status monitoring
 """
-import logging
 import os
 import sys
 import signal
-from typing import Optional, List, Annotated, Literal
+from typing import Optional, Annotated, Literal, cast
 
 from mcp.server.fastmcp import FastMCP
-from mcp.server.fastmcp.tools import Tool
-from mcp.types import TextContent as Content
 from pydantic import Field, BaseModel
 from fastapi import Body
 
@@ -116,7 +113,10 @@ class ProxmoxMCPServer:
             "ProxmoxMCP",
             host=self.config.mcp.host,
             port=self.config.mcp.port,
-            log_level=self.config.logging.level.upper(),
+            log_level=cast(
+                Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+                self.config.logging.level.upper(),
+            ),
         )
         self._setup_tools()
 

--- a/src/proxmox_mcp/services/__init__.py
+++ b/src/proxmox_mcp/services/__init__.py
@@ -1,0 +1,5 @@
+"""Application service layer scaffolding."""
+
+from .tool_registry import ToolRegistryPlugin, ToolRegistry
+
+__all__ = ["ToolRegistryPlugin", "ToolRegistry"]

--- a/src/proxmox_mcp/services/tool_registry.py
+++ b/src/proxmox_mcp/services/tool_registry.py
@@ -1,0 +1,26 @@
+"""Plugin-ready registry for MCP tool registration."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class ToolRegistryPlugin(Protocol):
+    """Contract for a pluggable tool registration module."""
+
+    def register(self, server: object) -> None:
+        """Register tools onto the given server."""
+
+
+class ToolRegistry:
+    """Runtime registry for loading and registering tool plugins."""
+
+    def __init__(self) -> None:
+        self._plugins: list[ToolRegistryPlugin] = []
+
+    def add(self, plugin: ToolRegistryPlugin) -> None:
+        self._plugins.append(plugin)
+
+    def register_all(self, server: object) -> None:
+        for plugin in self._plugins:
+            plugin.register(server)

--- a/src/proxmox_mcp/tools/base.py
+++ b/src/proxmox_mcp/tools/base.py
@@ -11,7 +11,8 @@ All tool implementations inherit from the ProxmoxTool base class to ensure
 consistent behavior and error handling across the MCP server.
 """
 import logging
-from typing import Any, Dict, List, Optional, Union
+import time
+from typing import Any, Callable, Dict, List, Optional
 from mcp.types import TextContent as Content
 from proxmoxer import ProxmoxAPI
 from proxmox_mcp.formatting import ProxmoxTemplates
@@ -37,6 +38,37 @@ class ProxmoxTool:
         """
         self.proxmox = proxmox_api
         self.logger = logging.getLogger(f"proxmox-mcp.{self.__class__.__name__.lower()}")
+        self._cache: Dict[str, tuple[float, Any]] = {}
+
+    def _cache_get(self, key: str) -> Any:
+        entry = self._cache.get(key)
+        if not entry:
+            return None
+        expires_at, value = entry
+        if time.time() >= expires_at:
+            self._cache.pop(key, None)
+            return None
+        return value
+
+    def _cache_set(self, key: str, value: Any, ttl_seconds: int = 5) -> None:
+        self._cache[key] = (time.time() + ttl_seconds, value)
+
+    def _call_with_retry(
+        self,
+        operation: str,
+        fn: Callable[[], Any],
+        retries: int = 2,
+        backoff_seconds: float = 0.2,
+    ) -> Any:
+        attempt = 0
+        while True:
+            try:
+                return fn()
+            except Exception as error:
+                attempt += 1
+                if attempt > retries:
+                    self._handle_error(operation, error)
+                time.sleep(backoff_seconds * attempt)
 
     def _format_response(self, data: Any, resource_type: Optional[str] = None) -> List[Content]:
         """Format response data into MCP content using templates.

--- a/src/proxmox_mcp/tools/base.py
+++ b/src/proxmox_mcp/tools/base.py
@@ -12,7 +12,7 @@ consistent behavior and error handling across the MCP server.
 """
 import logging
 import time
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, NoReturn, Optional
 from mcp.types import TextContent as Content
 from proxmoxer import ProxmoxAPI
 from proxmox_mcp.formatting import ProxmoxTemplates
@@ -109,7 +109,7 @@ class ProxmoxTool:
 
         return [Content(type="text", text=formatted)]
 
-    def _handle_error(self, operation: str, error: Exception) -> None:
+    def _handle_error(self, operation: str, error: Exception) -> NoReturn:
         """Handle and log errors from Proxmox operations.
 
         Provides standardized error handling across all tools by:

--- a/src/proxmox_mcp/tools/cluster.py
+++ b/src/proxmox_mcp/tools/cluster.py
@@ -13,7 +13,6 @@ cluster health and ensuring proper operation.
 from typing import List
 from mcp.types import TextContent as Content
 from proxmox_mcp.tools.base import ProxmoxTool
-from proxmox_mcp.tools.definitions import GET_CLUSTER_STATUS_DESC
 
 class ClusterTools(ProxmoxTool):
     """Tools for managing Proxmox cluster.
@@ -63,8 +62,14 @@ class ClusterTools(ProxmoxTool):
                         - Authentication problems
                         - API endpoint failures
         """
+        cached = self._cache_get("cluster:status")
+        if cached is not None:
+            return self._format_response(cached, "cluster")
+
         try:
-            result = self.proxmox.cluster.status.get()
+            result = self._call_with_retry(
+                "get cluster status", lambda: self.proxmox.cluster.status.get()
+            )
         
             first_item = result[0] if result and len(result) > 0 else {}
             status = {
@@ -73,6 +78,7 @@ class ClusterTools(ProxmoxTool):
                 "nodes": len([node for node in result if node.get("type") == "node"]) if result else 0,
                 "resources": [res for res in result if res.get("type") == "resource"] if result else []
             }
+            self._cache_set("cluster:status", status, ttl_seconds=5)
             return self._format_response(status, "cluster")
         except Exception as e:
             self._handle_error("get cluster status", e)

--- a/src/proxmox_mcp/tools/console/container_manager.py
+++ b/src/proxmox_mcp/tools/console/container_manager.py
@@ -53,7 +53,13 @@ class ContainerConsoleManager:
 
         # 3. SSH to node and run command
         client = paramiko.SSHClient()
-        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        if self.ssh_cfg.strict_host_key_checking:
+            client.load_system_host_keys()
+            if self.ssh_cfg.known_hosts_file:
+                client.load_host_keys(os.path.expanduser(self.ssh_cfg.known_hosts_file))
+            client.set_missing_host_key_policy(paramiko.RejectPolicy())
+        else:
+            client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
         connect_kwargs: Dict[str, Any] = dict(
             hostname=self._ssh_host(node),

--- a/src/proxmox_mcp/tools/console/container_manager.py
+++ b/src/proxmox_mcp/tools/console/container_manager.py
@@ -12,7 +12,7 @@ import shlex
 import logging
 from typing import Dict, Any
 
-import paramiko
+import paramiko  # type: ignore[import-untyped]
 
 
 class ContainerConsoleManager:

--- a/src/proxmox_mcp/tools/containers.py
+++ b/src/proxmox_mcp/tools/containers.py
@@ -1,6 +1,7 @@
 from typing import List, Dict, Optional, Tuple, Any, Union
 import json
 from mcp.types import TextContent as Content
+from proxmox_mcp.models import ToolResult
 from .base import ProxmoxTool
 from .console.container_manager import ContainerConsoleManager
 
@@ -712,13 +713,13 @@ class ContainerTools(ProxmoxTool):
             if self.command_policy is not None:
                 decision = self.command_policy.evaluate(command, approval_token=approval_token)
                 if not decision.allowed:
-                    return self._json_fmt(
-                        {
-                            "success": False,
-                            "code": decision.code,
-                            "error": decision.message,
-                        }
+                    result = ToolResult(
+                        success=False,
+                        code=decision.code,
+                        message="Command execution blocked by policy",
+                        data={"reason": decision.message},
                     )
+                    return self._json_fmt(result.model_dump())
 
             targets = self._resolve_targets(selector)
             if not targets:

--- a/src/proxmox_mcp/tools/containers.py
+++ b/src/proxmox_mcp/tools/containers.py
@@ -79,11 +79,7 @@ class ContainerTools(ProxmoxTool):
         return [Content(type="text", text=json.dumps(data, indent=2, sort_keys=True))]
 
     def _err(self, action: str, e: Exception) -> List[Content]:
-        if hasattr(self, "handle_error"):
-            return self.handle_error(e, action)  # type: ignore[attr-defined]
-        if hasattr(self, "_handle_error"):
-            return self._handle_error(action, e)  # type: ignore[attr-defined]
-        return [Content(type="text", text=json.dumps({"error": str(e), "action": action}))]
+        self._handle_error(action, e)
 
     # ---------- helpers ----------
     def _list_ct_pairs(self, node: Optional[str]) -> List[Tuple[str, Dict]]:
@@ -551,7 +547,6 @@ class ContainerTools(ProxmoxTool):
                 # Prefer local-lvm, then any storage that supports rootdir/images
                 for s in storage_list:
                     sname = _get(s, "storage")
-                    stype = _get(s, "type")
                     content = _get(s, "content", "")
                     if sname == "local-lvm":
                         storage = sname
@@ -713,13 +708,13 @@ class ContainerTools(ProxmoxTool):
             if self.command_policy is not None:
                 decision = self.command_policy.evaluate(command, approval_token=approval_token)
                 if not decision.allowed:
-                    result = ToolResult(
+                    policy_result = ToolResult(
                         success=False,
                         code=decision.code,
                         message="Command execution blocked by policy",
                         data={"reason": decision.message},
                     )
-                    return self._json_fmt(result.model_dump())
+                    return self._json_fmt(policy_result.model_dump())
 
             targets = self._resolve_targets(selector)
             if not targets:
@@ -733,9 +728,9 @@ class ContainerTools(ProxmoxTool):
                     ),
                 )
             node, vmid, _label = targets[0]
-            result = self.console_manager.execute_command(node, str(vmid), command)
+            exec_result = self.console_manager.execute_command(node, str(vmid), command)
             import json as _json
-            return [Content(type="text", text=_json.dumps(result, indent=2))]
+            return [Content(type="text", text=_json.dumps(exec_result, indent=2))]
         except Exception as e:
             return self._err("execute_command", e)
 

--- a/src/proxmox_mcp/tools/containers.py
+++ b/src/proxmox_mcp/tools/containers.py
@@ -60,11 +60,17 @@ class ContainerTools(ProxmoxTool):
     - Pretty output rendered here; JSON path is raw & sanitized
     """
 
-    def __init__(self, proxmox_api: Any, ssh_config: Any = None) -> None:
+    def __init__(
+        self,
+        proxmox_api: Any,
+        ssh_config: Any = None,
+        command_policy: Any = None,
+    ) -> None:
         super().__init__(proxmox_api)
         self.console_manager: Optional[ContainerConsoleManager] = (
             ContainerConsoleManager(proxmox_api, ssh_config) if ssh_config is not None else None
         )
+        self.command_policy = command_policy
 
     # ---------- error / output ----------
     def _json_fmt(self, data: Any) -> List[Content]:
@@ -679,7 +685,12 @@ class ContainerTools(ProxmoxTool):
         except Exception as e:
             return self._err("Failed to delete container(s)", e)
 
-    def execute_command(self, selector: str, command: str) -> List[Content]:
+    def execute_command(
+        self,
+        selector: str,
+        command: str,
+        approval_token: Optional[str] = None,
+    ) -> List[Content]:
         """Execute a shell command inside a running LXC container via SSH + pct exec.
 
         Parameters:
@@ -698,6 +709,17 @@ class ContainerTools(ProxmoxTool):
                 ),
             )
         try:
+            if self.command_policy is not None:
+                decision = self.command_policy.evaluate(command, approval_token=approval_token)
+                if not decision.allowed:
+                    return self._json_fmt(
+                        {
+                            "success": False,
+                            "code": decision.code,
+                            "error": decision.message,
+                        }
+                    )
+
             targets = self._resolve_targets(selector)
             if not targets:
                 return self._err("execute_command", ValueError(f"No container matched selector: {selector}"))

--- a/src/proxmox_mcp/tools/iso.py
+++ b/src/proxmox_mcp/tools/iso.py
@@ -54,7 +54,7 @@ class ISOTools(ProxmoxTool):
         self, content_type: str, node: Optional[str] = None, storage: Optional[str] = None
     ) -> List[Dict]:
         """Get storage content filtered by type across nodes/storages."""
-        results = []
+        results: List[Dict[str, Any]] = []
         try:
             nodes = _as_list(self.proxmox.nodes.get())
         except Exception as e:

--- a/src/proxmox_mcp/tools/node.py
+++ b/src/proxmox_mcp/tools/node.py
@@ -15,7 +15,6 @@ with fallback mechanisms for partial data availability.
 from typing import List
 from mcp.types import TextContent as Content
 from proxmox_mcp.tools.base import ProxmoxTool
-from proxmox_mcp.tools.definitions import GET_NODES_DESC, GET_NODE_STATUS_DESC
 
 class NodeTools(ProxmoxTool):
     """Tools for managing Proxmox nodes.
@@ -58,8 +57,12 @@ class NodeTools(ProxmoxTool):
         Raises:
             RuntimeError: If the cluster-wide node query fails
         """
+        cached = self._cache_get("nodes:list")
+        if cached is not None:
+            return self._format_response(cached, "nodes")
+
         try:
-            result = self.proxmox.nodes.get()
+            result = self._call_with_retry("get nodes", lambda: self.proxmox.nodes.get())
             nodes = []
             
             # Get detailed info for each node
@@ -100,6 +103,7 @@ class NodeTools(ProxmoxTool):
                             "total": node.get("maxmem", 0)
                         }
                     })
+            self._cache_set("nodes:list", nodes, ttl_seconds=5)
             return self._format_response(nodes, "nodes")
         except Exception as e:
             self._handle_error("get nodes", e)

--- a/src/proxmox_mcp/tools/storage.py
+++ b/src/proxmox_mcp/tools/storage.py
@@ -15,7 +15,6 @@ detailed storage information might be temporarily unavailable.
 from typing import List
 from mcp.types import TextContent as Content
 from proxmox_mcp.tools.base import ProxmoxTool
-from proxmox_mcp.tools.definitions import GET_STORAGE_DESC
 
 class StorageTools(ProxmoxTool):
     """Tools for managing Proxmox storage.
@@ -60,8 +59,12 @@ class StorageTools(ProxmoxTool):
         Raises:
             RuntimeError: If the cluster-wide storage query fails
         """
+        cached = self._cache_get("storage:list")
+        if cached is not None:
+            return self._format_response(cached, "storage")
+
         try:
-            result = self.proxmox.storage.get()
+            result = self._call_with_retry("get storage", lambda: self.proxmox.storage.get())
             storage = []
             
             for store in result:
@@ -94,6 +97,7 @@ class StorageTools(ProxmoxTool):
                         "available": 0
                     })
                     
+            self._cache_set("storage:list", storage, ttl_seconds=10)
             return self._format_response(storage, "storage")
         except Exception as e:
             self._handle_error("get storage", e)

--- a/src/proxmox_mcp/tools/vm.py
+++ b/src/proxmox_mcp/tools/vm.py
@@ -15,7 +15,7 @@ This module provides tools for managing and interacting with Proxmox VMs:
 The tools implement fallback mechanisms for scenarios where
 detailed VM information might be temporarily unavailable.
 """
-from typing import List, Optional
+from typing import List, Optional, Any
 from mcp.types import TextContent as Content
 from proxmox_mcp.tools.base import ProxmoxTool
 from proxmox_mcp.tools.definitions import GET_VMS_DESC, EXECUTE_VM_COMMAND_DESC
@@ -37,7 +37,7 @@ class VMTools(ProxmoxTool):
     with QEMU guest agent for VM command execution.
     """
 
-    def __init__(self, proxmox_api):
+    def __init__(self, proxmox_api: Any, command_policy: Optional[Any] = None):
         """Initialize VM tools.
 
         Args:
@@ -45,6 +45,7 @@ class VMTools(ProxmoxTool):
         """
         super().__init__(proxmox_api)
         self.console_manager = VMConsoleManager(proxmox_api)
+        self.command_policy = command_policy
 
     def get_vms(self) -> List[Content]:
         """List all virtual machines across the cluster with detailed status.
@@ -424,7 +425,13 @@ class VMTools(ProxmoxTool):
                 raise ValueError(f"VM {vmid} not found on node {node}")
             self._handle_error(f"reset VM {vmid}", e)
 
-    async def execute_command(self, node: str, vmid: str, command: str) -> List[Content]:
+    async def execute_command(
+        self,
+        node: str,
+        vmid: str,
+        command: str,
+        approval_token: Optional[str] = None,
+    ) -> List[Content]:
         """Execute a command in a VM via QEMU guest agent.
 
         Uses the QEMU guest agent to execute commands within a running VM.
@@ -451,6 +458,20 @@ class VMTools(ProxmoxTool):
             RuntimeError: If command execution fails due to permissions or other issues
         """
         try:
+            if self.command_policy is not None:
+                decision = self.command_policy.evaluate(command, approval_token=approval_token)
+                if not decision.allowed:
+                    return [
+                        Content(
+                            type="text",
+                            text=(
+                                f"Command execution blocked by policy.\n"
+                                f"Code: {decision.code}\n"
+                                f"Reason: {decision.message}"
+                            ),
+                        )
+                    ]
+
             result = await self.console_manager.execute_command(node, vmid, command)
             # Use the command output formatter from ProxmoxFormatters
             from proxmox_mcp.formatting import ProxmoxFormatters

--- a/src/proxmox_mcp/tools/vm.py
+++ b/src/proxmox_mcp/tools/vm.py
@@ -170,7 +170,7 @@ class VMTools(ProxmoxTool):
         try:
             # Check if VM ID already exists
             try:
-                existing_vm = self.proxmox.nodes(node).qemu(vmid).config.get()
+                self.proxmox.nodes(node).qemu(vmid).config.get()
                 raise ValueError(f"VM {vmid} already exists on node {node}")
             except Exception as e:
                 if "does not exist" not in str(e).lower():
@@ -461,7 +461,7 @@ class VMTools(ProxmoxTool):
             if self.command_policy is not None:
                 decision = self.command_policy.evaluate(command, approval_token=approval_token)
                 if not decision.allowed:
-                    result = ToolResult(
+                    policy_result = ToolResult(
                         success=False,
                         code=decision.code,
                         message="Command execution blocked by policy",
@@ -470,18 +470,18 @@ class VMTools(ProxmoxTool):
                     return [
                         Content(
                             type="text",
-                            text=result.model_dump_json(indent=2),
+                            text=policy_result.model_dump_json(indent=2),
                         )
                     ]
 
-            result = await self.console_manager.execute_command(node, vmid, command)
+            exec_result = await self.console_manager.execute_command(node, vmid, command)
             # Use the command output formatter from ProxmoxFormatters
             from proxmox_mcp.formatting import ProxmoxFormatters
             formatted = ProxmoxFormatters.format_command_output(
-                success=result["success"],
+                success=exec_result["success"],
                 command=command,
-                output=result["output"],
-                error=result.get("error")
+                output=exec_result["output"],
+                error=exec_result.get("error")
             )
             return [Content(type="text", text=formatted)]
         except Exception as e:

--- a/src/proxmox_mcp/tools/vm.py
+++ b/src/proxmox_mcp/tools/vm.py
@@ -17,8 +17,8 @@ detailed VM information might be temporarily unavailable.
 """
 from typing import List, Optional, Any
 from mcp.types import TextContent as Content
+from proxmox_mcp.models import ToolResult
 from proxmox_mcp.tools.base import ProxmoxTool
-from proxmox_mcp.tools.definitions import GET_VMS_DESC, EXECUTE_VM_COMMAND_DESC
 from proxmox_mcp.tools.console.manager import VMConsoleManager
 
 class VMTools(ProxmoxTool):
@@ -461,14 +461,16 @@ class VMTools(ProxmoxTool):
             if self.command_policy is not None:
                 decision = self.command_policy.evaluate(command, approval_token=approval_token)
                 if not decision.allowed:
+                    result = ToolResult(
+                        success=False,
+                        code=decision.code,
+                        message="Command execution blocked by policy",
+                        data={"reason": decision.message},
+                    )
                     return [
                         Content(
                             type="text",
-                            text=(
-                                f"Command execution blocked by policy.\n"
-                                f"Code: {decision.code}\n"
-                                f"Reason: {decision.message}"
-                            ),
+                            text=result.model_dump_json(indent=2),
                         )
                     ]
 

--- a/src/proxmox_mcp/utils/auth.py
+++ b/src/proxmox_mcp/utils/auth.py
@@ -3,7 +3,7 @@ Authentication utilities for the Proxmox MCP server.
 """
 
 import os
-from typing import Dict, Optional, Tuple
+from typing import Dict, Tuple
 
 from pydantic import BaseModel
 
@@ -42,6 +42,7 @@ def load_auth_from_env() -> ProxmoxAuth:
             missing.append("PROXMOX_TOKEN_VALUE")
         raise ValueError(f"Missing required environment variables: {', '.join(missing)}")
 
+    assert user is not None and token_name is not None and token_value is not None
     return ProxmoxAuth(
         user=user,
         token_name=token_name,

--- a/src/proxmox_mcp/utils/logging.py
+++ b/src/proxmox_mcp/utils/logging.py
@@ -27,7 +27,7 @@ def setup_logging(
     logger.setLevel(getattr(logging, level.upper()))
 
     # Create handlers
-    handlers = []
+    handlers: list[logging.Handler] = []
 
     # Console handler
     console_handler = logging.StreamHandler(sys.stderr)

--- a/tests/integration/test_contract_scaffold.py
+++ b/tests/integration/test_contract_scaffold.py
@@ -1,0 +1,8 @@
+"""Scaffold for future contract/integration tests against real Proxmox."""
+
+import pytest
+
+
+@pytest.mark.skip(reason="Integration environment not configured yet")
+def test_openapi_contract_scaffold() -> None:
+    assert True

--- a/tests/test_container_console.py
+++ b/tests/test_container_console.py
@@ -20,6 +20,8 @@ class _SSHConfig:
     password = None
     host_overrides: dict = {}
     use_sudo = False
+    known_hosts_file = None
+    strict_host_key_checking = False
 
 
 @pytest.fixture

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock, patch
 
 from mcp.server.fastmcp.exceptions import ToolError
 from proxmox_mcp.server import ProxmoxMCPServer
+from proxmox_mcp.config.loader import load_config
 
 @pytest.fixture
 def mock_env_vars(tmp_path):
@@ -29,6 +30,9 @@ def mock_env_vars(tmp_path):
         "logging": {
             "level": "DEBUG",
         },
+        "command_policy": {
+            "mode": "audit_only",
+        },
     }))
 
     env_vars = {
@@ -38,6 +42,7 @@ def mock_env_vars(tmp_path):
         "PROXMOX_TOKEN_NAME": "test_token",
         "PROXMOX_TOKEN_VALUE": "test_value",
         "LOG_LEVEL": "DEBUG",
+        "COMMAND_POLICY_MODE": "audit_only",
     }
     with patch.dict(os.environ, env_vars):
         yield env_vars
@@ -88,6 +93,32 @@ def test_server_applies_configured_http_host_and_port(mock_proxmox, tmp_path):
 
     assert http_server.mcp.settings.host == "0.0.0.0"
     assert http_server.mcp.settings.port == 9000
+
+
+def test_loader_blocks_insecure_tls_in_prod(tmp_path):
+    config_path = tmp_path / "config_insecure.json"
+    config_path.write_text(json.dumps({
+        "proxmox": {"host": "test.proxmox.com", "port": 8006, "verify_ssl": False, "service": "PVE"},
+        "auth": {"user": "test@pve", "token_name": "test_token", "token_value": "test_value"},
+        "logging": {"level": "INFO"},
+        "security": {"dev_mode": False},
+    }))
+
+    with pytest.raises(ValueError, match="Insecure TLS configuration blocked"):
+        load_config(str(config_path))
+
+
+def test_loader_allows_insecure_tls_in_dev_mode(tmp_path):
+    config_path = tmp_path / "config_insecure_dev.json"
+    config_path.write_text(json.dumps({
+        "proxmox": {"host": "test.proxmox.com", "port": 8006, "verify_ssl": False, "service": "PVE"},
+        "auth": {"user": "test@pve", "token_name": "test_token", "token_value": "test_value"},
+        "logging": {"level": "INFO"},
+        "security": {"dev_mode": True},
+    }))
+
+    config = load_config(str(config_path))
+    assert config.proxmox.verify_ssl is False
 
 
 @pytest.mark.asyncio
@@ -540,6 +571,26 @@ async def test_execute_vm_command_with_error(server, mock_proxmox):
     assert "Console Command Result" in text
     assert "Status: SUCCESS" in text
     assert "command not found" in text
+
+
+@pytest.mark.asyncio
+async def test_execute_vm_command_blocked_by_policy(mock_proxmox, tmp_path):
+    """Deny-all mode blocks commands not explicitly allowlisted."""
+    config_path = tmp_path / "config_policy_deny.json"
+    config_path.write_text(json.dumps({
+        "proxmox": {"host": "test.proxmox.com", "port": 8006, "verify_ssl": True, "service": "PVE"},
+        "auth": {"user": "test@pve", "token_name": "test_token", "token_value": "test_value"},
+        "logging": {"level": "DEBUG"},
+        "command_policy": {"mode": "deny_all"},
+    }))
+
+    deny_server = ProxmoxMCPServer(str(config_path))
+    response = await deny_server.mcp.call_tool("execute_vm_command", {
+        "node": "node1",
+        "vmid": "100",
+        "command": "uname -a",
+    })
+    assert "blocked by policy" in response[0].text.lower()
 
 @pytest.mark.asyncio
 async def test_start_vm(server, mock_proxmox):


### PR DESCRIPTION
## Summary
This PR introduces a security-hardening baseline and foundational engineering upgrades for ProxmoxMCP-Plus.

## What Changed

### Batch A: Security and Stability
- Fixed a critical startup bug in Proxmox API initialization (fail-fast on init errors).
- Removed runtime auto-install behavior from `main.py` (dependencies must be installed at build/deploy time).
- Enforced secure TLS defaults (`verify_ssl=true` by default, insecure mode only allowed with explicit `dev_mode=true`).
- Added strict SSH host key validation by default for container command execution.
- Added a command policy gateway for `execute_*_command` flows:
  - policy modes: `deny_all`, `allowlist`, `audit_only`
  - optional approval token enforcement
  - deny-pattern checks for dangerous command shapes

### Batch B: Engineering and Performance Baseline
- Added reusable retry + short TTL cache utilities in tool base layer.
- Applied cache/retry to core read paths (`nodes`, `storage`, `cluster`).
- Added a standardized tool result model (`ToolResult`) as schema baseline.
- Upgraded CI quality gates:
  - `pytest`
  - `ruff` (critical rule set)
  - `mypy`
  - `pip-audit`

### Batch C: Long-Term Platform Scaffolding
- Added plugin-ready tool registry scaffolding (`services/tool_registry.py`).
- Added observability scaffolding (`observability/metrics.py`) for future OTel/Prometheus integration.
- Added integration/contract test scaffold for real-environment validation.

## Validation
- Local tests: `46 passed, 1 skipped`.
- `ruff --select E9,F63,F7,F82` passes.
- Notes:
  - Full `mypy` currently exposes pre-existing type debt outside this PR scope.
  - `pip-audit` in local global environment reports unrelated vulnerabilities from non-project packages.

## Compatibility Notes
- Command execution behavior is now policy-driven and defaults to safer settings.
- Insecure TLS (`verify_ssl=false`) is blocked unless `security.dev_mode=true` is explicitly enabled.
- SSH strict host key checking is enabled by default; ensure host keys are present in known_hosts.

## Follow-ups
- Continue full server tool-registration modularization.
- Expand standardized response envelopes across all tools.
- Add real Proxmox integration test environment and full observability wiring.
