### PR TITLE
docs: rewrite README and wiki entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="assets/logo-proxmoxmcp-plus.png" alt="ProxmoxMCP-Plus Logo" width="160"/>
 </div>
 
-<p align="center"><strong>Use MCP and OpenAPI to safely control Proxmox VE VMs, LXCs, backups, snapshots, and ISO workflows from LLMs, AI agents, Claude Desktop, and Open WebUI.</strong></p>
+<p align="center"><strong>Control Proxmox VE from LLMs, AI agents, MCP clients, and OpenAPI tooling with one safer interface for VMs, LXCs, backups, snapshots, ISOs, and container commands.</strong></p>
 
 <p align="center">
   <a href="https://pypi.org/project/proxmox-mcp-plus/"><img alt="PyPI" src="https://img.shields.io/pypi/v/proxmox-mcp-plus"></a>
@@ -15,62 +15,130 @@
 </p>
 
 <p align="center">
-  <a href="#30-second-demo">30-second Demo</a> |
-  <a href="#proven-on-a-live-lab">Live Lab Proof</a> |
-  <a href="#install">Install</a> |
-  <a href="#scenario-templates">Scenario Templates</a> |
+  <a href="#quick-start">Quick Start</a> |
+  <a href="#demo">Demo</a> |
+  <a href="#validated-against-real-proxmox-infrastructure">Validation</a> |
+  <a href="#scenario-templates">Scenarios</a> |
+  <a href="#documentation">Docs</a> |
   <a href="https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki">Wiki</a>
 </p>
 
-![LLM and AI agent to Proxmox flow](assets/proxmoxmcp-demo.gif)
+![ProxmoxMCP-Plus architecture and control flow](assets/proxmoxmcp-drawio-hero.svg)
 
-## Why This Project Exists
+## What This Project Is
 
-Most Proxmox automation stops at raw API calls, one-off scripts, or UI-only workflows.
+ProxmoxMCP-Plus is a Proxmox VE control plane that exposes the same operational surface in two forms:
 
-ProxmoxMCP-Plus gives you:
+- `MCP` for Claude Desktop, Open WebUI, and other LLM or AI agent clients
+- `OpenAPI` for HTTP automation, dashboards, internal tools, and no-code workflows
 
-- `MCP` tools for Claude Desktop, Open WebUI, and other LLM or AI agent workflows
-- `OpenAPI` endpoints for HTTP clients, internal tools, and no-code integrations
-- `Guardrails` such as token auth, command policy, and safer execution paths
-- `Real operator workflows` for VM, LXC, backup, restore, snapshot, ISO, and SSH-backed container execution
+Instead of wiring raw Proxmox API calls, shell scripts, and separate glue services, you get one project that can handle:
 
-If you want an LLM or AI assistant to do more than just explain Proxmox, this is the missing control plane.
+- VM and LXC lifecycle actions
+- snapshot create, rollback, and delete
+- backup and restore workflows
+- ISO download and cleanup
+- node, storage, and cluster inspection
+- SSH-backed container command execution with guardrails
 
-## 30-second Demo
+## Why Teams Reach For This
 
-What a user says in Claude Desktop or Open WebUI:
+This project exists for the gap between "the Proxmox API is powerful" and "an LLM or AI agent can safely operate real infrastructure."
 
-```text
-Create a small Debian test VM on node pve, snapshot it before changes,
-and expose the same control surface over OpenAPI so I can verify /health.
-```
+- `Dual-surface design`: MCP for conversational workflows, OpenAPI for standard automation
+- `Operator-oriented`: focuses on real tasks, not just raw low-level endpoints
+- `Safer by default`: auth, command policy, and explicit execution paths
+- `Evidence over claims`: important workflows were exercised against a real Proxmox lab
 
-What ProxmoxMCP-Plus enables:
+## Quick Start
 
-1. The LLM calls MCP tools to create and start the VM.
-2. The same server exposes matching OpenAPI endpoints for automation or dashboards.
-3. `/health` confirms the HTTP bridge is alive.
-4. The operator can later snapshot, roll back, back up, or delete the workload from the same interface.
+### 1. Prepare Proxmox access
 
-HTTP verification:
+Read the official Proxmox docs first if you are setting up a fresh lab:
+
+- [Proxmox VE installation guide](https://pve.proxmox.com/pve-docs/pve-installation-plain.html)
+- [Proxmox VE API guide](https://pve.proxmox.com/wiki/Proxmox_VE_API)
+- [Proxmox VE administration guide](https://pve.proxmox.com/pve-docs/pve-admin-guide.html)
+- [Linux Container guide](https://pve.proxmox.com/wiki/Linux_Container)
+
+At minimum, `proxmox-config/config.json` needs:
+
+- `proxmox.host`
+- `proxmox.port`
+- `auth.user`
+- `auth.token_name`
+- `auth.token_value`
+
+Add an `ssh` section as well if you want container command execution.
+
+### 2. Choose one runtime path
+
+#### PyPI
 
 ```bash
+pip install proxmox-mcp-plus
+python main.py
+```
+
+#### Docker / GHCR
+
+```bash
+docker run --rm -p 8811:8811 \
+  -v "$(pwd)/proxmox-config/config.json:/app/proxmox-config/config.json:ro" \
+  ghcr.io/rekklesna/proxmoxmcp-plus:latest
+```
+
+#### Source
+
+```bash
+git clone https://github.com/RekklesNA/ProxmoxMCP-Plus.git
+cd ProxmoxMCP-Plus
+uv venv
+uv pip install -e ".[dev]"
+python main.py
+```
+
+### 3. Run the HTTP/OpenAPI surface
+
+```bash
+docker compose up -d
 curl -f http://localhost:8811/health
 curl http://localhost:8811/openapi.json
 ```
 
-This is the core pitch in one sentence:
+### 4. Point an MCP client at the server
 
-> one Proxmox control plane for both LLM-native workflows and standard HTTP/OpenAPI automation.
+Minimal MCP client shape:
 
-## Proven on a Live Lab
+```json
+{
+  "mcpServers": {
+    "proxmox-mcp-plus": {
+      "command": "python",
+      "args": ["/path/to/ProxmoxMCP-Plus/main.py"],
+      "env": {
+        "PROXMOX_MCP_CONFIG": "/path/to/ProxmoxMCP-Plus/proxmox-config/config.json"
+      }
+    }
+  }
+}
+```
 
-This project is not presented as "should work in theory". The core operator flows were run against a real Proxmox environment and checked end to end.
+Client-specific examples for Claude Desktop and Open WebUI are in the [Integrations Guide](docs/wiki/Integrations%20Guide.md).
 
-Most useful paths verified so far:
+## Demo
 
-| Workflow | Live status |
+This GIF shows the product pitch in the fastest possible format: an LLM-facing workflow, Proxmox operations behind it, and the HTTP health surface available for verification.
+
+![Recorded demo gif](assets/proxmoxmcp-demo.gif)
+
+## Validated Against Real Proxmox Infrastructure
+
+The strongest claim here is not "has features." It is "the important workflows were exercised against a real Proxmox environment."
+
+Latest verified paths:
+
+| Workflow | Status |
 | --- | --- |
 | VM create / start / stop / delete | Verified |
 | VM snapshot create / rollback / delete | Verified |
@@ -82,153 +150,64 @@ Most useful paths verified so far:
 | Local OpenAPI `/health` and schema | Verified |
 | Docker image build and `/health` | Verified |
 
-If you want to inspect or rerun the same checks, start here:
+Validation entry points in this repository:
 
 - `pytest -q`
 - `tests/integration/test_real_contract.py`
 - `test_scripts/run_real_e2e.py`
 
-## Install
+## Why This Instead Of Raw API Calls Or Scripts
 
-Three supported ways to get started:
-
-### 1. PyPI
-
-```bash
-pip install proxmox-mcp-plus
-```
-
-### 2. Docker / GHCR
-
-```bash
-docker run --rm -p 8811:8811 \
-  -v "$(pwd)/proxmox-config/config.json:/app/proxmox-config/config.json:ro" \
-  ghcr.io/rekklesna/proxmoxmcp-plus:latest
-```
-
-### 3. Source
-
-```bash
-git clone https://github.com/RekklesNA/ProxmoxMCP-Plus.git
-cd ProxmoxMCP-Plus
-uv venv
-uv pip install -e ".[dev]"
-```
-
-Run the MCP server:
-
-```bash
-python main.py
-```
-
-Run the OpenAPI bridge:
-
-```bash
-docker compose up -d
-```
-
-## Quick Proxmox Setup
-
-Do these before blaming the project:
-
-- Install Proxmox VE from the official guide: [Installation Guide](https://pve.proxmox.com/pve-docs/pve-installation-plain.html)
-- Create a Proxmox API token and put it in `proxmox-config/config.json`: [Proxmox VE API](https://pve.proxmox.com/wiki/Proxmox_VE_API)
-- Make sure your node has a bridge such as `vmbr0`: [Administration Guide](https://pve.proxmox.com/pve-docs/pve-admin-guide.html)
-- For LXC workflows, ensure at least one template is available or let the live E2E script download one: [Linux Container Guide](https://pve.proxmox.com/wiki/Linux_Container)
-- For container command execution, add the `ssh` section to `proxmox-config/config.json`
-- If template or ISO downloads fail, check DNS on the Proxmox host first
-
-Minimal config fields:
-
-- `proxmox.host`
-- `proxmox.port`
-- `auth.user`
-- `auth.token_name`
-- `auth.token_value`
+| Capability | Official Proxmox API | One-off scripts | ProxmoxMCP-Plus |
+| --- | --- | --- | --- |
+| MCP for LLM and AI agent workflows | No | No | Yes |
+| OpenAPI surface for standard HTTP tooling | No | Usually no | Yes |
+| VM and LXC operations in one interface | Low-level only | Depends | Yes |
+| Snapshot, backup, and restore workflows | Low-level only | Depends | Yes |
+| Container command execution with policy controls | No | Custom only | Yes |
+| Docker distribution path | No | Rare | Yes |
+| Repo-level real-environment validation | N/A | Rare | Yes |
 
 ## Scenario Templates
 
-Ready-to-copy examples live in [`examples/`](examples/README.md).
+Ready-to-copy examples live in [`examples/`](examples/README.md):
 
 - [Create a test VM](examples/create-test-vm.md)
 - [Roll back a risky change with snapshots](examples/rollback-snapshot.md)
 - [Download an ISO and create an LXC](examples/download-iso-and-create-lxc.md)
 
-These examples include:
-
-- plain-language prompts for Claude or Open WebUI
-- example OpenAPI requests
-- expected operator outcome
-
-## Why Share This Instead of Raw Scripts
-
-| Capability | Official Proxmox API | One-off scripts | ProxmoxMCP-Plus |
-| --- | --- | --- | --- |
-| MCP for LLM / AI agents | No | No | Yes |
-| OpenAPI bridge | No | Usually no | Yes |
-| VM + LXC lifecycle in one interface | Low-level only | Depends | Yes |
-| Snapshot / backup / restore workflows | Low-level only | Depends | Yes |
-| Container SSH-backed execution | No | Custom only | Yes |
-| Command policy / guardrails | No | Rare | Yes |
-| Real repo-level E2E coverage | N/A | Rare | Yes |
-
-## What You Can Build With It
-
-- `Claude Desktop + Proxmox`: ask an LLM to create a sandbox VM, list nodes, or roll back snapshots
-- `Open WebUI + homelab`: expose Proxmox actions to a self-hosted AI assistant
-- `AI infra tools + HTTP`: call `/openapi.json` and integrate with dashboards or internal portals
-- `Operator workflows`: use one control surface for read-only checks and write operations
-
-## Repo Structure
-
-- `src/proxmox_mcp/`: server, tools, config, security, formatting
-- `test_scripts/run_real_e2e.py`: live Proxmox, OpenAPI, Docker smoke path
-- `tests/`: unit and integration coverage
-- `proxmox-config/`: example and runtime config
-- `examples/`: copy-paste usage templates for LLM and HTTP flows
-
-## Release and Distribution
-
-- PyPI package: [proxmox-mcp-plus](https://pypi.org/project/proxmox-mcp-plus/)
-- GitHub releases: [Releases](https://github.com/RekklesNA/ProxmoxMCP-Plus/releases)
-- GHCR image: `ghcr.io/rekklesna/proxmoxmcp-plus`
-
-Current release notes should describe user-visible ability, not generic bugfixes:
-
-- live Proxmox E2E coverage
-- container SSH execution path
-- Docker OpenAPI `/health`
-- source-vs-installed-package test correctness
-
-## Community and Launch
-
-If you want to promote the project instead of just dropping a link, start here:
-
-- [Launch post draft](docs/launch-post.md)
-- [20-30 second demo script](docs/demo-script.md)
-- GitHub Discussions
-- Reddit: `r/selfhosted`, `r/homelab`, `r/Proxmox`, `r/LocalLLaMA`
-- Hacker News: `Show HN`
-- X / AI infra / MCP circles
-
-Suggested angle:
-
-> I built an MCP + OpenAPI server that lets LLMs and AI agents operate real Proxmox VE workflows, and I verified the core paths on a live lab.
+These are written for both human operators and LLM-driven usage.
 
 ## Documentation
 
-README is intentionally optimized for fast GitHub conversion. Deep docs live in the wiki:
+The README is intentionally optimized for fast GitHub comprehension. Longer operational docs live in `docs/wiki/` and can also be published to the GitHub Wiki.
 
-- [Home](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/Home)
-- [Operator Guide](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/Operator-Guide)
-- [Developer Guide](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/Developer-Guide)
-- [Security Guide](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/Security-Guide)
-- [Integrations Guide](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/Integrations-Guide)
-- [API & Tool Reference](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/API-&-Tool-Reference)
-- [Troubleshooting](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/Troubleshooting)
-- [Release & Upgrade Notes](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/Release-&-Upgrade-Notes)
+| If you need to... | Start here |
+| --- | --- |
+| Understand the project and deployment flow | [Wiki Home](docs/wiki/Home.md) |
+| Configure and run against a Proxmox environment | [Operator Guide](docs/wiki/Operator%20Guide.md) |
+| Connect Claude Desktop or Open WebUI | [Integrations Guide](docs/wiki/Integrations%20Guide.md) |
+| Review security and command policy | [Security Guide](docs/wiki/Security%20Guide.md) |
+| Inspect tool groups and behavior | [API & Tool Reference](docs/wiki/API%20%26%20Tool%20Reference.md) |
+| Debug startup, auth, or health issues | [Troubleshooting](docs/wiki/Troubleshooting.md) |
+| Work on the codebase or release it | [Developer Guide](docs/wiki/Developer%20Guide.md) |
+| Review release and upgrade notes | [Release & Upgrade Notes](docs/wiki/Release%20%26%20Upgrade%20Notes.md) |
 
-## Development
+Published wiki:
+
+- [GitHub Wiki Home](https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki/Home)
+
+## Repo Layout
+
+- `src/proxmox_mcp/`: MCP server, config loading, security, OpenAPI bridge
+- `main.py`: MCP entrypoint for local and client-driven usage
+- `docker-compose.yml`: HTTP/OpenAPI runtime
+- `test_scripts/run_real_e2e.py`: live Proxmox and Docker/OpenAPI path
+- `tests/`: unit and integration coverage
+- `examples/`: scenario-driven prompts and HTTP examples
+- `docs/wiki/`: longer-form operator, integration, and reference docs
+
+## Development Checks
 
 ```bash
 pytest -q
@@ -239,4 +218,4 @@ python -m build
 
 ## License
 
-[MIT License](LICENSE)
+[MIT](LICENSE)

--- a/assets/proxmoxmcp-drawio-hero.svg
+++ b/assets/proxmoxmcp-drawio-hero.svg
@@ -1,0 +1,98 @@
+<svg width="1280" height="760" viewBox="0 0 1280 760" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style>
+      .title { font: 700 32px 'Segoe UI', Arial, sans-serif; fill: #111827; }
+      .subtitle { font: 400 17px 'Segoe UI', Arial, sans-serif; fill: #4B5563; }
+      .section { font: 700 20px 'Segoe UI', Arial, sans-serif; fill: #111827; }
+      .body { font: 400 14px 'Segoe UI', Arial, sans-serif; fill: #374151; }
+      .small { font: 600 13px 'Segoe UI', Arial, sans-serif; fill: #334155; }
+      .mono { font: 700 13px 'Consolas', 'Courier New', monospace; fill: #0F172A; }
+      .line { stroke: #64748B; stroke-width: 3; stroke-linecap: round; stroke-linejoin: round; }
+      .arrow { fill: #64748B; }
+    </style>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="8" flood-color="#0F172A" flood-opacity="0.10"/>
+    </filter>
+  </defs>
+
+  <rect width="1280" height="760" rx="24" fill="#F8FAFC"/>
+  <rect x="24" y="24" width="1232" height="712" rx="20" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
+
+  <text x="56" y="74" class="title">ProxmoxMCP-Plus: one Proxmox control plane for LLMs, AI agents, MCP, and OpenAPI</text>
+  <text x="56" y="102" class="subtitle">Use Claude Desktop, Open WebUI, or HTTP clients to drive real VM, LXC, snapshot, backup, restore, ISO, and SSH-backed workflows.</text>
+
+  <rect x="56" y="144" width="254" height="186" rx="14" fill="#EFF6FF" stroke="#60A5FA" stroke-width="2" filter="url(#shadow)"/>
+  <text x="82" y="182" class="section">LLM and MCP Clients</text>
+  <rect x="82" y="198" width="202" height="32" rx="8" fill="#DBEAFE" stroke="#93C5FD"/>
+  <text x="112" y="219" class="body">Claude Desktop</text>
+  <rect x="82" y="240" width="202" height="32" rx="8" fill="#DBEAFE" stroke="#93C5FD"/>
+  <text x="126" y="261" class="body">Open WebUI</text>
+  <rect x="82" y="282" width="202" height="32" rx="8" fill="#DBEAFE" stroke="#93C5FD"/>
+  <text x="123" y="303" class="body">Other MCP clients</text>
+
+  <rect x="56" y="372" width="254" height="146" rx="14" fill="#F5F3FF" stroke="#A78BFA" stroke-width="2" filter="url(#shadow)"/>
+  <text x="82" y="410" class="section">HTTP Consumers</text>
+  <rect x="82" y="426" width="202" height="32" rx="8" fill="#EDE9FE" stroke="#C4B5FD"/>
+  <text x="101" y="447" class="body">OpenAPI / Swagger UI</text>
+  <rect x="82" y="468" width="202" height="32" rx="8" fill="#EDE9FE" stroke="#C4B5FD"/>
+  <text x="104" y="489" class="body">Internal tools / scripts</text>
+
+  <rect x="378" y="142" width="544" height="404" rx="16" fill="#F8FAFC" stroke="#0F766E" stroke-width="3" filter="url(#shadow)"/>
+  <rect x="398" y="162" width="504" height="46" rx="10" fill="#CCFBF1" stroke="#5EEAD4"/>
+  <text x="424" y="191" class="section">ProxmoxMCP-Plus service boundary</text>
+
+  <rect x="418" y="228" width="216" height="82" rx="10" fill="#ECFEFF" stroke="#67E8F9"/>
+  <text x="442" y="258" class="small">MCP server layer</text>
+  <text x="442" y="280" class="body">stdio transport</text>
+  <text x="442" y="298" class="body">assistant-facing tools</text>
+
+  <rect x="664" y="228" width="216" height="82" rx="10" fill="#ECFDF5" stroke="#86EFAC"/>
+  <text x="688" y="258" class="small">OpenAPI bridge</text>
+  <text x="688" y="280" class="body">/docs, /openapi.json, /health</text>
+  <text x="688" y="298" class="body">HTTP automation surface</text>
+
+  <rect x="418" y="334" width="216" height="94" rx="10" fill="#FEFCE8" stroke="#FACC15"/>
+  <text x="442" y="364" class="small">Operator workflows</text>
+  <text x="442" y="386" class="body">VM and LXC lifecycle</text>
+  <text x="442" y="404" class="body">snapshot, backup, restore, ISO</text>
+
+  <rect x="664" y="334" width="216" height="94" rx="10" fill="#FEF2F2" stroke="#FCA5A5"/>
+  <text x="688" y="364" class="small">Control and guardrails</text>
+  <text x="688" y="386" class="body">token auth, command policy</text>
+  <text x="688" y="404" class="body">logging and execution limits</text>
+
+  <rect x="418" y="452" width="462" height="72" rx="10" fill="#F1F5F9" stroke="#94A3B8"/>
+  <text x="442" y="480" class="small">Live-lab verified paths</text>
+  <text x="442" y="504" class="body">VM | LXC | snapshot | backup | restore | ISO | SSH | OpenAPI | Docker</text>
+
+  <rect x="974" y="164" width="248" height="318" rx="14" fill="#FFF7ED" stroke="#FB923C" stroke-width="2" filter="url(#shadow)"/>
+  <text x="1000" y="202" class="section">Proxmox VE</text>
+  <rect x="1000" y="220" width="196" height="44" rx="8" fill="#FFEDD5" stroke="#FDBA74"/>
+  <text x="1046" y="247" class="body">Cluster API</text>
+  <rect x="1000" y="280" width="196" height="44" rx="8" fill="#FFEDD5" stroke="#FDBA74"/>
+  <text x="1057" y="307" class="body">Nodes</text>
+  <rect x="1000" y="340" width="196" height="44" rx="8" fill="#FFEDD5" stroke="#FDBA74"/>
+  <text x="1043" y="367" class="body">VMs and LXCs</text>
+  <rect x="1000" y="400" width="196" height="44" rx="8" fill="#FFEDD5" stroke="#FDBA74"/>
+  <text x="1034" y="427" class="body">Storage and backups</text>
+
+  <rect x="378" y="586" width="844" height="114" rx="16" fill="#F8FAFC" stroke="#94A3B8" stroke-width="2" filter="url(#shadow)"/>
+  <text x="406" y="624" class="section">Typical operator path</text>
+  <text x="406" y="650" class="body">1. An LLM, AI agent, or HTTP client requests a Proxmox action.</text>
+  <text x="406" y="672" class="body">2. ProxmoxMCP-Plus applies auth and policy, then executes the workflow.</text>
+  <text x="406" y="694" class="body">3. The same result can be returned to MCP clients and HTTP consumers.</text>
+
+  <line x1="310" y1="238" x2="378" y2="238" class="line"/>
+  <polygon points="378,238 364,230 364,246" class="arrow"/>
+  <line x1="310" y1="446" x2="378" y2="446" class="line"/>
+  <polygon points="378,446 364,438 364,454" class="arrow"/>
+  <line x1="634" y1="268" x2="664" y2="268" class="line"/>
+  <polygon points="664,268 650,260 650,276" class="arrow"/>
+  <line x1="880" y1="280" x2="974" y2="280" class="line"/>
+  <polygon points="974,280 960,272 960,288" class="arrow"/>
+  <line x1="880" y1="382" x2="974" y2="382" class="line"/>
+  <polygon points="974,382 960,374 960,390" class="arrow"/>
+
+  <text x="432" y="142" class="mono">MCP / HTTP</text>
+  <text x="928" y="150" class="mono">Proxmox REST API</text>
+</svg>

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,51 +1,66 @@
 # ProxmoxMCP-Plus Wiki
 
-This wiki contains the longer documentation for ProxmoxMCP-Plus.
+This wiki is the longer-form documentation hub for ProxmoxMCP-Plus.
 
-ProxmoxMCP-Plus is an MCP server and OpenAPI bridge for Proxmox VE. It lets MCP-capable assistants, WebUI tools, and HTTP clients work with VMs, LXC containers, snapshots, backups, storage, and cluster state through one service.
+ProxmoxMCP-Plus gives you one Proxmox VE control surface for both:
+
+- MCP clients such as Claude Desktop and Open WebUI
+- HTTP and OpenAPI consumers such as dashboards, internal tools, and automation jobs
+
+Use the root `README.md` for the fast project overview. Use this wiki when you need setup detail, operating guidance, security notes, or tool-by-tool reference material.
 
 ## Start Here
 
-- First-time deployment: [Operator Guide](Operator-Guide)
-- Local setup and contribution flow: [Developer Guide](Developer-Guide)
-- Security settings and command policy: [Security Guide](Security-Guide)
-- Client integration examples: [Integrations Guide](Integrations-Guide)
-- Tool-by-tool capability index: [API & Tool Reference](API-&-Tool-Reference)
-- Common failures and recovery steps: [Troubleshooting](Troubleshooting)
-- Version tracking and upgrade notes: [Release & Upgrade Notes](Release-&-Upgrade-Notes)
+| If you want to... | Open this page |
+| --- | --- |
+| Deploy the project against a real Proxmox environment | [Operator Guide](Operator-Guide) |
+| Work on the codebase, run checks, or publish releases | [Developer Guide](Developer-Guide) |
+| Connect Claude Desktop, Open WebUI, or HTTP clients | [Integrations Guide](Integrations-Guide) |
+| Understand auth, command policy, and execution safety | [Security Guide](Security-Guide) |
+| Browse the exact tool surface and prerequisites | [API & Tool Reference](API-&-Tool-Reference) |
+| Debug startup, auth, SSH, or `/health` issues | [Troubleshooting](Troubleshooting) |
+| Review release history and upgrade notes | [Release & Upgrade Notes](Release-&-Upgrade-Notes) |
 
-## What This Project Does
+## What The Project Covers
 
-- Exposes Proxmox operations as MCP tools
-- Optionally exposes the same operations over HTTP through an OpenAPI proxy
-- Supports VM lifecycle actions such as create, start, stop, shutdown, reset, and delete
-- Supports LXC listing, creation, resource updates, start/stop/restart, config reads, IP discovery, and deletion
-- Supports snapshots, backup creation, backup restore, ISO browsing, template browsing, node status, storage status, and cluster status
-- Adds policy checks around command execution tools
+- VM and LXC lifecycle operations
+- snapshots, rollback, backup, and restore
+- ISO and template workflows
+- cluster, node, and storage inspection
+- SSH-backed container command execution
+- OpenAPI bridging for the MCP tool surface
 
 ## Architecture Summary
 
-- `main.py` starts the MCP server bundle
+- `main.py` starts the MCP server entrypoint
 - `src/proxmox_mcp/server.py` registers MCP tools
-- `src/proxmox_mcp/openapi_proxy.py` wraps the MCP server behind FastAPI and adds `/`, `/docs`, `/openapi.json`, and `/health`
-- `src/proxmox_mcp/config/` contains validation for JSON and environment-based configuration
-- `src/proxmox_mcp/security/command_policy.py` evaluates command execution requests against allow and deny rules
-- `docs/container-command-execution.md` explains the SSH-based LXC command flow
+- `src/proxmox_mcp/openapi_proxy.py` exposes `/`, `/docs`, `/openapi.json`, and `/health`
+- `src/proxmox_mcp/config/` validates configuration and runtime settings
+- `src/proxmox_mcp/security/command_policy.py` applies allow and deny rules for execution requests
+- `docs/container-command-execution.md` explains the SSH-backed LXC command path
 
-## Documentation Layout
+## Validation Summary
 
-- Use the root `README.md` for a quick product overview and minimal startup steps
-- Use this wiki for setup details, operating guidance, and tool behavior
-- Keep page titles stable so README and external links do not break
+The repository includes real-environment validation entry points for:
 
-## Quick Navigation
+- VM create, start, stop, and delete
+- snapshot create, rollback, and delete
+- backup and restore
+- ISO download and cleanup
+- LXC create, start, stop, and delete
+- container SSH-backed command execution
+- local OpenAPI `/health` and schema
+- Docker image build and `/health`
 
-| Topic | Use it for |
-| --- | --- |
-| [Operator Guide](Operator-Guide) | Config, runtime modes, Docker/OpenAPI deployment, health checks |
-| [Developer Guide](Developer-Guide) | Local install, test commands, code layout, release workflow |
-| [Security Guide](Security-Guide) | TLS, token handling, `dev_mode`, command policy, SSH-based container execution |
-| [Integrations Guide](Integrations-Guide) | Claude Desktop, OpenCode, OpenAPI clients |
-| [API & Tool Reference](API-&-Tool-Reference) | Exact tool groups, parameters, prerequisites, and output expectations |
-| [Troubleshooting](Troubleshooting) | Startup failures, auth issues, tool registration problems, health check issues |
-| [Release & Upgrade Notes](Release-&-Upgrade-Notes) | Release entries, upgrade checklist, rollback notes |
+Primary validation entry points:
+
+- `pytest -q`
+- `tests/integration/test_real_contract.py`
+- `test_scripts/run_real_e2e.py`
+
+## External References
+
+- [Proxmox VE installation guide](https://pve.proxmox.com/pve-docs/pve-installation-plain.html)
+- [Proxmox VE API guide](https://pve.proxmox.com/wiki/Proxmox_VE_API)
+- [Proxmox VE administration guide](https://pve.proxmox.com/pve-docs/pve-admin-guide.html)
+- [Linux Container guide](https://pve.proxmox.com/wiki/Linux_Container)

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -1,14 +1,14 @@
 # Wiki Seed Pages
 
-This directory contains the markdown pages intended to be published to the GitHub Wiki for ProxmoxMCP-Plus.
+This directory contains the markdown files intended for the GitHub Wiki and the in-repo documentation hub.
 
-## Documentation Model
+## Documentation Strategy
 
-- `README.md` in the repo root is the short project entrypoint
-- `docs/wiki/` contains the longer operational and reference pages
-- page names here should stay aligned with the published Wiki page names
+- `README.md` in the repository root is the conversion-focused homepage
+- `docs/wiki/` holds the longer operator, integration, security, and reference material
+- page names should stay stable so README links and published wiki URLs do not break
 
-## Pages Included
+## Included Pages
 
 - `Home.md`
 - `Operator Guide.md`
@@ -40,6 +40,7 @@ git push
 
 ## Maintenance Notes
 
-- Keep titles stable so wiki URLs stay stable
-- Update the root README links if a wiki page is renamed
-- Avoid adding placeholders for features that do not exist in the codebase
+- Keep titles stable so wiki URLs remain stable
+- Update the root README when adding, removing, or renaming wiki pages
+- Keep the homepage short and move operational detail into wiki pages
+- Do not add placeholders for features that do not exist in the codebase


### PR DESCRIPTION
## Summary
- rewrite the README to match high-conversion MCP project structure
- add a professional draw.io-style hero diagram
- turn the wiki home into a stronger documentation entrypoint

## Testing
- git diff --check