### PR TITLE
Fix Home Assistant get_containers schema compatibility

### DIFF
--- a/docs/releases/v0.4.5.md
+++ b/docs/releases/v0.4.5.md
@@ -1,0 +1,14 @@
+# ProxmoxMCP-Plus v0.4.5
+
+Released: 2026-05-01
+
+## Fixes
+
+- Changes the `get_containers` MCP input schema to expose top-level parameters instead of a nested Pydantic `payload` `$ref`, allowing stricter clients such as Home Assistant MCP to load the server.
+- Keeps the legacy `payload` object accepted for existing clients that already call `get_containers` with the previous nested shape.
+
+## Upgrade Notes
+
+- No configuration migration is required.
+- New clients should send `node`, `include_stats`, `include_raw`, and `format_style` as top-level tool arguments.
+- Existing clients using `payload` can continue to do so.

--- a/docs/wiki/API & Tool Reference.md
+++ b/docs/wiki/API & Tool Reference.md
@@ -105,7 +105,7 @@ Selector-based tools fail when no container matches the selector or when a bulk 
 
 | Tool | Mode | Required Inputs | Optional Inputs | Prerequisites | Common Failures |
 | --- | --- | --- | --- | --- | --- |
-| `get_containers` | Read-only | `payload` body | `node`, `include_stats=true`, `include_raw=false`, `format_style=pretty\|json` | Proxmox API reachable | invalid payload shape, auth failure |
+| `get_containers` | Read-only | none | `node`, `include_stats=true`, `include_raw=false`, `format_style=pretty\|json`, legacy `payload` object | Proxmox API reachable | invalid payload shape, auth failure |
 | `start_container` | Mutating | `selector` | `format_style=pretty\|json` | selector resolves to one or more containers | no selector match, start failure from Proxmox |
 | `stop_container` | Mutating | `selector` | `graceful=true`, `timeout_seconds=10`, `format_style=pretty\|json` | selector resolves to one or more containers | no selector match, timeout on graceful shutdown, container already stopped |
 | `restart_container` | Mutating | `selector` | `timeout_seconds=10`, `format_style=pretty\|json` | selector resolves to one or more containers | no selector match, reboot failure |
@@ -119,7 +119,7 @@ Selector-based tools fail when no container matches the selector or when a bulk 
 
 ### Container Notes
 
-- `get_containers` uses a request body model rather than a flat parameter list.
+- `get_containers` exposes flat top-level parameters for stricter MCP clients. The legacy `payload` object is still accepted for existing callers.
 - `update_container_resources.disk_gb` is an additional resize amount for the selected disk, not a full replacement size target.
 - `create_container.start_after_create` controls immediate startup after provisioning.
 - `create_container.nesting` and `create_container.unprivileged` change container execution characteristics and should match your Proxmox policy.

--- a/docs/wiki/Release & Upgrade Notes.md
+++ b/docs/wiki/Release & Upgrade Notes.md
@@ -18,6 +18,21 @@ Use this page to track version-level behavior changes, upgrade steps, and rollba
 
 ## Release History
 
+### Version `0.4.5`
+
+- Release date: 2026-05-01
+- Summary: fixes Home Assistant MCP compatibility for `get_containers` by removing the nested `$ref` payload schema while retaining legacy payload calls.
+- Changed behavior:
+  - `get_containers` now exposes flat top-level MCP arguments
+  - legacy `payload` object input remains accepted for existing clients
+- Config changes:
+  - no required config changes
+- Docs updated:
+  - `docs/releases/v0.4.5.md`
+  - `docs/wiki/API & Tool Reference.md`
+- Upgrade steps:
+  - no migration required
+
 ### Version `0.4.4`
 
 - Release date: 2026-04-28

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": "0.4",
     "name": "proxmox-mcp-plus",
     "display_name": "ProxmoxMCP-Plus",
-    "version": "0.4.4",
+    "version": "0.4.5",
     "description": "An enhanced MCP server for managing Proxmox virtualization platforms.",
     "long_description": "ProxmoxMCP-Plus is an enhanced Model Context Protocol (MCP) server that provides comprehensive tools for managing Proxmox virtualization environments, including VM lifecycle, container management, snapshot operations, and backup/restore capabilities.",
     "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "proxmox-mcp-plus"
-version = "0.4.4"
+version = "0.4.5"
 description = "Enhanced Proxmox MCP Server"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -18,13 +18,13 @@
     "url": "https://github.com/RekklesNA/ProxmoxMCP-Plus",
     "source": "github"
   },
-  "version": "0.4.4",
+  "version": "0.4.5",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "proxmox-mcp-plus",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="proxmox-mcp-plus",
-    version="0.4.4",
+    version="0.4.5",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     python_requires=">=3.11",

--- a/src/proxmox_mcp/__init__.py
+++ b/src/proxmox_mcp/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .server import ProxmoxMCPServer
 
-__version__ = "0.4.2"
+__version__ = "0.4.5"
 __all__ = ["ProxmoxMCPServer"]
 
 

--- a/src/proxmox_mcp/services/builtin_tool_plugins.py
+++ b/src/proxmox_mcp/services/builtin_tool_plugins.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import time
 from typing import Annotated, Any, Awaitable, Callable, Literal, Optional
 
-from fastapi import Body
 from pydantic import BaseModel, Field
 
 from proxmox_mcp.tools.definitions import (
@@ -319,13 +318,28 @@ class ContainerToolsPlugin(RegistryPluginBase):
     def register(self, server: Any) -> None:
         @server.mcp.tool(description=GET_CONTAINERS_DESC)
         def get_containers(
-            payload: GetContainersPayload = Body(..., embed=True, description="Container query options")
+            node: Annotated[Optional[str], Field(description="Optional node name (e.g. 'pve1')")] = None,
+            include_stats: Annotated[bool, Field(description="Include live stats and fallbacks")] = True,
+            include_raw: Annotated[bool, Field(description="Include raw status/config")] = False,
+            format_style: Annotated[Literal["pretty", "json"], Field(description="'pretty' or 'json'")] = "pretty",
+            payload: Annotated[Optional[dict[str, Any]], Field(description="Legacy container query options")] = None,
         ) -> Any:
+            if payload is not None:
+                legacy_payload = GetContainersPayload.model_validate(payload)
+                if "node" in legacy_payload.model_fields_set:
+                    node = legacy_payload.node
+                if "include_stats" in legacy_payload.model_fields_set:
+                    include_stats = legacy_payload.include_stats
+                if "include_raw" in legacy_payload.model_fields_set:
+                    include_raw = legacy_payload.include_raw
+                if "format_style" in legacy_payload.model_fields_set:
+                    format_style = legacy_payload.format_style
+
             return self._wrap_sync(server, "get_containers", server.container_tools.get_containers)(
-                node=payload.node,
-                include_stats=payload.include_stats,
-                include_raw=payload.include_raw,
-                format_style=payload.format_style,
+                node=node,
+                include_stats=include_stats,
+                include_raw=include_raw,
+                format_style=format_style,
             )
 
         @server.mcp.tool(description=START_CONTAINER_DESC)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -11,6 +11,15 @@ from mcp.server.fastmcp.exceptions import ToolError
 from proxmox_mcp.server import ProxmoxMCPServer
 from proxmox_mcp.config.loader import load_config
 
+
+def _schema_contains_key(value, key):
+    if isinstance(value, dict):
+        return key in value or any(_schema_contains_key(item, key) for item in value.values())
+    if isinstance(value, list):
+        return any(_schema_contains_key(item, key) for item in value)
+    return False
+
+
 @pytest.fixture
 def mock_env_vars(tmp_path):
     """Fixture to set up test environment variables."""
@@ -142,6 +151,20 @@ async def test_list_tools(server):
 
 
 @pytest.mark.asyncio
+async def test_get_containers_schema_avoids_refs(server):
+    """Home Assistant's MCP client rejects nested payload schemas with $ref/$defs."""
+    tools = await server.mcp.list_tools()
+    get_containers = next(tool for tool in tools if tool.name == "get_containers")
+    schema = get_containers.inputSchema
+
+    assert "$defs" not in schema
+    assert not _schema_contains_key(schema, "$ref")
+    assert {"node", "include_stats", "include_raw", "format_style"}.issubset(schema["properties"])
+    assert "payload" in schema["properties"]
+    assert "payload" not in schema.get("required", [])
+
+
+@pytest.mark.asyncio
 async def test_list_tools_with_ssh_config(mock_proxmox, tmp_path):
     """execute_container_command is registered only when an ssh section is present."""
     config_path = tmp_path / "config_ssh.json"
@@ -267,11 +290,25 @@ async def test_get_containers(server, mock_proxmox):
         {"vmid": "201", "name": "container2", "status": "stopped"}
     ]
 
-    response = await server.mcp.call_tool("get_containers", {"payload": {"format_style": "json"}})
+    response = await server.mcp.call_tool("get_containers", {"format_style": "json"})
     result = json.loads(response[0].text)
     assert len(result) > 0
     assert result[0]["name"] == "container1"
     assert result[1]["name"] == "container2"
+
+
+@pytest.mark.asyncio
+async def test_get_containers_accepts_legacy_payload(server, mock_proxmox):
+    """Existing clients may still send the pre-0.4.5 nested payload shape."""
+    mock_proxmox.return_value.nodes.get.return_value = [{"node": "node1", "status": "online"}]
+    mock_proxmox.return_value.nodes.return_value.lxc.get.return_value = [
+        {"vmid": "200", "name": "container1", "status": "running"},
+    ]
+
+    response = await server.mcp.call_tool("get_containers", {"payload": {"format_style": "json"}})
+    result = json.loads(response[0].text)
+    assert result[0]["name"] == "container1"
+
 
 @pytest.mark.asyncio
 async def test_get_containers_skips_offline_node(server, mock_proxmox):


### PR DESCRIPTION
## Summary
- flatten get_containers MCP schema to avoid nested payload / for stricter clients like Home Assistant
- keep legacy payload object accepted for existing clients
- bump release metadata to 0.4.5 and add release notes

## Tests
- python -m pytest
- python -m build
- python -m twine check dist/*