### PR TITLE
Release 0.4.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -16,10 +16,10 @@ jobs:
       contents: read
       packages: write
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Log in to GHCR
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -27,7 +27,7 @@ jobs:
 
     - name: Extract Docker metadata
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |
@@ -38,7 +38,7 @@ jobs:
           type=semver,pattern={{major}}.{{minor}},value=${{ github.event.release.tag_name }}
 
     - name: Build and push image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .
         push: true

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -15,12 +15,12 @@ jobs:
       contents: read
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
 

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -11,10 +11,10 @@ jobs:
     permissions:
       contents: read
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
 
@@ -29,7 +29,7 @@ jobs:
         twine check dist/*
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: python-dist
         path: dist/
@@ -47,7 +47,7 @@ jobs:
       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
     steps:
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: python-dist
         path: dist/

--- a/docs/releases/v0.4.4.md
+++ b/docs/releases/v0.4.4.md
@@ -1,0 +1,20 @@
+# ProxmoxMCP-Plus v0.4.4
+
+Release date: 2026-04-28
+
+## Summary
+
+This maintenance release updates GitHub Actions workflow dependencies to current
+Node 24-compatible major versions.
+
+## Changes
+
+- Updated checkout and Python setup actions used by CI and release workflows.
+- Updated artifact upload/download actions used by the PyPI publishing workflow.
+- Updated Docker login, metadata, and build/push actions used by the GHCR
+  publishing workflow.
+
+## Upgrade Notes
+
+- No runtime or config migration is required.
+- This release only changes repository automation and package metadata.

--- a/docs/wiki/Release & Upgrade Notes.md
+++ b/docs/wiki/Release & Upgrade Notes.md
@@ -18,6 +18,19 @@ Use this page to track version-level behavior changes, upgrade steps, and rollba
 
 ## Release History
 
+### Version `0.4.4`
+
+- Release date: 2026-04-28
+- Summary: updates GitHub Actions workflow dependencies to current Node 24-compatible major versions.
+- Changed behavior:
+  - no runtime behavior changes
+- Config changes:
+  - no required config changes
+- Docs updated:
+  - `docs/releases/v0.4.4.md`
+- Upgrade steps:
+  - no migration required
+
 ### Version `0.4.3`
 
 - Release date: 2026-04-28

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": "0.4",
     "name": "proxmox-mcp-plus",
     "display_name": "ProxmoxMCP-Plus",
-    "version": "0.4.3",
+    "version": "0.4.4",
     "description": "An enhanced MCP server for managing Proxmox virtualization platforms.",
     "long_description": "ProxmoxMCP-Plus is an enhanced Model Context Protocol (MCP) server that provides comprehensive tools for managing Proxmox virtualization environments, including VM lifecycle, container management, snapshot operations, and backup/restore capabilities.",
     "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "proxmox-mcp-plus"
-version = "0.4.3"
+version = "0.4.4"
 description = "Enhanced Proxmox MCP Server"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -18,13 +18,13 @@
     "url": "https://github.com/RekklesNA/ProxmoxMCP-Plus",
     "source": "github"
   },
-  "version": "0.4.3",
+  "version": "0.4.4",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "proxmox-mcp-plus",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="proxmox-mcp-plus",
-    version="0.4.3",
+    version="0.4.4",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     python_requires=">=3.11",


### PR DESCRIPTION
﻿## Summary
- bump package, manifest, and MCP registry metadata versions to 0.4.4
- update GitHub Actions workflow dependencies to current Node 24-compatible major versions
- add 0.4.4 release notes

## Validation
- pytest -q
- ruff check . --select E9,F63,F7,F82
- mypy src --ignore-missing-imports
- python -m build
- python -m twine check dist/*
