### PR TITLE
Release 0.4.3

### DIFF
--- a/docs/releases/v0.4.3.md
+++ b/docs/releases/v0.4.3.md
@@ -1,0 +1,24 @@
+# ProxmoxMCP-Plus v0.4.3
+
+Release date: 2026-04-28
+
+## Summary
+
+This release adds a `clone_vm` MCP tool for cloning existing Proxmox QEMU virtual
+machines from templates, snapshots, or existing VM instances.
+
+## Changes
+
+- Added `clone_vm` to the VM MCP tool set.
+- Added support for full and linked clones.
+- Added optional clone target settings for VM name, target node, target storage,
+  resource pool, and source snapshot.
+- Registered `clone_vm` through the built-in plugin registry used by current
+  server startup.
+- Added server tests for tool registration and clone API payloads.
+
+## Upgrade Notes
+
+- No config migration is required.
+- The Proxmox API token used by the server must have the permissions required to
+  clone QEMU VMs on the relevant source and target resources.

--- a/docs/wiki/Release & Upgrade Notes.md
+++ b/docs/wiki/Release & Upgrade Notes.md
@@ -18,6 +18,22 @@ Use this page to track version-level behavior changes, upgrade steps, and rollba
 
 ## Release History
 
+### Version `0.4.3`
+
+- Release date: 2026-04-28
+- Summary: adds the `clone_vm` MCP tool for cloning existing Proxmox QEMU virtual machines.
+- New tools or endpoints:
+  - MCP tool: `clone_vm`
+- Changed behavior:
+  - no behavior changes to existing tools
+- Config changes:
+  - no required config changes
+- Docs updated:
+  - `docs/releases/v0.4.3.md`
+- Upgrade steps:
+  - no migration required
+  - confirm the configured Proxmox API token has VM clone permissions before using `clone_vm`
+
 ### Version `0.4.2`
 
 - Release date: 2026-04-28

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": "0.4",
     "name": "proxmox-mcp-plus",
     "display_name": "ProxmoxMCP-Plus",
-    "version": "0.4.2",
+    "version": "0.4.3",
     "description": "An enhanced MCP server for managing Proxmox virtualization platforms.",
     "long_description": "ProxmoxMCP-Plus is an enhanced Model Context Protocol (MCP) server that provides comprehensive tools for managing Proxmox virtualization environments, including VM lifecycle, container management, snapshot operations, and backup/restore capabilities.",
     "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "proxmox-mcp-plus"
-version = "0.4.2"
+version = "0.4.3"
 description = "Enhanced Proxmox MCP Server"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -18,13 +18,13 @@
     "url": "https://github.com/RekklesNA/ProxmoxMCP-Plus",
     "source": "github"
   },
-  "version": "0.4.2",
+  "version": "0.4.3",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "proxmox-mcp-plus",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="proxmox-mcp-plus",
-    version="0.4.2",
+    version="0.4.3",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     python_requires=">=3.11",


### PR DESCRIPTION
﻿## Summary
- bump package, manifest, and MCP registry metadata versions to 0.4.3
- add release notes for the new clone_vm MCP tool

## Validation
- pytest -q
- ruff check . --select E9,F63,F7,F82
- mypy src --ignore-missing-imports
- python -m build
- python -m twine check dist/*
