### PR TITLE
Prepare 0.2.1 release for MCP Registry publishing

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,85 @@
+name: Publish MCP Registry Metadata
+
+on:
+  workflow_run:
+    workflows: ["Publish Python Package"]
+    types: [completed]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - name: Resolve registry package version
+      id: version
+      shell: bash
+      run: |
+        version=$(python - <<'PY'
+        import json
+        from pathlib import Path
+
+        print(json.loads(Path("server.json").read_text(encoding="utf-8"))["version"])
+        PY
+        )
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
+    - name: Wait for PyPI release visibility
+      shell: bash
+      env:
+        PACKAGE_NAME: proxmox-mcp-plus
+        PACKAGE_VERSION: ${{ steps.version.outputs.version }}
+      run: |
+        python - <<'PY'
+        import json
+        import os
+        import sys
+        import time
+        import urllib.request
+
+        package_name = os.environ["PACKAGE_NAME"]
+        package_version = os.environ["PACKAGE_VERSION"]
+        url = f"https://pypi.org/pypi/{package_name}/json"
+
+        for attempt in range(1, 19):
+            with urllib.request.urlopen(url, timeout=30) as response:
+                payload = json.load(response)
+            releases = payload.get("releases", {})
+            if releases.get(package_version):
+                print(f"Found {package_name}=={package_version} on PyPI.")
+                sys.exit(0)
+            print(
+                f"Attempt {attempt}/18: {package_name}=={package_version} "
+                "is not visible on PyPI yet. Waiting 10 seconds..."
+            )
+            time.sleep(10)
+
+        raise SystemExit(
+            f"{package_name}=={package_version} did not become visible on PyPI in time."
+        )
+        PY
+
+    - name: Install mcp-publisher
+      shell: bash
+      run: |
+        curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+        chmod +x ./mcp-publisher
+
+    - name: Authenticate to MCP Registry
+      run: ./mcp-publisher login github-oidc
+
+    - name: Publish server to MCP Registry
+      run: ./mcp-publisher publish

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ProxmoxMCP-Plus
 
+<!-- mcp-name: io.github.RekklesNA/proxmox-mcp-plus -->
+
 <div align="center">
   <img src="assets/logo-proxmoxmcp-plus.png" alt="ProxmoxMCP-Plus Logo" width="160"/>
 </div>
@@ -76,8 +78,14 @@ Add an `ssh` section as well if you want container command execution.
 #### PyPI
 
 ```bash
+uvx proxmox-mcp-plus
+```
+
+Or install it first:
+
+```bash
 pip install proxmox-mcp-plus
-python main.py
+proxmox-mcp-plus
 ```
 
 #### Docker / GHCR

--- a/docs/releases/v0.2.1.md
+++ b/docs/releases/v0.2.1.md
@@ -1,0 +1,18 @@
+## Why this release matters
+
+`v0.2.1` turns the project's MCP Registry path into a repeatable release workflow instead of a one-off manual step.
+
+This release is aimed at making discovery and installation more reliable across GitHub Copilot and other MCP Registry consumers.
+
+## User-visible highlights
+
+- added `server.json` metadata for MCP Registry publication
+- added PyPI README ownership marker required for registry verification
+- aligned the published CLI entrypoint with the PyPI package name via `proxmox-mcp-plus`
+- added GitHub Actions automation to publish `server.json` to the MCP Registry with GitHub OIDC after PyPI publication succeeds
+- corrected bundle manifest version drift so packaging metadata now points at the same release
+
+## Validation
+
+- `python -m json.tool server.json`
+- `python -m build`

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": "0.4",
     "name": "proxmox-mcp-plus",
     "display_name": "ProxmoxMCP-Plus",
-    "version": "0.1.0",
+    "version": "0.2.1",
     "description": "An enhanced MCP server for managing Proxmox virtualization platforms.",
     "long_description": "ProxmoxMCP-Plus is an enhanced Model Context Protocol (MCP) server that provides comprehensive tools for managing Proxmox virtualization environments, including VM lifecycle, container management, snapshot operations, and backup/restore capabilities.",
     "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "proxmox-mcp-plus"
-version = "0.2.0"
+version = "0.2.1"
 description = "Enhanced Proxmox MCP Server"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -51,6 +51,7 @@ Issues = "https://github.com/RekklesNA/ProxmoxMCP-Plus/issues"
 
 [project.scripts]
 proxmox-mcp = "proxmox_mcp.server:main"
+proxmox-mcp-plus = "proxmox_mcp.server:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/server.json
+++ b/server.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.RekklesNA/proxmox-mcp-plus",
+  "title": "ProxmoxMCP-Plus",
+  "description": "Enhanced Proxmox MCP server for managing Proxmox VE nodes, VMs, LXCs, snapshots, backups, ISOs, and related operational workflows.",
+  "repository": {
+    "url": "https://github.com/RekklesNA/ProxmoxMCP-Plus",
+    "source": "github"
+  },
+  "version": "0.2.1",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "proxmox-mcp-plus",
+      "version": "0.2.1",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "PROXMOX_HOST",
+          "description": "Hostname or IP address of the Proxmox VE API endpoint.",
+          "isRequired": true,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "PROXMOX_USER",
+          "description": "Proxmox username with realm, for example root@pam.",
+          "isRequired": true,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "PROXMOX_TOKEN_NAME",
+          "description": "Name of the Proxmox API token.",
+          "isRequired": true,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "PROXMOX_TOKEN_VALUE",
+          "description": "Secret value of the Proxmox API token.",
+          "isRequired": true,
+          "format": "string",
+          "isSecret": true
+        },
+        {
+          "name": "PROXMOX_PORT",
+          "description": "Proxmox API port. Defaults to 8006.",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "PROXMOX_VERIFY_SSL",
+          "description": "Set to true to verify TLS certificates, or false for self-signed lab environments.",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "PROXMOX_SERVICE",
+          "description": "Proxmox service type. Defaults to PVE.",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "LOG_LEVEL",
+          "description": "Server log verbosity. Defaults to INFO.",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        }
+      ]
+    }
+  ]
+}

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="proxmox-mcp-plus",
-    version="0.2.0",
+    version="0.2.1",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     python_requires=">=3.11",
@@ -39,6 +39,7 @@ setup(
     entry_points={
         "console_scripts": [
             "proxmox-mcp=proxmox_mcp.server:main",
+            "proxmox-mcp-plus=proxmox_mcp.server:main",
         ],
     },
     author="Kevin",

--- a/src/proxmox_mcp/__init__.py
+++ b/src/proxmox_mcp/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .server import ProxmoxMCPServer
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __all__ = ["ProxmoxMCPServer"]
 
 


### PR DESCRIPTION
## Summary
- bump package and manifest versions to 0.2.1 and align release metadata
- add MCP Registry metadata and PyPI verification marker for registry publication
- add a GitHub Actions workflow that publishes server.json to the MCP Registry with GitHub OIDC after PyPI publication succeeds

## Validation
- python -m json.tool server.json
- python -m build