### PR TITLE
Fix PyPI workflow conditionals

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -43,6 +43,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    env:
+      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
     steps:
     - name: Download build artifacts
       uses: actions/download-artifact@v4
@@ -51,11 +53,11 @@ jobs:
         path: dist/
 
     - name: Publish to PyPI with API token
-      if: ${{ secrets.PYPI_API_TOKEN != '' }}
+      if: ${{ env.PYPI_API_TOKEN != '' }}
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
+        password: ${{ env.PYPI_API_TOKEN }}
 
     - name: Publish to PyPI with trusted publishing
-      if: ${{ secrets.PYPI_API_TOKEN == '' }}
+      if: ${{ env.PYPI_API_TOKEN == '' }}
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -8,26 +8,26 @@ Open-source MCP server for Proxmox VE automation.
 This repository provides a secure control plane for VM and container lifecycle operations, plus an OpenAPI bridge for integrations.
 
 Documentation strategy: this README is the stable entrypoint, while detailed runbooks and references live in Wiki.
-This keeps onboarding fast while preserving operational depth in one canonical location.
+This keeps onboarding fast while leaving longer guides and runbooks in Wiki.
 
-[Quick Start](#quick-start) | [Security](#security--compliance) | [API Reference](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/API-&-Tool-Reference) | [Troubleshooting](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/Troubleshooting)
+[Quick Start](#quick-start) | [Security](#security) | [API Reference](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/API-&-Tool-Reference) | [Troubleshooting](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/Troubleshooting)
 
 ## 1) Project Positioning and Value
 
 ProxmoxMCP-Plus is designed for teams that need:
 
 - Reliable MCP-native automation for Proxmox clusters
-- Operationally safe execution paths with policy controls
+- Safer execution paths with policy controls
 - Integration flexibility across MCP clients and HTTP/OpenAPI consumers
 - A documentation model where README stays concise and Wiki carries deep guidance
 
-This project builds on [canvrno/ProxmoxMCP](https://github.com/canvrno/ProxmoxMCP), and extends it for enterprise-oriented deployment and operations.
+This project builds on [canvrno/ProxmoxMCP](https://github.com/canvrno/ProxmoxMCP), and extends it with stronger operational controls, OpenAPI access, and clearer documentation for day-to-day use.
 
 Target audience:
 
-- Platform engineering teams operating Proxmox at scale
-- AI platform teams exposing virtualization controls to assistant workflows
-- Infrastructure teams requiring auditable and policy-aware automation
+- Teams operating Proxmox with MCP-based automation
+- AI and tooling teams exposing virtualization controls to assistant workflows
+- Infrastructure operators who need traceable automation with policy controls
 
 ## 2) Architecture and Capability Overview
 
@@ -39,6 +39,8 @@ High-level architecture:
 - `Observability Layer`: logging and health visibility
 - `OpenAPI Bridge`: HTTP exposure for external platforms
 
+![ProxmoxMCP-Plus architecture overview](assets/architecture-overview.drawio-style.svg)
+
 Capability groups:
 
 | Domain | Coverage |
@@ -48,6 +50,24 @@ Capability groups:
 | Platform Operations | Node, cluster, storage, and ISO/template management |
 | Remote Execution | Optional command execution for VM and container workflows |
 | Integrations | MCP clients, OpenAPI consumers, and WebUI-based automation |
+
+Core features:
+
+- `VM lifecycle you can actually automate`: create VMs with CPU, memory, disk, storage, OS type, and bridge settings; then start, stop, shut down, reset, or delete them from MCP or HTTP clients.
+- `LXC management with practical controls`: list containers, start/stop/restart them, resize CPU and memory, create new containers from templates, inspect config, fetch container IPs, and remove containers cleanly.
+- `Snapshots and rollback`: create, list, delete, and roll back snapshots for both VMs and containers, so assistants can handle change checkpoints without dropping to the Proxmox UI.
+- `Backups and restore flows`: browse backup volumes, trigger backups, restore them to new IDs, and clean up old backup artifacts when needed.
+- `Storage and image visibility`: inspect storage pools, browse uploaded ISOs, list templates, and download or delete ISO images without switching tools.
+- `Cluster and node awareness`: read cluster status, enumerate nodes, and inspect per-node health before making changes.
+- `Command execution with guardrails`: run commands in VMs through QEMU Guest Agent and in containers through SSH-backed execution, while still passing through command policy checks.
+- `OpenAPI bridge out of the box`: expose the same MCP capabilities over HTTP with `/docs`, `/openapi.json`, and `/health`, which makes it easier to connect Open WebUI, internal tools, or simple automation scripts.
+
+Why this is useful in practice:
+
+- An assistant can create a test VM from a plain-language request, choose storage automatically, and return the resulting VM details.
+- A workflow can snapshot a workload before change, run an update, and roll back if the verification step fails.
+- A WebUI or internal portal can use the OpenAPI endpoint instead of implementing Proxmox calls directly.
+- Teams can keep risky command execution behind policy checks instead of exposing raw shell access everywhere.
 
 Full endpoint and tool details are maintained in Wiki: [API & Tool Reference](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/API-&-Tool-Reference).
 
@@ -105,7 +125,7 @@ Health endpoint:
 curl -f http://localhost:8811/health
 ```
 
-For production deployment details, use [Operator Guide](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/Operator-Guide).
+For deployment details and runtime operations, use [Operator Guide](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/Operator-Guide).
 
 Validation path for first run:
 
@@ -127,22 +147,22 @@ Integration expectations:
 - Use environment-specific API keys when exposing OpenAPI.
 - Test with read-only operations before enabling lifecycle mutation workflows.
 
-## 5) Security & Compliance
+## 5) Security
 
-Security posture summary:
+Security summary:
 
 - API-token based Proxmox authentication
 - Environment-aware controls (`dev_mode` for development-only relaxation)
 - Command execution policy and allow/deny constraints
 - Operational logging and health visibility
 
-Security baseline, hardening checklist, and threat boundaries are documented in [Security Guide](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/Security-Guide).
+Security controls, deployment guidance, and threat boundaries are documented in [Security Guide](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/Security-Guide).
 
-Minimum production controls:
+Recommended deployment controls:
 
 - Enforce `security.dev_mode=false`
 - Restrict ingress to trusted networks or VPN paths
-- Terminate TLS at an approved reverse proxy
+- Terminate TLS at a reverse proxy you control
 - Rotate API credentials regularly and monitor denied operations
 
 ## 6) Contributing / Development
@@ -193,18 +213,18 @@ Support channels:
 
 FAQ shortcuts:
 
-- How do I deploy to production? See [Operator Guide](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/Operator-Guide).
+- How do I deploy this service? See [Operator Guide](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/Operator-Guide).
 - Where are all tools/endpoints listed? See [API & Tool Reference](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/API-&-Tool-Reference).
 - How do I configure secure command execution? See [Security Guide](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/Security-Guide).
 
-Escalation guidance:
+When troubleshooting deeper issues:
 
-- For security-sensitive incidents, collect logs and request context before remediation.
+- For security-related incidents, collect logs and request context before remediation.
 - For breaking behavior after upgrade, compare against [Release & Upgrade Notes](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/Release-&-Upgrade-Notes).
 
 ## 8) Wiki Navigation Panel
 
-GitHub Wiki is the source of truth for detailed documentation.  
+GitHub Wiki contains the detailed documentation.  
 If Wiki is not enabled yet, enable it in repository settings first, then publish the seed pages from `docs/wiki/`.
 
 ### Documentation Map
@@ -212,9 +232,9 @@ If Wiki is not enabled yet, enable it in repository settings first, then publish
 | Topic | What it covers | Wiki link |
 | --- | --- | --- |
 | Home | Documentation landing page and navigation | [Home](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/Home) |
-| Operator Guide | Deployment, runtime operations, OpenAPI, production checklist | [Operator Guide](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/Operator-Guide) |
+| Operator Guide | Deployment, runtime operations, OpenAPI, and operating checklist | [Operator Guide](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/Operator-Guide) |
 | Developer Guide | Local setup, coding standards, testing and release flow | [Developer Guide](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/Developer-Guide) |
-| Security Guide | Auth model, command policy, hardening and audit guidance | [Security Guide](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/Security-Guide) |
+| Security Guide | Auth model, command policy, hardening, and logging guidance | [Security Guide](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/Security-Guide) |
 | Integrations Guide | Claude, Cline, Open WebUI, MCP transport setup | [Integrations Guide](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/Integrations-Guide) |
 | API & Tool Reference | Tool groups, endpoint behavior, and request notes | [API & Tool Reference](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/API-&-Tool-Reference) |
 | Troubleshooting | Incident patterns, diagnostics, and recovery actions | [Troubleshooting](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/Troubleshooting) |
@@ -222,7 +242,7 @@ If Wiki is not enabled yet, enable it in repository settings first, then publish
 
 Local seed pages for Wiki bootstrap are available in [`docs/wiki/`](docs/wiki/README.md).
 
-### Documentation Contract
+### Documentation Notes
 
 README remains intentionally concise and stable.  
 Detailed operational guidance, examples, and runbooks live in Wiki.
@@ -230,7 +250,7 @@ Detailed operational guidance, examples, and runbooks live in Wiki.
 The following entry points are treated as stable documentation interfaces:
 
 - `Quick Start`: repository bootstrap and first-run verification
-- `Security`: baseline controls and hardening navigation
+- `Security`: control overview and hardening navigation
 - `API Reference`: tool and endpoint behavior index
 - `Troubleshooting`: incident diagnosis and recovery guidance
 

--- a/assets/architecture-overview.drawio-style.svg
+++ b/assets/architecture-overview.drawio-style.svg
@@ -1,0 +1,99 @@
+<svg width="1280" height="760" viewBox="0 0 1280 760" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style>
+      .title { font: 700 30px 'Segoe UI', Arial, sans-serif; fill: #111827; }
+      .subtitle { font: 400 16px 'Segoe UI', Arial, sans-serif; fill: #4B5563; }
+      .label { font: 700 18px 'Segoe UI', Arial, sans-serif; fill: #111827; }
+      .body { font: 400 14px 'Segoe UI', Arial, sans-serif; fill: #374151; }
+      .small { font: 600 13px 'Segoe UI', Arial, sans-serif; fill: #374151; }
+      .mono { font: 700 13px 'Consolas', 'Courier New', monospace; fill: #0F172A; }
+      .line { stroke: #64748B; stroke-width: 3; stroke-linecap: round; stroke-linejoin: round; }
+      .arrow { fill: #64748B; }
+    </style>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="8" flood-color="#0F172A" flood-opacity="0.12"/>
+    </filter>
+  </defs>
+
+  <rect x="0" y="0" width="1280" height="760" rx="24" fill="#F8FAFC"/>
+  <rect x="28" y="28" width="1224" height="704" rx="20" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
+
+  <text x="56" y="76" class="title">ProxmoxMCP-Plus Architecture Overview</text>
+  <text x="56" y="104" class="subtitle">MCP clients and HTTP consumers share one controlled service boundary for Proxmox automation.</text>
+
+  <rect x="56" y="140" width="250" height="160" rx="14" fill="#EFF6FF" stroke="#60A5FA" stroke-width="2" filter="url(#shadow)"/>
+  <text x="82" y="178" class="label">MCP Clients</text>
+  <rect x="82" y="196" width="198" height="30" rx="8" fill="#DBEAFE" stroke="#93C5FD"/>
+  <text x="104" y="216" class="body">Claude Desktop / Cline</text>
+  <rect x="82" y="236" width="198" height="30" rx="8" fill="#DBEAFE" stroke="#93C5FD"/>
+  <text x="124" y="256" class="body">Open WebUI</text>
+  <rect x="82" y="276" width="198" height="30" rx="8" fill="#DBEAFE" stroke="#93C5FD"/>
+  <text x="136" y="296" class="body">Custom MCP Apps</text>
+
+  <rect x="56" y="370" width="250" height="120" rx="14" fill="#F5F3FF" stroke="#A78BFA" stroke-width="2" filter="url(#shadow)"/>
+  <text x="82" y="408" class="label">HTTP Consumers</text>
+  <rect x="82" y="426" width="198" height="30" rx="8" fill="#EDE9FE" stroke="#C4B5FD"/>
+  <text x="111" y="446" class="body">OpenAPI / Swagger UI</text>
+  <rect x="82" y="466" width="198" height="30" rx="8" fill="#EDE9FE" stroke="#C4B5FD"/>
+  <text x="131" y="486" class="body">Automation Tools</text>
+
+  <rect x="382" y="184" width="520" height="280" rx="16" fill="#F8FAFC" stroke="#0F766E" stroke-width="3" filter="url(#shadow)"/>
+  <rect x="404" y="206" width="476" height="48" rx="10" fill="#CCFBF1" stroke="#5EEAD4"/>
+  <text x="428" y="236" class="label">ProxmoxMCP-Plus Service Boundary</text>
+
+  <rect x="422" y="274" width="206" height="76" rx="10" fill="#ECFEFF" stroke="#67E8F9"/>
+  <text x="446" y="304" class="small">MCP Server</text>
+  <text x="446" y="326" class="body">stdio transport</text>
+  <text x="446" y="344" class="body">tool registration</text>
+
+  <rect x="654" y="274" width="206" height="76" rx="10" fill="#ECFDF5" stroke="#86EFAC"/>
+  <text x="678" y="304" class="small">OpenAPI Bridge</text>
+  <text x="678" y="326" class="body">HTTP routes</text>
+  <text x="678" y="344" class="body">health + docs</text>
+
+  <rect x="422" y="366" width="206" height="76" rx="10" fill="#FEFCE8" stroke="#FACC15"/>
+  <text x="446" y="396" class="small">Tooling Layer</text>
+  <text x="446" y="418" class="body">VM / LXC / storage / backup</text>
+
+  <rect x="654" y="366" width="206" height="76" rx="10" fill="#FEF2F2" stroke="#FCA5A5"/>
+  <text x="678" y="396" class="small">Control Layer</text>
+  <text x="678" y="418" class="body">auth / policy / logging</text>
+
+  <rect x="976" y="184" width="248" height="320" rx="14" fill="#FFF7ED" stroke="#FB923C" stroke-width="2" filter="url(#shadow)"/>
+  <text x="1002" y="222" class="label">Proxmox VE</text>
+  <rect x="1002" y="242" width="196" height="44" rx="8" fill="#FFEDD5" stroke="#FDBA74"/>
+  <text x="1047" y="269" class="body">Cluster API</text>
+  <rect x="1002" y="302" width="196" height="44" rx="8" fill="#FFEDD5" stroke="#FDBA74"/>
+  <text x="1057" y="329" class="body">Nodes</text>
+  <rect x="1002" y="362" width="196" height="44" rx="8" fill="#FFEDD5" stroke="#FDBA74"/>
+  <text x="1045" y="389" class="body">VMs and LXCs</text>
+  <rect x="1002" y="422" width="196" height="44" rx="8" fill="#FFEDD5" stroke="#FDBA74"/>
+  <text x="1036" y="449" class="body">Storage / Backups</text>
+
+  <rect x="382" y="538" width="842" height="148" rx="16" fill="#F8FAFC" stroke="#94A3B8" stroke-width="2" filter="url(#shadow)"/>
+  <text x="410" y="578" class="label">Typical Flow</text>
+  <text x="410" y="608" class="body">1. A client sends an MCP tool call or HTTP request.</text>
+  <text x="410" y="632" class="body">2. ProxmoxMCP-Plus validates credentials, applies command policy, and logs the action.</text>
+  <text x="410" y="656" class="body">3. The tooling layer executes the requested Proxmox operation and returns a structured result.</text>
+
+  <line x1="306" y1="220" x2="382" y2="220" class="line"/>
+  <polygon points="382,220 368,212 368,228" class="arrow"/>
+
+  <line x1="306" y1="430" x2="382" y2="430" class="line"/>
+  <polygon points="382,430 368,422 368,438" class="arrow"/>
+
+  <line x1="628" y1="312" x2="654" y2="312" class="line"/>
+  <polygon points="654,312 640,304 640,320" class="arrow"/>
+
+  <line x1="628" y1="404" x2="654" y2="404" class="line"/>
+  <polygon points="654,404 640,396 640,412" class="arrow"/>
+
+  <line x1="902" y1="324" x2="976" y2="324" class="line"/>
+  <polygon points="976,324 962,316 962,332" class="arrow"/>
+
+  <line x1="902" y1="404" x2="976" y2="404" class="line"/>
+  <polygon points="976,404 962,396 962,412" class="arrow"/>
+
+  <text x="464" y="156" class="mono">stdio / HTTP</text>
+  <text x="942" y="168" class="mono">REST API</text>
+</svg>

--- a/docs/wiki/API & Tool Reference.md
+++ b/docs/wiki/API & Tool Reference.md
@@ -1,6 +1,6 @@
 # API & Tool Reference
 
-This page is the authoritative index for tooling and endpoint behavior.
+This page is the main index for tools and endpoint behavior.
 
 ## Domain Coverage
 
@@ -10,15 +10,15 @@ This page is the authoritative index for tooling and endpoint behavior.
 - Storage, ISO, template, and node/cluster visibility
 - Optional remote command execution workflows
 
-## Reference Structure
+## What to document for each tool
 
 Document each tool and endpoint with:
 
-- Intent and expected use case
-- Required parameters and constraints
-- Authentication and authorization considerations
-- Typical success response and failure patterns
-- Operational caveats
+- What the tool is for
+- Required parameters and limits
+- Auth or permission requirements
+- Typical success response and common failure patterns
+- Notes that matter during day-to-day use
 
 ## Related Pages
 

--- a/docs/wiki/Developer Guide.md
+++ b/docs/wiki/Developer Guide.md
@@ -1,6 +1,6 @@
 # Developer Guide
 
-This guide describes local development workflows, code quality gates, and release expectations.
+This guide covers local development, validation, and release expectations.
 
 ## Local Setup
 
@@ -22,7 +22,7 @@ black .
 ## Development Expectations
 
 - Keep behavior changes covered by tests
-- Prefer explicit, typed interfaces for tool contracts
+- Prefer clear, typed interfaces for tool contracts
 - Document security-impacting changes in Wiki pages
 - Maintain README as a concise index, not a full manual
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,6 +1,6 @@
 # ProxmoxMCP-Plus Wiki
 
-Welcome to the canonical documentation for ProxmoxMCP-Plus.
+This wiki collects the longer guides for ProxmoxMCP-Plus.
 
 This Wiki is organized for operators, developers, and integrators running Proxmox automation through MCP and OpenAPI interfaces.
 
@@ -8,14 +8,14 @@ This Wiki is organized for operators, developers, and integrators running Proxmo
 
 - New deployment: [Operator Guide](Operator-Guide)
 - Local development: [Developer Guide](Developer-Guide)
-- Security baseline: [Security Guide](Security-Guide)
+- Security setup and hardening: [Security Guide](Security-Guide)
 - Client and platform connectivity: [Integrations Guide](Integrations-Guide)
 - Endpoint and tool details: [API & Tool Reference](API-&-Tool-Reference)
-- Incident response and diagnostics: [Troubleshooting](Troubleshooting)
+- Diagnostics and common failure paths: [Troubleshooting](Troubleshooting)
 - Version and upgrade history: [Release & Upgrade Notes](Release-&-Upgrade-Notes)
 
-## Documentation Principles
+## How to use this wiki
 
 - README is concise and points here for depth.
-- Operational guidance is explicit and version-aware.
-- Security-relevant behavior is documented with constraints and expected controls.
+- Operator and integration details live here instead of in the root README.
+- Security-sensitive features are documented with their limits and expected setup.

--- a/docs/wiki/Integrations Guide.md
+++ b/docs/wiki/Integrations Guide.md
@@ -1,6 +1,6 @@
 # Integrations Guide
 
-This guide covers client and platform integration paths for ProxmoxMCP-Plus.
+This guide covers the main ways to connect clients and platforms to ProxmoxMCP-Plus.
 
 ## Supported Integration Patterns
 
@@ -21,7 +21,7 @@ This guide covers client and platform integration paths for ProxmoxMCP-Plus.
 - Swagger UI: `http://<host>:8811/docs`
 - Health check: `http://<host>:8811/health`
 
-## Integration Validation
+## Integration checks
 
 - Confirm MCP server starts with expected tool registration
 - Confirm OpenAPI endpoints return authenticated responses

--- a/docs/wiki/Operator Guide.md
+++ b/docs/wiki/Operator Guide.md
@@ -1,6 +1,6 @@
 # Operator Guide
 
-This guide is for infrastructure and platform operators running ProxmoxMCP-Plus in managed environments.
+This guide is for people running ProxmoxMCP-Plus as a shared service or integration endpoint.
 
 ## Runtime Topology
 
@@ -8,13 +8,13 @@ This guide is for infrastructure and platform operators running ProxmoxMCP-Plus 
 - OpenAPI mode for HTTP client integrations
 - Docker Compose for service-oriented deployments
 
-## Production Deployment Checklist
+## Deployment Checklist
 
 - Validate Proxmox API token scope and RBAC model
-- Configure `proxmox-config/config.json` with production-safe values
+- Configure `proxmox-config/config.json` with deployment-safe values
 - Keep `security.dev_mode=false` in production
 - Set and enforce OpenAPI API key controls
-- Put OpenAPI endpoint behind TLS termination and trusted ingress
+- Put the OpenAPI endpoint behind TLS termination and controlled ingress
 - Configure centralized log shipping and retention
 - Monitor `/health` for liveness and readiness
 

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -2,9 +2,9 @@
 
 This directory contains the GitHub Wiki seed pages for ProxmoxMCP-Plus.
 
-## Canonical Documentation Model
+## Documentation Model
 
-- Source of truth for deep documentation: GitHub Wiki
+- Longer-form project documentation lives in GitHub Wiki
 - README role: concise project entry and navigation
 
 ## Pages Included
@@ -31,7 +31,7 @@ This directory contains the GitHub Wiki seed pages for ProxmoxMCP-Plus.
 4. Commit and push:
    ```bash
    git add .
-   git commit -m "Initialize enterprise documentation structure"
+   git commit -m "Initialize wiki documentation structure"
    git push
    ```
 

--- a/docs/wiki/Security Guide.md
+++ b/docs/wiki/Security Guide.md
@@ -1,24 +1,24 @@
 # Security Guide
 
-This guide defines security boundaries and hardening expectations for ProxmoxMCP-Plus.
+This guide covers the main security boundaries and hardening steps for ProxmoxMCP-Plus.
 
 ## Security Objectives
 
 - Protect Proxmox credentials and API token material
 - Restrict destructive or high-risk execution paths
 - Enforce authenticated access for HTTP/OpenAPI traffic
-- Maintain auditable logs for sensitive operations
+- Keep logs for sensitive operations
 
-## Baseline Controls
+## Basic Controls
 
 - Use least-privilege Proxmox API tokens
 - Keep TLS verification enabled in production
 - Disable development-only relaxations outside local testing
-- Gate command execution features through explicit policy
+- Gate command execution features through command policy
 
 ## Hardening Checklist
 
-- Restrict ingress to trusted networks
+- Restrict ingress to networks you control
 - Terminate TLS and apply reverse-proxy controls
 - Rotate credentials on a defined schedule
 - Alert on repeated auth failures and policy denials

--- a/docs/wiki/Troubleshooting.md
+++ b/docs/wiki/Troubleshooting.md
@@ -1,8 +1,8 @@
 # Troubleshooting
 
-Use this page for incident diagnosis and recovery workflows.
+Use this page to diagnose and recover from common failures.
 
-## Common Incident Areas
+## Common Problem Areas
 
 - Proxmox connectivity or auth failures
 - Permission and RBAC denials
@@ -10,7 +10,7 @@ Use this page for incident diagnosis and recovery workflows.
 - Command policy denials
 - Storage compatibility or allocation failures
 
-## First-Line Diagnostics
+## First Checks
 
 - Verify configuration values and token validity
 - Check server logs and recent deployment changes


### PR DESCRIPTION
## Summary
- fix invalid conditional usage in the PyPI publish workflow
- use an env var derived from the secret so Actions can parse the workflow
- keep support for either API token publishing or trusted publishing

## Why
The previous workflow failed immediately with a workflow file issue and never started the PyPI publish job.