### PR TITLE
Expand and complete wiki documentation

### DIFF
--- a/docs/wiki/API & Tool Reference.md
+++ b/docs/wiki/API & Tool Reference.md
@@ -2,26 +2,133 @@
 
 This page is the main index for tools and endpoint behavior.
 
-## Domain Coverage
+## Service Endpoints
 
-- VM lifecycle and operations
-- LXC container lifecycle and operations
-- Snapshot and backup workflows
-- Storage, ISO, template, and node/cluster visibility
-- Optional remote command execution workflows
+When the OpenAPI wrapper is running, the main endpoints are:
 
-## What to document for each tool
+| Path | Purpose |
+| --- | --- |
+| `/` | basic service metadata |
+| `/docs` | Swagger UI |
+| `/openapi.json` | generated OpenAPI schema |
+| `/health` | wrapper health and MCP backend connection status |
 
-Document each tool and endpoint with:
+## Tool Groups
 
-- What the tool is for
-- Required parameters and limits
-- Auth or permission requirements
-- Typical success response and common failure patterns
-- Notes that matter during day-to-day use
+The MCP server currently registers tools from these groups:
+
+- nodes
+- VMs
+- containers
+- storage
+- cluster status
+- snapshots
+- ISOs and templates
+- backups
+- container config and IP inspection
+- optional command execution
+
+## Node Tools
+
+| Tool | Purpose | Notes |
+| --- | --- | --- |
+| `get_nodes` | list nodes in the cluster | returns node status and summary data |
+| `get_node_status` | inspect one node | accepts a required `node` parameter |
+
+## VM Tools
+
+| Tool | Purpose | Notes |
+| --- | --- | --- |
+| `get_vms` | list VMs across the cluster | skips nodes that cannot be queried |
+| `create_vm` | create a new VM | requires `node`, `vmid`, `name`, `cpus`, `memory`, `disk_size` |
+| `start_vm` | start a VM | mutating |
+| `stop_vm` | force stop a VM | mutating |
+| `shutdown_vm` | graceful shutdown | mutating |
+| `reset_vm` | restart/reset a VM | mutating |
+| `delete_vm` | delete a VM | supports `force=false` by default |
+| `execute_vm_command` | run a command via QEMU Guest Agent | subject to command policy |
+
+## Container Tools
+
+| Tool | Purpose | Notes |
+| --- | --- | --- |
+| `get_containers` | list containers | supports node filter and `pretty` or `json` output |
+| `start_container` | start one or more containers | selector syntax supports ID, node-prefixed ID, name, or comma list |
+| `stop_container` | stop one or more containers | supports graceful or forced stop |
+| `restart_container` | restart one or more containers | mutating |
+| `update_container_resources` | update cores, memory, swap, and disk | supports resizing `rootfs` |
+| `create_container` | create a new LXC container | supports template, resources, networking, onboot, nesting, unprivileged mode |
+| `delete_container` | delete one or more containers | supports `force` |
+| `execute_container_command` | run a command inside a running container | only registered when `ssh` config exists |
+| `update_container_ssh_keys` | append or replace root `authorized_keys` in a container | only registered when `ssh` config exists |
+| `get_container_config` | return full container config | no SSH required |
+| `get_container_ip` | inspect container interfaces and primary IP | no SSH required |
+
+### Container Selector Grammar
+
+Several container tools accept a `selector` parameter. Supported forms:
+
+- `123`
+- `pve1:123`
+- `pve1/name`
+- `name`
+- comma-separated lists for bulk operations
+
+## Snapshot Tools
+
+| Tool | Purpose | Notes |
+| --- | --- | --- |
+| `list_snapshots` | list snapshots for a VM or container | supports `vm_type=qemu|lxc` |
+| `create_snapshot` | create a snapshot | can include `vmstate` for VMs |
+| `delete_snapshot` | delete a snapshot | mutating |
+| `rollback_snapshot` | restore a snapshot | mutating and potentially disruptive |
+
+## ISO and Template Tools
+
+| Tool | Purpose | Notes |
+| --- | --- | --- |
+| `list_isos` | list ISO images | optional node and storage filters |
+| `list_templates` | list LXC templates | use result as `ostemplate` when creating containers |
+| `download_iso` | download an ISO into Proxmox storage | supports checksum and algorithm |
+| `delete_iso` | delete an ISO or template file | mutating |
+
+## Backup Tools
+
+| Tool | Purpose | Notes |
+| --- | --- | --- |
+| `list_backups` | list backup archives | optional node, storage, and VMID filters |
+| `create_backup` | create a VM or container backup | supports compression and backup mode |
+| `restore_backup` | restore from a backup archive | restore to a new `vmid` |
+| `delete_backup` | delete a backup archive | mutating |
+
+## Storage and Cluster Tools
+
+| Tool | Purpose | Notes |
+| --- | --- | --- |
+| `get_storage` | list storage pools and usage | read-only |
+| `get_cluster_status` | get overall cluster status | read-only |
+
+## Output and Prerequisite Notes
+
+- Some tools return pretty formatted text by default
+- Some container tools support explicit JSON output through `format_style`
+- `execute_vm_command` requires the VM to be running and QEMU Guest Agent to be available
+- `execute_container_command` requires SSH config and a running container
+- mutating tools should be tested only after read-only tools confirm the environment is reachable
+
+## What To Document For New Tools
+
+When you add a new tool, document:
+
+- what it does
+- required parameters
+- optional parameters
+- prerequisites
+- common failure cases
+- whether it is read-only or mutating
 
 ## Related Pages
 
-- Runtime deployment and operations: [Operator Guide](Operator-Guide)
-- Security constraints: [Security Guide](Security-Guide)
-- Integration usage: [Integrations Guide](Integrations-Guide)
+- [Operator Guide](Operator-Guide)
+- [Security Guide](Security-Guide)
+- [Troubleshooting](Troubleshooting)

--- a/docs/wiki/Developer Guide.md
+++ b/docs/wiki/Developer Guide.md
@@ -1,6 +1,6 @@
 # Developer Guide
 
-This guide covers local development, validation, and release expectations.
+This guide covers local development, testing, and release work for ProxmoxMCP-Plus.
 
 ## Local Setup
 
@@ -10,24 +10,93 @@ uv pip install -e ".[dev]"
 cp proxmox-config/config.example.json proxmox-config/config.json
 ```
 
-## Validation Commands
+Set `proxmox-config/config.json` to a real environment or use a test config path through `PROXMOX_MCP_CONFIG`.
+
+## Common Commands
 
 ```bash
 pytest
 ruff .
 mypy .
 black .
+python main.py
+python -m proxmox_mcp.openapi_proxy --host 0.0.0.0 --port 8811 -- python main.py
 ```
+
+## Project Layout
+
+| Path | Purpose |
+| --- | --- |
+| `main.py` | bootstrap entrypoint used by the packaged bundle |
+| `src/proxmox_mcp/server.py` | MCP server initialization and tool registration |
+| `src/proxmox_mcp/openapi_proxy.py` | FastAPI wrapper for HTTP/OpenAPI mode |
+| `src/proxmox_mcp/config/` | config models and loader |
+| `src/proxmox_mcp/security/` | command policy checks |
+| `src/proxmox_mcp/tools/` | Proxmox-facing tool implementations |
+| `tests/` | unit and integration-facing test coverage |
+| `docs/wiki/` | wiki seed pages |
 
 ## Development Expectations
 
 - Keep behavior changes covered by tests
 - Prefer clear, typed interfaces for tool contracts
-- Document security-impacting changes in Wiki pages
-- Maintain README as a concise index, not a full manual
+- Update docs when a tool, config field, or runtime behavior changes
+- Avoid documenting features that are not actually registered in `server.py`
+
+## What To Check When Changing Tools
+
+If you add or change a tool:
+
+- Update the implementation in `src/proxmox_mcp/tools/`
+- Register or adjust it in `src/proxmox_mcp/server.py`
+- Update descriptions in `src/proxmox_mcp/tools/definitions.py`
+- Add or update tests under `tests/`
+- Update [API & Tool Reference](API-&-Tool-Reference) if the surface changed
+
+## Configuration Development Notes
+
+The config loader supports:
+
+- JSON file loading through `PROXMOX_MCP_CONFIG`
+- Environment-only fallback when no config file is available
+- TLS safety checks that block `verify_ssl=false` unless `security.dev_mode=true`
+- MCP transport normalization, including `STREAMABLE_HTTP` to `STREAMABLE`
+
+If you change config semantics, keep the example files in `proxmox-config/` consistent.
+
+## Packaging and Release
+
+The package metadata lives in `pyproject.toml`.
+
+Notable details:
+
+- Package name: `proxmox-mcp-plus`
+- Console script: `proxmox-mcp = proxmox_mcp.server:main`
+- Build backend: `hatchling`
+- Supported Python versions in metadata: 3.11 and 3.12
+
+Local packaging check:
+
+```bash
+python -m pip install --upgrade build twine
+python -m build
+twine check dist/*
+```
+
+## Test Coverage Focus
+
+The current tests cover several important behaviors already:
+
+- tool registration with and without SSH config
+- config validation and TLS safety checks
+- OpenAPI root and health endpoints
+- VM and container tool behavior
+- backup, storage, ISO, and cluster-related flows
+
+When adding a new feature, extend tests in the same area rather than only relying on manual checks.
 
 ## Documentation Workflow
 
-- Update Wiki pages for operational or integration changes
-- Keep page titles stable to avoid link breakage
-- Record upgrade-impacting changes in [Release & Upgrade Notes](Release-&-Upgrade-Notes)
+- Update `README.md` for top-level positioning or setup changes
+- Update `docs/wiki/` for details, examples, and operational behavior
+- Keep wiki titles stable so the GitHub Wiki URLs do not change

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,21 +1,51 @@
 # ProxmoxMCP-Plus Wiki
 
-This wiki collects the longer guides for ProxmoxMCP-Plus.
+This wiki contains the longer documentation for ProxmoxMCP-Plus.
 
-This Wiki is organized for operators, developers, and integrators running Proxmox automation through MCP and OpenAPI interfaces.
+ProxmoxMCP-Plus is an MCP server and OpenAPI bridge for Proxmox VE. It lets MCP-capable assistants, WebUI tools, and HTTP clients work with VMs, LXC containers, snapshots, backups, storage, and cluster state through one service.
 
 ## Start Here
 
-- New deployment: [Operator Guide](Operator-Guide)
-- Local development: [Developer Guide](Developer-Guide)
-- Security setup and hardening: [Security Guide](Security-Guide)
-- Client and platform connectivity: [Integrations Guide](Integrations-Guide)
-- Endpoint and tool details: [API & Tool Reference](API-&-Tool-Reference)
-- Diagnostics and common failure paths: [Troubleshooting](Troubleshooting)
-- Version and upgrade history: [Release & Upgrade Notes](Release-&-Upgrade-Notes)
+- First-time deployment: [Operator Guide](Operator-Guide)
+- Local setup and contribution flow: [Developer Guide](Developer-Guide)
+- Security settings and command policy: [Security Guide](Security-Guide)
+- Client integration examples: [Integrations Guide](Integrations-Guide)
+- Tool-by-tool capability index: [API & Tool Reference](API-&-Tool-Reference)
+- Common failures and recovery steps: [Troubleshooting](Troubleshooting)
+- Version tracking and upgrade notes: [Release & Upgrade Notes](Release-&-Upgrade-Notes)
 
-## How to use this wiki
+## What This Project Does
 
-- README is concise and points here for depth.
-- Operator and integration details live here instead of in the root README.
-- Security-sensitive features are documented with their limits and expected setup.
+- Exposes Proxmox operations as MCP tools
+- Optionally exposes the same operations over HTTP through an OpenAPI proxy
+- Supports VM lifecycle actions such as create, start, stop, shutdown, reset, and delete
+- Supports LXC listing, creation, resource updates, start/stop/restart, config reads, IP discovery, and deletion
+- Supports snapshots, backup creation, backup restore, ISO browsing, template browsing, node status, storage status, and cluster status
+- Adds policy checks around command execution tools
+
+## Architecture Summary
+
+- `main.py` starts the MCP server bundle
+- `src/proxmox_mcp/server.py` registers MCP tools
+- `src/proxmox_mcp/openapi_proxy.py` wraps the MCP server behind FastAPI and adds `/`, `/docs`, `/openapi.json`, and `/health`
+- `src/proxmox_mcp/config/` contains validation for JSON and environment-based configuration
+- `src/proxmox_mcp/security/command_policy.py` evaluates command execution requests against allow and deny rules
+- `docs/container-command-execution.md` explains the SSH-based LXC command flow
+
+## Documentation Layout
+
+- Use the root `README.md` for a quick product overview and minimal startup steps
+- Use this wiki for setup details, operating guidance, and tool behavior
+- Keep page titles stable so README and external links do not break
+
+## Quick Navigation
+
+| Topic | Use it for |
+| --- | --- |
+| [Operator Guide](Operator-Guide) | Config, runtime modes, Docker/OpenAPI deployment, health checks |
+| [Developer Guide](Developer-Guide) | Local install, test commands, code layout, release workflow |
+| [Security Guide](Security-Guide) | TLS, token handling, `dev_mode`, command policy, SSH-based container execution |
+| [Integrations Guide](Integrations-Guide) | Claude Desktop, OpenCode, OpenAPI clients |
+| [API & Tool Reference](API-&-Tool-Reference) | Exact tool groups, parameters, prerequisites, and output expectations |
+| [Troubleshooting](Troubleshooting) | Startup failures, auth issues, tool registration problems, health check issues |
+| [Release & Upgrade Notes](Release-&-Upgrade-Notes) | Release entries, upgrade checklist, rollback notes |

--- a/docs/wiki/Integrations Guide.md
+++ b/docs/wiki/Integrations Guide.md
@@ -2,33 +2,98 @@
 
 This guide covers the main ways to connect clients and platforms to ProxmoxMCP-Plus.
 
-## Supported Integration Patterns
+## Integration Patterns
 
-- MCP client integration through stdio transport
-- OpenAPI integration for HTTP-native consumers
-- Tool orchestration via assistant platforms
+- `Direct MCP`: a client launches the server locally and talks over stdio
+- `HTTP/OpenAPI`: a client talks to the FastAPI proxy over HTTP
 
-## Assistant and Client Targets
+Use direct MCP when the client already supports MCP. Use OpenAPI when the client only understands HTTP or Swagger-style APIs.
 
-- Claude Desktop
-- Cline
-- Open WebUI
-- Other MCP-compatible runtimes
+## Claude Desktop
 
-## OpenAPI Integration
+An example Claude Desktop config is included at `proxmox-config/claude_desktop_config.example.json`.
 
-- Service root: `http://<host>:8811/`
-- Swagger UI: `http://<host>:8811/docs`
-- Health check: `http://<host>:8811/health`
+Key fields:
 
-## Integration checks
+- `command`: points to your Python interpreter
+- `args`: launches `-m proxmox_mcp.server`
+- `PYTHONPATH`: points to the local `src` directory
+- `PROXMOX_MCP_CONFIG`: points to your config file
 
-- Confirm MCP server starts with expected tool registration
-- Confirm OpenAPI endpoints return authenticated responses
-- Verify policy behavior for command-related tool calls
+Typical workflow:
+
+1. Create and populate `proxmox-config/config.json`
+2. Update the example paths to your local machine
+3. Add the server entry to Claude Desktop's MCP config
+4. Restart Claude Desktop and confirm the tools appear
+
+## OpenCode
+
+Examples for OpenCode live under `proxmox-config/opencode/`.
+
+Files included:
+
+- `opencode.jsonc.example`
+- `proxmox-mcp.env.example`
+
+The example command sources environment variables and then launches the package. This is useful when you want to avoid hard-coding credentials into the JSON client config.
+
+## Generic MCP Clients
+
+Any client that supports launching a stdio MCP server can use this project.
+
+Typical requirements:
+
+- Python environment with project dependencies installed
+- `PYTHONPATH` pointing to `src` when running from source
+- `PROXMOX_MCP_CONFIG` or equivalent environment variables
+
+## OpenAPI Clients
+
+For HTTP-native clients, run the OpenAPI wrapper and connect to:
+
+- root: `http://<host>:8811/`
+- docs: `http://<host>:8811/docs`
+- schema: `http://<host>:8811/openapi.json`
+- health: `http://<host>:8811/health`
+
+This path works well for:
+
+- internal portals
+- small automation scripts
+- tools that only speak REST/OpenAPI
+- Open WebUI-style integrations
+
+## OpenAPI Auth and CORS
+
+The proxy supports:
+
+- optional API key middleware
+- strict auth mode
+- configurable CORS allow origins
+- configurable path prefix and root path
+
+If you expose the API outside a dev machine, configure an API key and restrict origin/network access.
+
+## Integration Checks
+
+After connecting a client, verify:
+
+- the server starts without config validation errors
+- read-only tools such as `get_nodes` and `get_vms` are listed
+- OpenAPI mode returns `/docs` and `/health`
+- container SSH tools appear only when the `ssh` config exists
+
+## Common Integration Mistakes
+
+- `PYTHONPATH` not set when running from source
+- `PROXMOX_MCP_CONFIG` points to the wrong file
+- OpenAPI proxy runs, but `/health` stays degraded because the MCP subprocess did not start
+- TLS verification disabled in config while `dev_mode` is false
+- assuming `execute_container_command` should exist without an `ssh` section
 
 ## Related Pages
 
-- Runtime operations: [Operator Guide](Operator-Guide)
-- Security controls: [Security Guide](Security-Guide)
-- Endpoint catalog: [API & Tool Reference](API-&-Tool-Reference)
+- [Operator Guide](Operator-Guide)
+- [Security Guide](Security-Guide)
+- [Troubleshooting](Troubleshooting)

--- a/docs/wiki/Operator Guide.md
+++ b/docs/wiki/Operator Guide.md
@@ -1,33 +1,152 @@
 # Operator Guide
 
-This guide is for people running ProxmoxMCP-Plus as a shared service or integration endpoint.
+This guide covers how to configure, run, and operate ProxmoxMCP-Plus.
 
-## Runtime Topology
+## Runtime Modes
 
-- MCP stdio mode for local assistant integration
-- OpenAPI mode for HTTP client integrations
-- Docker Compose for service-oriented deployments
+ProxmoxMCP-Plus can be used in two main ways:
 
-## Deployment Checklist
+- `MCP stdio mode`: assistants launch the server directly and call tools over MCP
+- `OpenAPI mode`: FastAPI wraps the MCP server and exposes HTTP endpoints for other clients
 
-- Validate Proxmox API token scope and RBAC model
-- Configure `proxmox-config/config.json` with deployment-safe values
-- Keep `security.dev_mode=false` in production
-- Set and enforce OpenAPI API key controls
-- Put the OpenAPI endpoint behind TLS termination and controlled ingress
-- Configure centralized log shipping and retention
-- Monitor `/health` for liveness and readiness
+The core tool set is the same in both modes. The difference is only the transport.
 
-## Operational Procedures
+## Prerequisites
 
-- Startup and shutdown runbook
-- Configuration change management
-- Backup and restore process validation
-- Storage and node capacity checks
-- Token rotation and credential hygiene
+- Python 3.11 or newer
+- Access to a Proxmox VE API endpoint
+- A Proxmox API token with the permissions your workflows need
+- Network access from the machine running ProxmoxMCP-Plus to the Proxmox API
 
-## Linked Deep Dives
+Optional:
 
-- Container command execution setup: [container-command-execution.md](../container-command-execution.md)
-- Security model: [Security Guide](Security-Guide)
-- Incident diagnostics: [Troubleshooting](Troubleshooting)
+- SSH access from the MCP host to Proxmox nodes if you want LXC command execution tools
+
+## Configuration File
+
+The main config file is `proxmox-config/config.json`.
+
+Start from the example:
+
+```bash
+cp proxmox-config/config.example.json proxmox-config/config.json
+```
+
+The main sections are:
+
+- `proxmox`: host, port, TLS verification, service type
+- `auth`: Proxmox API user and token
+- `logging`: log level, format, optional log file
+- `mcp`: MCP host, port, and transport
+- `security`: currently includes `dev_mode`
+- `command_policy`: rules for `execute_*` tools
+- `ssh`: optional SSH settings for LXC command execution
+
+## Environment Variable Fallback
+
+If `PROXMOX_MCP_CONFIG` is not set or the file is missing, the loader falls back to environment variables.
+
+Common variables:
+
+- `PROXMOX_HOST`
+- `PROXMOX_PORT`
+- `PROXMOX_USER`
+- `PROXMOX_TOKEN_NAME`
+- `PROXMOX_TOKEN_VALUE`
+- `PROXMOX_VERIFY_SSL`
+- `PROXMOX_SERVICE`
+- `LOG_LEVEL`
+- `MCP_HOST`
+- `MCP_PORT`
+- `MCP_TRANSPORT`
+- `PROXMOX_DEV_MODE`
+- `COMMAND_POLICY_MODE`
+
+## Minimal Local Start
+
+```bash
+uv venv
+uv pip install -e ".[dev]"
+$env:PROXMOX_MCP_CONFIG="D:\\PycharmProject\\ProxmoxMCP-Plus\\proxmox-config\\config.json"
+python main.py
+```
+
+If startup succeeds, the server stays attached to stdio and waits for MCP clients.
+
+## OpenAPI Mode
+
+You can run the OpenAPI wrapper directly:
+
+```bash
+python -m proxmox_mcp.openapi_proxy --host 0.0.0.0 --port 8811 -- python main.py
+```
+
+Available routes:
+
+- `/` returns basic service metadata
+- `/docs` serves Swagger UI
+- `/openapi.json` serves the generated schema
+- `/health` returns `503` until the proxy is connected to the MCP backend, then `200`
+
+## Docker Compose Deployment
+
+The repository includes `docker-compose.yml` and `Dockerfile`.
+
+Default Compose behavior:
+
+- Builds the local image
+- Mounts `./proxmox-config` read-only into `/app/proxmox-config`
+- Exposes `8811`
+- Sets `PROXMOX_MCP_CONFIG=/app/proxmox-config/config.json`
+- Adds a container health check against `http://localhost:8811/health`
+
+Start it with:
+
+```bash
+docker compose up -d --build
+```
+
+## Operating Checklist
+
+Before exposing the service to users:
+
+- Confirm the Proxmox API token has only the permissions you intend to expose
+- Keep `proxmox.verify_ssl=true` unless you are explicitly in development mode
+- Keep `security.dev_mode=false` outside local testing
+- Set an API key when exposing the OpenAPI endpoint outside a private dev machine
+- Restrict ingress to networks you control
+- Monitor the `/health` endpoint if you run the OpenAPI proxy
+- Store logs somewhere persistent if you need auditability
+
+## Command Execution Features
+
+There are two command execution paths:
+
+- `execute_vm_command`: uses QEMU Guest Agent inside VMs
+- `execute_container_command`: uses SSH to the Proxmox node and then `pct exec` inside containers
+
+Container command execution is optional and only appears when an `ssh` section exists in the config.
+
+For setup details, see [Container Command Execution Guide](https://github.com/RekklesNA/ProxmoxMCP-Plus/blob/main/docs/container-command-execution.md).
+
+## First Verification Flow
+
+After deployment, test in this order:
+
+1. Start the service and confirm there are no config validation errors
+2. Call read-only tools first: `get_nodes`, `get_vms`, `get_storage`, `get_cluster_status`
+3. In OpenAPI mode, confirm `/health` and `/docs` both respond
+4. If you enabled SSH-backed container commands, confirm `execute_container_command` appears in the tool list
+5. Only then test mutating tools such as create, start, delete, snapshot, or backup
+
+## Logs and Health
+
+- Application logging is configured under the `logging` section
+- `main.py` prints early startup messages to stderr to make bootstrap failures visible
+- The OpenAPI wrapper reports `degraded` until it is connected to the MCP subprocess
+
+## Related Pages
+
+- [Security Guide](Security-Guide)
+- [Integrations Guide](Integrations-Guide)
+- [Troubleshooting](Troubleshooting)

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -1,11 +1,12 @@
 # Wiki Seed Pages
 
-This directory contains the GitHub Wiki seed pages for ProxmoxMCP-Plus.
+This directory contains the markdown pages intended to be published to the GitHub Wiki for ProxmoxMCP-Plus.
 
 ## Documentation Model
 
-- Longer-form project documentation lives in GitHub Wiki
-- README role: concise project entry and navigation
+- `README.md` in the repo root is the short project entrypoint
+- `docs/wiki/` contains the longer operational and reference pages
+- page names here should stay aligned with the published Wiki page names
 
 ## Pages Included
 
@@ -19,23 +20,26 @@ This directory contains the GitHub Wiki seed pages for ProxmoxMCP-Plus.
 - `Release & Upgrade Notes.md`
 - `_Sidebar.md`
 
-## Enable and Publish Wiki
+## Publishing To GitHub Wiki
 
-1. Enable repository Wiki in GitHub:
-   - Repository `Settings` -> `Features` -> enable `Wikis`
-2. Clone the Wiki repository:
-   ```bash
-   git clone https://github.com/RekklesNA/ProxmoxMCP-Plus.wiki.git
-   ```
-3. Copy seed pages into the cloned wiki repo root.
+1. Enable the repository Wiki in GitHub settings.
+2. Clone the wiki repository:
+
+```bash
+git clone https://github.com/RekklesNA/ProxmoxMCP-Plus.wiki.git
+```
+
+3. Copy the files from `docs/wiki/` into the root of the cloned wiki repository.
 4. Commit and push:
-   ```bash
-   git add .
-   git commit -m "Initialize wiki documentation structure"
-   git push
-   ```
 
-## Naming Note
+```bash
+git add .
+git commit -m "Update wiki content"
+git push
+```
 
-GitHub Wiki URL slugs are generated from page titles.  
-Keep these titles stable to preserve external links from `README.md`.
+## Maintenance Notes
+
+- Keep titles stable so wiki URLs stay stable
+- Update the root README links if a wiki page is renamed
+- Avoid adding placeholders for features that do not exist in the codebase

--- a/docs/wiki/Release & Upgrade Notes.md
+++ b/docs/wiki/Release & Upgrade Notes.md
@@ -1,21 +1,47 @@
 # Release & Upgrade Notes
 
-Track version-level behavior changes and upgrade guidance here.
+Use this page to track version-level behavior changes, upgrade steps, and rollback notes.
 
 ## Release Entry Template
 
-### Version
+### Version `<version>`
 
 - Release date:
-- Change summary:
-- Breaking changes:
-- Security-impacting changes:
-- Migration steps:
-- Rollback guidance:
+- Summary:
+- New tools or endpoints:
+- Changed behavior:
+- Removed or deprecated behavior:
+- Config changes:
+- Docs updated:
+- Upgrade steps:
+- Rollback notes:
 
-## Upgrade Validation Checklist
+## Suggested Upgrade Checklist
 
-- Validate config compatibility with the target version
-- Run smoke tests for core tool groups
-- Confirm auth and policy behavior post-upgrade
-- Confirm OpenAPI health and endpoint accessibility
+Before upgrading:
+
+- review changes to config examples
+- review command policy defaults
+- review OpenAPI wrapper behavior if your deployment depends on `/health` or auth
+- check whether any new tool requires extra credentials or runtime dependencies
+
+After upgrading:
+
+- start the service and confirm config validation still passes
+- call `get_nodes` and `get_cluster_status`
+- verify expected tools are still registered
+- verify `/health` and `/docs` if you run the OpenAPI proxy
+- test at least one mutating workflow in a safe environment
+
+## Suggested Release Checklist
+
+- run `pytest`
+- run `ruff .`
+- run `mypy .`
+- build the package
+- confirm `README.md` and `docs/wiki/` reflect the released behavior
+- note any user-visible changes here
+
+## Existing Notes
+
+No release history has been backfilled yet. Add entries here starting with the next tagged release or when reconstructing past changes from git history.

--- a/docs/wiki/Security Guide.md
+++ b/docs/wiki/Security Guide.md
@@ -2,30 +2,100 @@
 
 This guide covers the main security boundaries and hardening steps for ProxmoxMCP-Plus.
 
-## Security Objectives
+## Security Model Overview
 
-- Protect Proxmox credentials and API token material
-- Restrict destructive or high-risk execution paths
-- Enforce authenticated access for HTTP/OpenAPI traffic
-- Keep logs for sensitive operations
+ProxmoxMCP-Plus sits between clients and the Proxmox API. The main controls are:
+
+- Proxmox API token authentication
+- TLS verification for Proxmox API connections
+- optional API key protection for OpenAPI exposure
+- command policy checks for `execute_*` tools
+- optional SSH configuration for container command execution
 
 ## Basic Controls
 
 - Use least-privilege Proxmox API tokens
-- Keep TLS verification enabled in production
-- Disable development-only relaxations outside local testing
-- Gate command execution features through command policy
+- Keep `proxmox.verify_ssl=true`
+- Only use `security.dev_mode=true` for local development
+- Restrict who can reach the OpenAPI endpoint
+- Keep logs for sensitive operations
+
+## TLS Safety
+
+The config loader rejects insecure TLS in normal operation.
+
+If `proxmox.verify_ssl=false` and `security.dev_mode=false`, startup fails with a validation error.
+
+This is an intentional guardrail to avoid quietly running against a Proxmox API endpoint without certificate verification.
+
+## Command Policy
+
+Command execution tools are protected by `command_policy`.
+
+Supported modes:
+
+- `deny_all`: block commands unless they match `allow_patterns`
+- `allowlist`: also requires matching `allow_patterns`
+- `audit_only`: allow commands but still evaluate the rules
+
+Other controls:
+
+- `deny_patterns`: blocks known-dangerous patterns
+- `require_approval_token`: requires a caller-supplied token
+- `approval_token`: token value checked by the server
+
+Default deny patterns in the config model already block common destructive shell patterns such as `rm -rf`.
+
+## VM Command Execution
+
+`execute_vm_command` depends on QEMU Guest Agent inside the guest VM.
+
+Implications:
+
+- the VM must be running
+- the guest agent must be installed and reachable
+- command results come back through the agent channel, not SSH
+
+## Container Command Execution
+
+`execute_container_command` and `update_container_ssh_keys` are optional.
+
+These tools only register when the config includes an `ssh` section. Without it:
+
+- no SSH connection is attempted
+- the tools do not appear at all
+
+The implementation SSHes to the Proxmox node and runs `pct exec`. Because this path is more powerful than pure API reads, treat it as a separate security decision.
+
+Read the full setup and threat model in [Container Command Execution Guide](https://github.com/RekklesNA/ProxmoxMCP-Plus/blob/main/docs/container-command-execution.md).
+
+## OpenAPI Exposure
+
+If you run the OpenAPI proxy:
+
+- configure an API key when the service is not strictly local
+- place it behind TLS termination
+- restrict ingress to networks you control
+- monitor `/health`
+- avoid exposing it directly to the public internet without additional controls
+
+## Credential Handling
+
+- Keep Proxmox API tokens out of committed source files
+- Use a dedicated config file or environment variables per environment
+- If using SSH for container execution, use a dedicated keypair for this service
+- Rotate API tokens and SSH keys on a schedule that fits your environment
 
 ## Hardening Checklist
 
 - Restrict ingress to networks you control
-- Terminate TLS and apply reverse-proxy controls
-- Rotate credentials on a defined schedule
-- Alert on repeated auth failures and policy denials
-- Review command execution policy after every release
+- Keep OpenAPI behind a reverse proxy you manage
+- Use per-environment credentials
+- Keep `dev_mode` off outside local testing
+- Review command policy after enabling or expanding command tools
+- Verify host key checking if you enable SSH-backed container commands
 
 ## Related Pages
 
-- Deployment controls: [Operator Guide](Operator-Guide)
-- Endpoint behavior: [API & Tool Reference](API-&-Tool-Reference)
-- Incident handling: [Troubleshooting](Troubleshooting)
+- [Operator Guide](Operator-Guide)
+- [Troubleshooting](Troubleshooting)

--- a/docs/wiki/Troubleshooting.md
+++ b/docs/wiki/Troubleshooting.md
@@ -2,30 +2,113 @@
 
 Use this page to diagnose and recover from common failures.
 
-## Common Problem Areas
+## Startup Fails Before The Server Registers Tools
 
-- Proxmox connectivity or auth failures
-- Permission and RBAC denials
-- OpenAPI service unavailability
-- Command policy denials
-- Storage compatibility or allocation failures
+Check:
 
-## First Checks
+- `PROXMOX_MCP_CONFIG` points to a real JSON file
+- required config values are present
+- Python dependencies are installed
+- the JSON file is valid
 
-- Verify configuration values and token validity
-- Check server logs and recent deployment changes
-- Confirm OpenAPI health endpoint behavior
-- Validate network path and reverse-proxy routing
+Common causes:
 
-## Escalation Data to Capture
+- missing `proxmox.host`
+- missing auth fields
+- invalid JSON syntax
+- `verify_ssl=false` while `security.dev_mode=false`
 
-- Timestamp and environment
-- Request path and payload shape
-- Error response and log excerpts
-- Recent configuration or version changes
+## `/health` Returns `degraded`
 
-## Related Pages
+This usually means the OpenAPI wrapper started but did not connect to the MCP subprocess yet.
 
-- Security behavior and policy: [Security Guide](Security-Guide)
-- Deployment operations: [Operator Guide](Operator-Guide)
-- Version compatibility: [Release & Upgrade Notes](Release-&-Upgrade-Notes)
+Check:
+
+- the command passed after `--` actually launches the MCP server
+- the subprocess has access to `PYTHONPATH` and the config file
+- stderr output from `main.py` for startup errors
+
+## OpenAPI `/docs` Works But Tool Calls Fail
+
+Check:
+
+- the wrapped MCP server is starting successfully
+- Proxmox auth values are correct
+- the OpenAPI layer is pointing at the intended config file
+- the underlying tool is actually registered in `server.py`
+
+## `execute_container_command` Is Missing
+
+This is expected when the config has no `ssh` section.
+
+If you expected the tool to exist:
+
+- add the `ssh` section to the config
+- restart the server
+- verify the SSH user, key, host mapping, and `use_sudo` settings
+
+## VM Command Execution Fails
+
+`execute_vm_command` depends on QEMU Guest Agent.
+
+Check:
+
+- the VM is running
+- the guest agent is installed
+- the guest agent service is running in the VM
+- the command policy is not blocking the requested command
+
+## Container Command Execution Fails
+
+Check:
+
+- the target container is running
+- SSH works from the MCP host to the correct Proxmox node
+- the SSH key is valid
+- the sudo rule for `pct exec` exists if `use_sudo=true`
+- command policy is not blocking the command
+
+Also see [Container Command Execution Guide](https://github.com/RekklesNA/ProxmoxMCP-Plus/blob/main/docs/container-command-execution.md).
+
+## Tool Is Registered But Returns Empty Results
+
+Possible causes:
+
+- Proxmox API token lacks permissions for the target resource
+- node or storage filters are too narrow
+- the cluster contains offline nodes and only healthy nodes are being returned
+- there are genuinely no matching VMs, containers, ISO files, or backups
+
+## TLS Errors Against Proxmox API
+
+Check:
+
+- certificate trust on the machine running the service
+- the hostname in config matches the certificate
+- `verify_ssl` is not disabled unless you are explicitly in development mode
+
+## Config Works In One Client But Not Another
+
+Check:
+
+- environment variables are available in that client's runtime
+- the client starts the same Python interpreter and project path
+- `PYTHONPATH` is set when running from source
+
+## Useful First Checks
+
+Start with:
+
+1. validate the config path
+2. run a read-only tool such as `get_nodes`
+3. confirm `/health` in OpenAPI mode
+4. inspect logs or stderr
+5. verify whether the missing behavior is transport-specific or affects both MCP and OpenAPI
+
+## What To Capture When Reporting A Problem
+
+- exact command or tool name
+- config mode used: MCP stdio or OpenAPI
+- relevant log lines or stderr output
+- whether the issue affects one node, one VM/container, or the whole cluster
+- whether the same call works directly in Proxmox


### PR DESCRIPTION
## Summary
- expand the wiki seed pages from placeholders into publishable project documentation
- document runtime modes, configuration, integrations, security controls, tool groups, and troubleshooting flows
- align wiki content with the current codebase, config model, and OpenAPI behavior

## Scope
- update Home, Operator Guide, Developer Guide, Integrations Guide, Security Guide, API & Tool Reference, Troubleshooting, Release & Upgrade Notes, and wiki README
- replace vague placeholder text with concrete guidance based on the repository
- update links to the container command execution guide so they resolve correctly when published to GitHub Wiki

## Testing
- not run; documentation-only changes