### PR TITLE
Release 0.4.6 reliability fixes

### DIFF
--- a/docs/releases/v0.4.6.md
+++ b/docs/releases/v0.4.6.md
@@ -1,0 +1,17 @@
+# ProxmoxMCP-Plus v0.4.6
+
+Released: 2026-05-02
+
+## Fixes
+
+- Makes `api_tunnel` effective by connecting Proxmox API calls to the configured local tunnel endpoint when the tunnel is enabled.
+- Refreshes persisted job records from SQLite before job reads and controls so OpenAPI `/jobs` can see jobs created by the MCP subprocess after proxy startup.
+- Prevents LXC creation secrets from being persisted in SQLite retry recipes when `password` or `ssh_public_keys` are provided.
+- Stops `rollback_snapshot` from implicitly deleting newer child snapshots before rollback. The tool now refuses rollback until those snapshots are explicitly deleted.
+- Queries storage usage through real Proxmox nodes instead of falling back to a fake `localhost` node.
+
+## Upgrade Notes
+
+- No configuration migration is required.
+- If you use `api_tunnel`, verify the tunnel `local_host` and `local_port` point at the intended local forward.
+- If a snapshot rollback now reports newer child snapshots, delete those snapshots intentionally before retrying rollback.

--- a/docs/wiki/Release & Upgrade Notes.md
+++ b/docs/wiki/Release & Upgrade Notes.md
@@ -18,6 +18,24 @@ Use this page to track version-level behavior changes, upgrade steps, and rollba
 
 ## Release History
 
+### Version `0.4.6`
+
+- Release date: 2026-05-02
+- Summary: fixes API tunnel routing, cross-process job visibility, secret persistence in LXC retry specs, snapshot rollback safety, and storage status node selection.
+- Changed behavior:
+  - `api_tunnel.enabled=true` now routes Proxmox API calls to the local tunnel endpoint
+  - OpenAPI `/jobs` refreshes persisted SQLite records before reads and job controls
+  - `create_container` no longer persists retry recipes when container passwords or SSH public keys are present
+  - `rollback_snapshot` refuses to continue when newer child snapshots exist instead of deleting them implicitly
+  - `get_storage` queries status through real Proxmox nodes instead of `localhost`
+- Config changes:
+  - no required config changes
+- Docs updated:
+  - `docs/releases/v0.4.6.md`
+- Upgrade steps:
+  - no migration required
+  - if you use snapshot rollback, explicitly delete newer child snapshots before retrying rollback
+
 ### Version `0.4.5`
 
 - Release date: 2026-05-01

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": "0.4",
     "name": "proxmox-mcp-plus",
     "display_name": "ProxmoxMCP-Plus",
-    "version": "0.4.5",
+    "version": "0.4.6",
     "description": "An enhanced MCP server for managing Proxmox virtualization platforms.",
     "long_description": "ProxmoxMCP-Plus is an enhanced Model Context Protocol (MCP) server that provides comprehensive tools for managing Proxmox virtualization environments, including VM lifecycle, container management, snapshot operations, and backup/restore capabilities.",
     "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "proxmox-mcp-plus"
-version = "0.4.5"
+version = "0.4.6"
 description = "Enhanced Proxmox MCP Server"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -18,13 +18,13 @@
     "url": "https://github.com/RekklesNA/ProxmoxMCP-Plus",
     "source": "github"
   },
-  "version": "0.4.5",
+  "version": "0.4.6",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "proxmox-mcp-plus",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="proxmox-mcp-plus",
-    version="0.4.5",
+    version="0.4.6",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     python_requires=">=3.11",

--- a/src/proxmox_mcp/__init__.py
+++ b/src/proxmox_mcp/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .server import ProxmoxMCPServer
 
-__version__ = "0.4.5"
+__version__ = "0.4.6"
 __all__ = ["ProxmoxMCPServer"]
 
 

--- a/src/proxmox_mcp/core/proxmox.py
+++ b/src/proxmox_mcp/core/proxmox.py
@@ -44,6 +44,7 @@ class ProxmoxManager:
             auth_config: Authentication configuration
         """
         self.logger = logging.getLogger("proxmox-mcp.proxmox")
+        self.api_tunnel_config = api_tunnel_config
         self.tunnel_manager = SSHTunnelManager(api_tunnel_config, ssh_config) if api_tunnel_config is not None else None
         if self.tunnel_manager is not None:
             self.tunnel_manager.ensure_tunnel()
@@ -67,9 +68,20 @@ class ProxmoxManager:
         Returns:
             Dictionary containing merged configuration ready for API initialization
         """
+        host = proxmox_config.host
+        port = proxmox_config.port
+        if self.api_tunnel_config is not None and getattr(self.api_tunnel_config, "enabled", False):
+            host = self.api_tunnel_config.local_host
+            port = self.api_tunnel_config.local_port
+            self.logger.info(
+                "Using local Proxmox API tunnel endpoint: %s:%s",
+                host,
+                port,
+            )
+
         return {
-            'host': proxmox_config.host,
-            'port': proxmox_config.port,
+            'host': host,
+            'port': port,
             'timeout': proxmox_config.timeout,
             'user': auth_config.user,
             'token_name': auth_config.token_name,

--- a/src/proxmox_mcp/core/ssh_tunnel.py
+++ b/src/proxmox_mcp/core/ssh_tunnel.py
@@ -9,7 +9,6 @@ import shlex
 import socket
 import subprocess
 import time
-from pathlib import Path
 from typing import Any
 
 

--- a/src/proxmox_mcp/services/jobs.py
+++ b/src/proxmox_mcp/services/jobs.py
@@ -152,6 +152,7 @@ class JobStore:
         limit: int = 100,
     ) -> list[dict[str, Any]]:
         with self._lock:
+            self._refresh_records_from_db()
             rows = list(self._jobs.values())
         rows.sort(key=lambda item: item.created_at, reverse=True)
         filtered: list[JobRecord] = []
@@ -164,10 +165,13 @@ class JobStore:
         return [item.as_dict() for item in filtered[:limit]]
 
     def get_job(self, job_id: str) -> dict[str, Any]:
-        return self._get_record(job_id).as_dict()
+        with self._lock:
+            self._refresh_records_from_db()
+            return self._get_record(job_id).as_dict()
 
     def poll_job(self, job_id: str) -> dict[str, Any]:
         with self._lock:
+            self._refresh_records_from_db()
             record = self._get_record(job_id)
             if not record.upid or not record.node:
                 record.add_audit("poll_skipped", reason="missing_upid_or_node")
@@ -182,6 +186,7 @@ class JobStore:
         status, last_error, completed_at = self._normalize_status(status_payload)
 
         with self._lock:
+            self._refresh_records_from_db()
             record = self._get_record(job_id)
             record.progress = progress
             record.status = status
@@ -199,6 +204,7 @@ class JobStore:
 
     def cancel_job(self, job_id: str) -> dict[str, Any]:
         with self._lock:
+            self._refresh_records_from_db()
             record = self._get_record(job_id)
             if not record.upid or not record.node:
                 raise JobConflictError(f"Job {job_id} has no task UPID to cancel")
@@ -212,6 +218,7 @@ class JobStore:
             self.proxmox.nodes(node).tasks(upid).status.stop.post()
 
         with self._lock:
+            self._refresh_records_from_db()
             record = self._get_record(job_id)
             record.status = "cancel_requested"
             record.add_audit("cancel_requested", upid=upid)
@@ -220,6 +227,7 @@ class JobStore:
 
     def retry_job(self, job_id: str) -> dict[str, Any]:
         with self._lock:
+            self._refresh_records_from_db()
             record = self._get_record(job_id)
             retry_factory = record.retry_factory
             retry_spec = dict(record.retry_spec or {})
@@ -239,6 +247,7 @@ class JobStore:
             new_upid = handler(params)
 
         with self._lock:
+            self._refresh_records_from_db()
             record = self._get_record(job_id)
             if record.upid:
                 record.previous_upids.append(record.upid)
@@ -289,36 +298,45 @@ class JobStore:
 
     def _load_records(self) -> None:
         with self._lock:
-            rows = self._conn.execute("SELECT * FROM jobs").fetchall()
-            for row in rows:
-                record = JobRecord(
-                    job_id=str(row["job_id"]),
-                    tool_name=str(row["tool_name"]),
-                    summary=str(row["summary"]),
-                    node=row["node"],
-                    upid=row["upid"],
-                    created_at=str(row["created_at"]),
-                    updated_at=str(row["updated_at"]),
-                    status=str(row["status"]),
-                    progress=row["progress"],
-                    attempts=int(row["attempts"]),
-                    retry_count=int(row["retry_count"]),
-                    last_error=row["last_error"],
-                    completed_at=row["completed_at"],
-                    result=json.loads(row["result_json"]) if row["result_json"] else None,
-                    metadata=json.loads(row["metadata_json"]) if row["metadata_json"] else {},
-                    previous_upids=json.loads(row["previous_upids_json"]) if row["previous_upids_json"] else [],
-                    audit_log=[
-                        JobAuditEvent(
-                            timestamp=item["timestamp"],
-                            event=item["event"],
-                            details=item.get("details", {}),
-                        )
-                        for item in (json.loads(row["audit_log_json"]) if row["audit_log_json"] else [])
-                    ],
-                    retry_spec=json.loads(row["retry_spec_json"]) if row["retry_spec_json"] else None,
-                )
-                self._jobs[record.job_id] = record
+            self._refresh_records_from_db()
+
+    def _refresh_records_from_db(self) -> None:
+        rows = self._conn.execute("SELECT * FROM jobs").fetchall()
+        refreshed: dict[str, JobRecord] = {}
+        for row in rows:
+            job_id = str(row["job_id"])
+            existing = self._jobs.get(job_id)
+            record = JobRecord(
+                job_id=job_id,
+                tool_name=str(row["tool_name"]),
+                summary=str(row["summary"]),
+                node=row["node"],
+                upid=row["upid"],
+                created_at=str(row["created_at"]),
+                updated_at=str(row["updated_at"]),
+                status=str(row["status"]),
+                progress=row["progress"],
+                attempts=int(row["attempts"]),
+                retry_count=int(row["retry_count"]),
+                last_error=row["last_error"],
+                completed_at=row["completed_at"],
+                result=json.loads(row["result_json"]) if row["result_json"] else None,
+                metadata=json.loads(row["metadata_json"]) if row["metadata_json"] else {},
+                previous_upids=json.loads(row["previous_upids_json"]) if row["previous_upids_json"] else [],
+                audit_log=[
+                    JobAuditEvent(
+                        timestamp=item["timestamp"],
+                        event=item["event"],
+                        details=item.get("details", {}),
+                    )
+                    for item in (json.loads(row["audit_log_json"]) if row["audit_log_json"] else [])
+                ],
+                retry_spec=json.loads(row["retry_spec_json"]) if row["retry_spec_json"] else None,
+                retry_factory=existing.retry_factory if existing is not None else None,
+                cancel_factory=existing.cancel_factory if existing is not None else None,
+            )
+            refreshed[record.job_id] = record
+        self._jobs = refreshed
 
     def _save_record(self, record: JobRecord) -> None:
         self._conn.execute(

--- a/src/proxmox_mcp/tools/containers.py
+++ b/src/proxmox_mcp/tools/containers.py
@@ -671,6 +671,10 @@ class ContainerTools(ProxmoxTool):
 
             # Create the container
             result = self.proxmox.nodes(node).lxc.create(**ct_config)
+            secret_fields = {"password", "ssh-public-keys"}
+            retry_spec = None
+            if not secret_fields.intersection(ct_config):
+                retry_spec = {"kind": "ct.create", "params": {"node": node, "ct_config": dict(ct_config)}}
 
             def retry_factory() -> Any:
                 return self.proxmox.nodes(node).lxc.create(**ct_config)
@@ -684,7 +688,7 @@ class ContainerTools(ProxmoxTool):
                 node=node,
                 upid=result,
                 metadata={"vmid": vmid, "hostname": hostname},
-                retry_spec={"kind": "ct.create", "params": {"node": node, "ct_config": ct_config}},
+                retry_spec=retry_spec,
                 retry_factory=retry_factory,
                 cancel_factory=cancel_factory,
             )

--- a/src/proxmox_mcp/tools/snapshots.py
+++ b/src/proxmox_mcp/tools/snapshots.py
@@ -248,7 +248,9 @@ class SnapshotTools(ProxmoxTool):
         """Rollback to a snapshot.
 
         WARNING: This will stop the VM/container and restore to the snapshot state!
-        NOTE: For ZFS storage, this will delete any snapshots newer than the target.
+        NOTE: For storage backends that require deleting newer child snapshots
+        first, this tool refuses to continue. Delete those snapshots explicitly
+        before retrying the rollback.
 
         Parameters:
             node: Host node name
@@ -261,31 +263,24 @@ class SnapshotTools(ProxmoxTool):
         """
         _ = approval_token
         try:
-            # For ZFS-based storage, we may need to delete newer snapshots first
-            # Get current snapshots to check if target is most recent
             if vm_type == "lxc":
                 snapshots = _as_list(self.proxmox.nodes(node).lxc(vmid).snapshot.get())
             else:
                 snapshots = _as_list(self.proxmox.nodes(node).qemu(vmid).snapshot.get())
 
-            # Find snapshots that are children of our target (newer snapshots)
-            # These need to be deleted for ZFS rollback to work
-            deleted_snaps = []
+            child_snaps = []
             for snap in snapshots:
                 parent = _get(snap, "parent", "")
                 snap_name = _get(snap, "name", "")
                 if snap_name != "current" and parent == snapname:
-                    # This snapshot is a child of our target, delete it
-                    try:
-                        if vm_type == "lxc":
-                            self.proxmox.nodes(node).lxc(vmid).snapshot(snap_name).delete()
-                        else:
-                            self.proxmox.nodes(node).qemu(vmid).snapshot(snap_name).delete()
-                        deleted_snaps.append(snap_name)
-                    except Exception:
-                        pass
+                    child_snaps.append(str(snap_name))
+            if child_snaps:
+                raise ValueError(
+                    "Refusing to rollback because snapshot "
+                    f"'{snapname}' has newer child snapshots: {', '.join(child_snaps)}. "
+                    "Delete those snapshots explicitly first, then retry rollback."
+                )
 
-            # Now perform the rollback
             if vm_type == "lxc":
                 result = self.proxmox.nodes(node).lxc(vmid).snapshot(snapname).rollback.post()
             else:
@@ -312,9 +307,6 @@ class SnapshotTools(ProxmoxTool):
                 f"  - {vm_type.upper()} ID: {vmid}",
                 f"  - Node: {node}",
             ]
-
-            if deleted_snaps:
-                lines.append(f"  - Deleted newer snapshots: {', '.join(deleted_snaps)}")
 
             lines.extend([
                 "",

--- a/src/proxmox_mcp/tools/storage.py
+++ b/src/proxmox_mcp/tools/storage.py
@@ -16,6 +16,18 @@ from typing import List
 from mcp.types import TextContent as Content
 from proxmox_mcp.tools.base import ProxmoxTool
 
+
+def _as_list(maybe):
+    """Return list; unwrap {'data': list}; else []."""
+    if isinstance(maybe, list):
+        return maybe
+    if isinstance(maybe, dict):
+        data = maybe.get("data")
+        if isinstance(data, list):
+            return data
+    return []
+
+
 class StorageTools(ProxmoxTool):
     """Tools for managing Proxmox storage.
     
@@ -28,6 +40,57 @@ class StorageTools(ProxmoxTool):
     Implements fallback mechanisms for scenarios where detailed
     storage information might be temporarily unavailable.
     """
+
+    def _node_names(self) -> List[str]:
+        nodes = _as_list(self._call_with_retry("get nodes", lambda: self.proxmox.nodes.get()))
+        online = [
+            str(node["node"])
+            for node in nodes
+            if isinstance(node, dict) and node.get("node") and node.get("status") != "offline"
+        ]
+        if online:
+            return online
+        return [str(node["node"]) for node in nodes if isinstance(node, dict) and node.get("node")]
+
+    def _candidate_nodes_for_storage(self, store: dict, node_names: List[str]) -> List[str]:
+        raw_nodes = store.get("nodes")
+        if isinstance(raw_nodes, str) and raw_nodes.strip():
+            restricted = [item.strip() for item in raw_nodes.split(",") if item.strip()]
+        elif isinstance(raw_nodes, list):
+            restricted = [str(item) for item in raw_nodes if str(item).strip()]
+        else:
+            restricted = []
+
+        if restricted:
+            preferred = [node for node in node_names if node in set(restricted)]
+            return preferred or restricted
+        return list(node_names)
+
+    def _storage_status(self, store: dict, node_names: List[str]) -> dict | None:
+        storage_name = store.get("storage")
+        if not storage_name:
+            return None
+
+        last_error = None
+        for node_name in self._candidate_nodes_for_storage(store, node_names):
+            try:
+                return self.proxmox.nodes(node_name).storage(storage_name).status.get()
+            except Exception as error:
+                last_error = error
+                self.logger.debug(
+                    "Storage status lookup failed for %s on node %s: %s",
+                    storage_name,
+                    node_name,
+                    error,
+                )
+
+        if last_error is not None:
+            self.logger.warning(
+                "Using basic info for storage %s due to status error: %s",
+                storage_name,
+                last_error,
+            )
+        return None
 
     def get_storage(self) -> List[Content]:
         """List storage pools across the cluster with detailed status.
@@ -65,12 +128,12 @@ class StorageTools(ProxmoxTool):
 
         try:
             result = self._call_with_retry("get storage", lambda: self.proxmox.storage.get())
+            node_names = self._node_names()
             storage = []
             
             for store in result:
-                # Get detailed storage info including usage
-                try:
-                    status = self.proxmox.nodes(store.get("node", "localhost")).storage(store["storage"]).status.get()
+                status = self._storage_status(store, node_names)
+                if status is not None:
                     storage.append({
                         "storage": store["storage"],
                         "type": store["type"],
@@ -80,13 +143,7 @@ class StorageTools(ProxmoxTool):
                         "total": status.get("total", 0),
                         "available": status.get("avail", 0)
                     })
-                except Exception as store_error:
-                    self.logger.warning(
-                        "Using basic info for storage %s due to status error: %s",
-                        store.get("storage"),
-                        store_error,
-                    )
-                    # If detailed status fails, add basic info
+                else:
                     storage.append({
                         "storage": store["storage"],
                         "type": store["type"],

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import sqlite3
 from pathlib import Path
 from unittest.mock import Mock
 from unittest.mock import patch
@@ -10,6 +11,7 @@ import pytest
 
 from proxmox_mcp.services.jobs import JobConflictError, JobStore
 from proxmox_mcp.server import ProxmoxMCPServer
+from proxmox_mcp.tools.containers import ContainerTools
 
 
 @pytest.fixture
@@ -126,6 +128,27 @@ def test_job_store_persists_to_sqlite(tmp_path: Path):
     assert loaded["retry_spec"]["kind"] == "iso.delete"
 
 
+def test_job_store_refreshes_records_written_by_another_instance(tmp_path: Path):
+    proxmox = Mock()
+    db_path = tmp_path / "jobs.sqlite3"
+
+    reader = JobStore(proxmox, sqlite_path=str(db_path))
+    writer = JobStore(proxmox, sqlite_path=str(db_path))
+    created = writer.register_task(
+        tool_name="start_vm",
+        summary="Start VM",
+        node="pve",
+        upid="UPID:created-after-reader-started",
+        retry_spec={"kind": "vm.start", "params": {"node": "pve", "vmid": "101"}},
+    )
+
+    jobs = reader.list_jobs()
+    loaded = reader.get_job(created["job_id"])
+
+    assert [job["job_id"] for job in jobs] == [created["job_id"]]
+    assert loaded["upid"] == "UPID:created-after-reader-started"
+
+
 def test_job_store_retry_uses_persisted_retry_spec(tmp_path: Path):
     proxmox = Mock()
     proxmox.nodes.return_value.qemu.return_value.status.start.post.return_value = "UPID:retry-from-sqlite"
@@ -159,6 +182,36 @@ def test_job_store_retry_raises_conflict_without_recipe(tmp_path: Path):
 
     with pytest.raises(JobConflictError):
         store.retry_job(created["job_id"])
+
+
+def test_create_container_does_not_persist_secret_retry_spec(tmp_path: Path):
+    proxmox = Mock()
+    proxmox.nodes.get.return_value = [{"node": "node1", "status": "online"}]
+    proxmox.nodes.return_value.lxc.get.return_value = []
+    proxmox.storage.get.return_value = [{"storage": "local-lvm", "content": "rootdir"}]
+    proxmox.nodes.return_value.lxc.create.return_value = "UPID:ct-create-secret"
+
+    db_path = tmp_path / "jobs.sqlite3"
+    store = JobStore(proxmox, sqlite_path=str(db_path))
+    tools = ContainerTools(proxmox, job_store=store)
+
+    tools.create_container(
+        node="node1",
+        vmid="200",
+        ostemplate="local:vztmpl/alpine.tar.xz",
+        password="super-secret",
+        ssh_public_keys="ssh-ed25519 AAAA-secret-key",
+    )
+
+    persisted = sqlite3.connect(db_path).execute("SELECT retry_spec_json FROM jobs").fetchone()[0]
+    job = store.list_jobs()[0]
+
+    assert persisted is None
+    assert job["retry_spec"] is None
+    proxmox.nodes.return_value.lxc.create.assert_called_once()
+    create_kwargs = proxmox.nodes.return_value.lxc.create.call_args.kwargs
+    assert create_kwargs["password"] == "super-secret"
+    assert create_kwargs["ssh-public-keys"] == "ssh-ed25519 AAAA-secret-key"
 
 
 @pytest.mark.asyncio

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -104,6 +104,30 @@ def test_server_applies_configured_http_host_and_port(mock_proxmox, tmp_path):
     assert http_server.mcp.settings.port == 9000
 
 
+def test_server_uses_local_api_tunnel_endpoint(mock_proxmox, tmp_path):
+    """API tunnel config should redirect ProxmoxAPI to the local forward."""
+    config_path = tmp_path / "config_tunnel.json"
+    config_path.write_text(json.dumps({
+        "proxmox": {"host": "remote.proxmox.test", "port": 8006, "verify_ssl": True, "service": "PVE"},
+        "api_tunnel": {
+            "enabled": True,
+            "ssh_host": "jump-host",
+            "local_host": "127.0.0.1",
+            "local_port": 18006,
+            "remote_host": "10.0.0.10",
+            "remote_port": 8006,
+        },
+        "auth": {"user": "test@pve", "token_name": "test_token", "token_value": "test_value"},
+        "logging": {"level": "INFO"},
+    }))
+
+    with patch("proxmox_mcp.core.ssh_tunnel.SSHTunnelManager.ensure_tunnel"):
+        ProxmoxMCPServer(str(config_path))
+
+    assert mock_proxmox.call_args.kwargs["host"] == "127.0.0.1"
+    assert mock_proxmox.call_args.kwargs["port"] == 18006
+
+
 def test_loader_blocks_insecure_tls_in_prod(tmp_path):
     config_path = tmp_path / "config_insecure.json"
     config_path.write_text(json.dumps({
@@ -443,6 +467,39 @@ async def test_get_storage(server, mock_proxmox):
     assert "local" in text
     assert "ceph" in text
 
+
+@pytest.mark.asyncio
+async def test_get_storage_uses_real_online_node(server, mock_proxmox):
+    """Storage status should be queried through an actual node, not localhost."""
+    proxmox = mock_proxmox.return_value
+    proxmox.storage.get.return_value = [
+        {"storage": "local", "type": "dir", "content": "iso,backup"},
+    ]
+    proxmox.nodes.get.return_value = [{"node": "node1", "status": "online"}]
+
+    node_api = Mock()
+    node_api.storage.return_value.status.get.return_value = {
+        "used": 1024,
+        "total": 4096,
+        "avail": 3072,
+    }
+    queried_nodes = []
+
+    def nodes_side_effect(node_name=None):
+        queried_nodes.append(node_name)
+        return node_api
+
+    proxmox.nodes.side_effect = nodes_side_effect
+
+    response = await server.mcp.call_tool("get_storage", {})
+    text = response[0].text
+
+    assert queried_nodes == ["node1"]
+    assert "localhost" not in queried_nodes
+    assert "local" in text
+    assert "4.00 KB" in text
+
+
 @pytest.mark.asyncio
 async def test_list_isos_skips_offline_node(server, mock_proxmox):
     """Test list_isos skips nodes that error."""
@@ -679,6 +736,26 @@ async def test_clone_vm(server, mock_proxmox):
 
     assert "clone initiated successfully" in response[0].text
     source_vm_api.clone.post.assert_called_once_with(newid=9100, full=1, name="cloned-vm")
+
+
+@pytest.mark.asyncio
+async def test_rollback_snapshot_refuses_to_delete_child_snapshots(server, mock_proxmox):
+    """Rollback must not implicitly delete newer child snapshots."""
+    snapshot_api = mock_proxmox.return_value.nodes.return_value.qemu.return_value.snapshot
+    snapshot_api.get.return_value = [
+        {"name": "base"},
+        {"name": "after-base", "parent": "base"},
+        {"name": "current", "parent": "after-base"},
+    ]
+
+    with pytest.raises(ToolError, match="newer child snapshots"):
+        await server.mcp.call_tool(
+            "rollback_snapshot",
+            {"node": "node1", "vmid": "100", "snapname": "base", "vm_type": "qemu"},
+        )
+
+    snapshot_api.return_value.delete.assert_not_called()
+    snapshot_api.return_value.rollback.post.assert_not_called()
 
 
 


### PR DESCRIPTION
## Summary

Release 0.4.6 with reliability and safety fixes for ProxmoxMCP-Plus.

## Changes

- Route Proxmox API calls through the configured local API tunnel endpoint when `api_tunnel.enabled=true`.
- Refresh SQLite-backed jobs before reads and job controls so OpenAPI `/jobs` sees jobs created by the MCP subprocess.
- Avoid persisting LXC creation secrets in retry specs when passwords or SSH public keys are provided.
- Refuse snapshot rollback when newer child snapshots exist instead of deleting them implicitly.
- Query storage status through real Proxmox nodes instead of a fake `localhost` node.
- Bump package and manifest metadata to `0.4.6` and add release notes.

## Validation

- `python -m pytest -q`
- `python -m ruff check .`
- `$env:MYPYPATH='src'; python -m mypy --explicit-package-bases src tests main.py`
- `python -m build`