### PR TITLE
Release 0.4.7 streamable HTTP Docker mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,11 @@ RUN useradd --create-home --shell /usr/sbin/nologin proxmoxmcp \
 
 USER proxmoxmcp
 
-EXPOSE 8811
+EXPOSE 8811 8000
 
 ENV PROXMOX_MCP_CONFIG="/app/proxmox-config/config.json"
+ENV PROXMOX_MCP_MODE="openapi"
 ENV API_HOST="0.0.0.0"
 ENV API_PORT="8811"
 
-CMD ["python", "-m", "proxmox_mcp.openapi_proxy", "--host", "0.0.0.0", "--port", "8811", "--", \
-     "python", "-m", "proxmox_mcp.server"]
+CMD ["python", "-m", "proxmox_mcp.docker_entrypoint"]

--- a/README.md
+++ b/README.md
@@ -112,11 +112,27 @@ proxmox-mcp-plus
 
 #### Docker / GHCR
 
+OpenAPI mode remains the default Docker runtime:
+
 ```bash
 docker run --rm -p 8811:8811 \
   -v "$(pwd)/proxmox-config/config.json:/app/proxmox-config/config.json:ro" \
   ghcr.io/rekklesna/proxmoxmcp-plus:latest
 ```
+
+Native MCP Streamable HTTP mode is available from the same image:
+
+```bash
+docker run --rm -p 8000:8000 \
+  -e PROXMOX_MCP_MODE=mcp-http \
+  -e MCP_HOST=0.0.0.0 \
+  -e MCP_PORT=8000 \
+  -e MCP_TRANSPORT=STREAMABLE_HTTP \
+  -v "$(pwd)/proxmox-config/config.json:/app/proxmox-config/config.json:ro" \
+  ghcr.io/rekklesna/proxmoxmcp-plus:latest
+```
+
+Point MCP clients that support Streamable HTTP at `http://<docker-host>:8000/mcp`.
 
 #### Source
 
@@ -136,7 +152,21 @@ curl -f http://localhost:8811/health
 curl http://localhost:8811/openapi.json
 ```
 
-### 4. Point an MCP client at the server
+### 4. Run the native MCP Streamable HTTP surface
+
+```bash
+docker compose --profile mcp-http up -d proxmox-mcp-http
+```
+
+Connect a Streamable HTTP MCP client to:
+
+```text
+http://localhost:8000/mcp
+```
+
+The `8811` service is the OpenAPI/REST bridge. The `8000` service is the native MCP HTTP endpoint.
+
+### 5. Point a stdio MCP client at the server
 
 Minimal MCP client shape:
 
@@ -183,6 +213,7 @@ Supported workflow areas:
 | MCP job control tools (`list_jobs`, `get_job`, `poll_job`, `cancel_job`, `retry_job`) | Available |
 | OpenAPI `/jobs` endpoints with explicit status codes | Available |
 | Local OpenAPI `/health` and schema | Available |
+| Docker native MCP Streamable HTTP at `/mcp` | Available |
 | Docker image build and `/health` | Available |
 
 Validation and contract entry points in this repository:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,24 @@ services:
     networks:
       - proxmox-network
 
+  proxmox-mcp-http:
+    build: .
+    profiles:
+      - mcp-http
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./proxmox-config:/app/proxmox-config:ro
+    environment:
+      - PROXMOX_MCP_CONFIG=/app/proxmox-config/config.json
+      - PROXMOX_MCP_MODE=mcp-http
+      - MCP_HOST=0.0.0.0
+      - MCP_PORT=8000
+      - MCP_TRANSPORT=STREAMABLE_HTTP
+    restart: unless-stopped
+    networks:
+      - proxmox-network
+
 networks:
   proxmox-network:
     driver: bridge 

--- a/docs/releases/v0.4.7.md
+++ b/docs/releases/v0.4.7.md
@@ -1,0 +1,42 @@
+# ProxmoxMCP-Plus v0.4.7
+
+This release adds a Docker-native MCP Streamable HTTP runtime for remote MCP clients.
+
+## What Changed
+
+- Added `proxmox_mcp.docker_entrypoint`, a Docker runtime selector that keeps OpenAPI mode as the default and adds native MCP HTTP mode.
+- Added `PROXMOX_MCP_MODE=mcp-http` for running the server directly as Streamable HTTP.
+- Added a Docker Compose `mcp-http` profile that exposes `http://<host>:8000/mcp`.
+- Added `MCP_HOST`, `MCP_PORT`, and `MCP_TRANSPORT` overrides for mounted config files so Docker users do not need to edit `config.json` just to switch transport.
+- Updated README and wiki docs to distinguish OpenAPI HTTP on `8811` from native MCP Streamable HTTP on `8000`.
+
+## Usage
+
+OpenAPI mode remains the default:
+
+```bash
+docker compose up -d
+```
+
+Native MCP Streamable HTTP mode:
+
+```bash
+docker compose --profile mcp-http up -d proxmox-mcp-http
+```
+
+Connect Streamable HTTP MCP clients to:
+
+```text
+http://<docker-host>:8000/mcp
+```
+
+## Notes
+
+- Port `8811` is the OpenAPI/REST bridge.
+- Port `8000` with `/mcp` is the native MCP Streamable HTTP endpoint.
+- Bind native MCP HTTP only on trusted networks or behind your own access control.
+
+## Validation
+
+- Added tests for Docker runtime command selection.
+- Added tests for MCP environment overrides over mounted config files.

--- a/docs/wiki/API & Tool Reference.md
+++ b/docs/wiki/API & Tool Reference.md
@@ -1,6 +1,6 @@
 # API & Tool Reference
 
-This page is the reference index for the ProxmoxMCP-Plus tool surface and the OpenAPI wrapper that exposes it over HTTP.
+This page is the reference index for the ProxmoxMCP-Plus tool surface, the native MCP Streamable HTTP endpoint, and the OpenAPI wrapper that exposes tools as REST-style HTTP routes.
 
 Use this page when you need exact tool names, input shapes, prerequisites, or common failure patterns. Use the [Operator Guide](Operator-Guide) for deployment and runtime setup, and the [Security Guide](Security-Guide) for policy and access controls.
 
@@ -9,7 +9,18 @@ Use this page when you need exact tool names, input shapes, prerequisites, or co
 - `Read-only` tools inspect Proxmox state and should be your first call when validating reachability or inventory.
 - `Mutating` tools create, start, stop, change, restore, or delete infrastructure.
 - Tool availability depends on runtime configuration. In particular, some command-execution tools are only registered when `ssh` config is present.
-- HTTP mode is a bridge over the same MCP tool surface. The generated schema at `/openapi.json` is the source of truth for the exact request and response shape exposed by the running server.
+- MCP Streamable HTTP mode exposes the native MCP endpoint at `/mcp`.
+- OpenAPI mode is a bridge over the same MCP tool surface. The generated schema at `/openapi.json` is the source of truth for the exact request and response shape exposed by the running server.
+
+## Native MCP Streamable HTTP Endpoint
+
+When `mcp.transport` is `STREAMABLE_HTTP` or `STREAMABLE`, the server exposes the MCP endpoint at:
+
+| Path | Purpose | Notes |
+| --- | --- | --- |
+| `/mcp` | MCP Streamable HTTP endpoint | use this for remote MCP clients that support Streamable HTTP |
+
+The Docker Compose `mcp-http` profile exposes this endpoint on port `8000`.
 
 ## OpenAPI Service Endpoints
 

--- a/docs/wiki/Integrations Guide.md
+++ b/docs/wiki/Integrations Guide.md
@@ -5,9 +5,10 @@ This guide covers the main ways to connect clients and platforms to ProxmoxMCP-P
 ## Integration Patterns
 
 - `Direct MCP`: a client launches the server locally and talks over stdio
+- `Native MCP HTTP`: a client connects to the Streamable HTTP MCP endpoint at `/mcp`
 - `HTTP/OpenAPI`: a client talks to the FastAPI proxy over HTTP
 
-Use direct MCP when the client already supports MCP. Use OpenAPI when the client only understands HTTP or Swagger-style APIs.
+Use direct MCP when the client launches local stdio servers. Use native MCP HTTP when the client supports Streamable HTTP and the server runs elsewhere, such as Docker on another host. Use OpenAPI when the client only understands HTTP or Swagger-style APIs.
 
 ## Claude Desktop
 
@@ -47,6 +48,22 @@ Typical requirements:
 - Python environment with project dependencies installed
 - `PYTHONPATH` pointing to `src` when running from source
 - `PROXMOX_MCP_CONFIG` or equivalent environment variables
+
+## Streamable HTTP MCP Clients
+
+For remote MCP clients, run the native MCP HTTP Docker mode:
+
+```bash
+docker compose --profile mcp-http up -d proxmox-mcp-http
+```
+
+Then connect the client to:
+
+```text
+http://<docker-host>:8000/mcp
+```
+
+The default OpenAPI service on port `8811` is not an MCP Streamable HTTP endpoint; MCP HTTP clients should use `/mcp` on the native MCP service.
 
 ## OpenAPI Clients
 

--- a/docs/wiki/Operator Guide.md
+++ b/docs/wiki/Operator Guide.md
@@ -7,6 +7,7 @@ This guide covers how to configure, run, and operate ProxmoxMCP-Plus.
 ProxmoxMCP-Plus can be used in two main ways:
 
 - `MCP stdio mode`: assistants launch the server directly and call tools over MCP
+- `MCP Streamable HTTP mode`: the server exposes a native MCP endpoint at `/mcp`
 - `OpenAPI mode`: FastAPI wraps the MCP server and exposes HTTP endpoints for other clients
 
 The core tool set is the same in both modes. The difference is only the transport.
@@ -76,6 +77,22 @@ python main.py
 
 If startup succeeds, the server stays attached to stdio and waits for MCP clients.
 
+## Native MCP Streamable HTTP Mode
+
+Set the MCP transport to `STREAMABLE_HTTP` and bind to an address reachable by the client:
+
+```bash
+MCP_HOST=0.0.0.0 MCP_PORT=8000 MCP_TRANSPORT=STREAMABLE_HTTP python -m proxmox_mcp.server
+```
+
+The MCP endpoint is:
+
+```text
+http://<host>:8000/mcp
+```
+
+This is the correct target for MCP clients that support Streamable HTTP. It is separate from the OpenAPI service on port `8811`.
+
 ## OpenAPI Mode
 
 You can run the OpenAPI wrapper directly:
@@ -102,6 +119,7 @@ Default Compose behavior:
 - Builds the local image
 - Mounts `./proxmox-config` read-only into `/app/proxmox-config`
 - Exposes `8811`
+- Keeps OpenAPI mode as the default Docker runtime
 - Sets `PROXMOX_MCP_CONFIG=/app/proxmox-config/config.json`
 - Adds a container health check against `http://localhost:8811/health`
 
@@ -109,6 +127,26 @@ Start it with:
 
 ```bash
 docker compose up -d --build
+```
+
+To run the native MCP Streamable HTTP service from Docker Compose:
+
+```bash
+docker compose --profile mcp-http up -d proxmox-mcp-http
+```
+
+Then connect Streamable HTTP MCP clients to `http://<docker-host>:8000/mcp`.
+
+The same image can also be run directly:
+
+```bash
+docker run --rm -p 8000:8000 \
+  -e PROXMOX_MCP_MODE=mcp-http \
+  -e MCP_HOST=0.0.0.0 \
+  -e MCP_PORT=8000 \
+  -e MCP_TRANSPORT=STREAMABLE_HTTP \
+  -v "$(pwd)/proxmox-config/config.json:/app/proxmox-config/config.json:ro" \
+  ghcr.io/rekklesna/proxmoxmcp-plus:latest
 ```
 
 ## Operating Checklist

--- a/docs/wiki/Release & Upgrade Notes.md
+++ b/docs/wiki/Release & Upgrade Notes.md
@@ -18,6 +18,29 @@ Use this page to track version-level behavior changes, upgrade steps, and rollba
 
 ## Release History
 
+### Version `0.4.7`
+
+- Release date: 2026-05-08
+- Summary: adds a Docker-native MCP Streamable HTTP runtime so remote MCP clients can connect to `/mcp` without going through the OpenAPI bridge.
+- New tools or endpoints:
+  - Docker Compose profile `mcp-http` exposes native MCP Streamable HTTP at `http://<host>:8000/mcp`
+- Changed behavior:
+  - the Docker image now starts through `proxmox_mcp.docker_entrypoint`
+  - OpenAPI mode remains the default Docker runtime on port `8811`
+  - `MCP_HOST`, `MCP_PORT`, and `MCP_TRANSPORT` can override the `mcp` section from a mounted config file
+- Config changes:
+  - optional `PROXMOX_MCP_MODE=mcp-http` selects native MCP HTTP mode in Docker
+- Docs updated:
+  - `README.md`
+  - `docs/releases/v0.4.7.md`
+  - `docs/wiki/API & Tool Reference.md`
+  - `docs/wiki/Integrations Guide.md`
+  - `docs/wiki/Operator Guide.md`
+- Upgrade steps:
+  - no migration required
+  - continue using the default Docker mode for OpenAPI clients
+  - use `docker compose --profile mcp-http up -d proxmox-mcp-http` for Streamable HTTP MCP clients
+
 ### Version `0.4.6`
 
 - Release date: 2026-05-02

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": "0.4",
     "name": "proxmox-mcp-plus",
     "display_name": "ProxmoxMCP-Plus",
-    "version": "0.4.6",
+    "version": "0.4.7",
     "description": "An enhanced MCP server for managing Proxmox virtualization platforms.",
     "long_description": "ProxmoxMCP-Plus is an enhanced Model Context Protocol (MCP) server that provides comprehensive tools for managing Proxmox virtualization environments, including VM lifecycle, container management, snapshot operations, and backup/restore capabilities.",
     "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "proxmox-mcp-plus"
-version = "0.4.6"
+version = "0.4.7"
 description = "Enhanced Proxmox MCP Server"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -18,13 +18,13 @@
     "url": "https://github.com/RekklesNA/ProxmoxMCP-Plus",
     "source": "github"
   },
-  "version": "0.4.6",
+  "version": "0.4.7",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "proxmox-mcp-plus",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="proxmox-mcp-plus",
-    version="0.4.6",
+    version="0.4.7",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     python_requires=">=3.11",

--- a/src/proxmox_mcp/config/loader.py
+++ b/src/proxmox_mcp/config/loader.py
@@ -15,6 +15,31 @@ import os
 from typing import Any, Dict, Optional
 from proxmox_mcp.config.models import Config
 
+
+def _apply_mcp_env_overrides(config_data: Dict[str, Any]) -> None:
+    """Allow deployment-specific MCP transport settings to override file config."""
+    env_map = {
+        "MCP_HOST": ("host", str),
+        "MCP_PORT": ("port", int),
+        "MCP_TRANSPORT": ("transport", str),
+    }
+    overrides = {
+        key: (coerce(os.environ[env_name]) if coerce is not str else os.environ[env_name])
+        for env_name, (key, coerce) in env_map.items()
+        if env_name in os.environ
+    }
+    if not overrides:
+        return
+
+    mcp_config = config_data.setdefault("mcp", {})
+    if not isinstance(mcp_config, dict):
+        raise ValueError("mcp config must be a JSON object when MCP_* overrides are used")
+
+    if "transport" in overrides and isinstance(overrides["transport"], str):
+        overrides["transport"] = overrides["transport"].strip().upper()
+    mcp_config.update(overrides)
+
+
 def load_config(config_path: Optional[str] = None) -> Config:
     """Load and validate configuration from JSON file.
 
@@ -112,10 +137,6 @@ def load_config(config_path: Optional[str] = None) -> Config:
             },
         }
         
-        # Handle the internal "STREAMABLE" vs "STREAMABLE_HTTP" naming
-        mcp_config = config_data.get("mcp")
-        if isinstance(mcp_config, dict) and mcp_config.get("transport") == "STREAMABLE_HTTP":
-            mcp_config["transport"] = "STREAMABLE"
         api_tunnel_config = config_data.get("api_tunnel")
         if isinstance(api_tunnel_config, dict) and not api_tunnel_config.get("ssh_host"):
             config_data.pop("api_tunnel", None)
@@ -129,6 +150,8 @@ def load_config(config_path: Optional[str] = None) -> Config:
             raise ValueError(f"Invalid JSON in config file: {e}")
         except Exception as e:
             raise ValueError(f"Failed to load config: {e}")
+
+    _apply_mcp_env_overrides(config_data)
 
     # Final validation check
     if not config_data.get('proxmox', {}).get('host'):

--- a/src/proxmox_mcp/docker_entrypoint.py
+++ b/src/proxmox_mcp/docker_entrypoint.py
@@ -1,0 +1,51 @@
+"""Docker runtime selector for OpenAPI and native MCP HTTP modes."""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import MutableMapping
+
+
+OPENAPI_MODES = {"openapi", "api", "rest"}
+MCP_HTTP_MODES = {"mcp-http", "streamable-http", "streamable", "mcp"}
+
+
+def build_command(mode: str | None = None, environ: MutableMapping[str, str] | None = None) -> list[str]:
+    env = environ if environ is not None else os.environ
+    selected_mode = (mode or env.get("PROXMOX_MCP_MODE", "openapi")).strip().lower()
+
+    if selected_mode in OPENAPI_MODES:
+        host = env.get("API_HOST", "0.0.0.0")
+        port = env.get("API_PORT", "8811")
+        return [
+            sys.executable,
+            "-m",
+            "proxmox_mcp.openapi_proxy",
+            "--host",
+            host,
+            "--port",
+            port,
+            "--",
+            sys.executable,
+            "-m",
+            "proxmox_mcp.server",
+        ]
+
+    if selected_mode in MCP_HTTP_MODES:
+        env.setdefault("MCP_HOST", "0.0.0.0")
+        env.setdefault("MCP_PORT", "8000")
+        env.setdefault("MCP_TRANSPORT", "STREAMABLE_HTTP")
+        return [sys.executable, "-m", "proxmox_mcp.server"]
+
+    valid_modes = ", ".join(sorted(OPENAPI_MODES | MCP_HTTP_MODES))
+    raise ValueError(f"Unsupported PROXMOX_MCP_MODE={selected_mode!r}. Expected one of: {valid_modes}")
+
+
+def main() -> None:
+    command = build_command()
+    os.execvp(command[0], command)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_docker_entrypoint.py
+++ b/tests/test_docker_entrypoint.py
@@ -1,0 +1,41 @@
+import sys
+
+import pytest
+
+from proxmox_mcp.docker_entrypoint import build_command
+
+
+def test_docker_entrypoint_defaults_to_openapi():
+    env = {"API_HOST": "127.0.0.1", "API_PORT": "8812"}
+
+    command = build_command(environ=env)
+
+    assert command == [
+        sys.executable,
+        "-m",
+        "proxmox_mcp.openapi_proxy",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "8812",
+        "--",
+        sys.executable,
+        "-m",
+        "proxmox_mcp.server",
+    ]
+
+
+def test_docker_entrypoint_mcp_http_sets_streamable_defaults():
+    env = {}
+
+    command = build_command("mcp-http", environ=env)
+
+    assert command == [sys.executable, "-m", "proxmox_mcp.server"]
+    assert env["MCP_HOST"] == "0.0.0.0"
+    assert env["MCP_PORT"] == "8000"
+    assert env["MCP_TRANSPORT"] == "STREAMABLE_HTTP"
+
+
+def test_docker_entrypoint_rejects_unknown_mode():
+    with pytest.raises(ValueError, match="Unsupported PROXMOX_MCP_MODE"):
+        build_command("unknown", environ={})

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -104,6 +104,26 @@ def test_server_applies_configured_http_host_and_port(mock_proxmox, tmp_path):
     assert http_server.mcp.settings.port == 9000
 
 
+def test_mcp_env_overrides_file_transport_for_docker(tmp_path, monkeypatch):
+    """Docker can select native MCP HTTP without editing a mounted config file."""
+    config_path = tmp_path / "config_stdio.json"
+    config_path.write_text(json.dumps({
+        "proxmox": {"host": "test.proxmox.com", "port": 8006, "verify_ssl": True, "service": "PVE"},
+        "auth": {"user": "test@pve", "token_name": "test_token", "token_value": "test_value"},
+        "logging": {"level": "INFO"},
+        "mcp": {"host": "127.0.0.1", "port": 8000, "transport": "STDIO"},
+    }))
+    monkeypatch.setenv("MCP_HOST", "0.0.0.0")
+    monkeypatch.setenv("MCP_PORT", "9001")
+    monkeypatch.setenv("MCP_TRANSPORT", "STREAMABLE_HTTP")
+
+    config = load_config(str(config_path))
+
+    assert config.mcp.host == "0.0.0.0"
+    assert config.mcp.port == 9001
+    assert config.mcp.transport == "STREAMABLE"
+
+
 def test_server_uses_local_api_tunnel_endpoint(mock_proxmox, tmp_path):
     """API tunnel config should redirect ProxmoxAPI to the local forward."""
     config_path = tmp_path / "config_tunnel.json"


### PR DESCRIPTION
﻿## Summary

- add Docker `PROXMOX_MCP_MODE=mcp-http` for native MCP Streamable HTTP at `/mcp`
- keep the existing OpenAPI Docker runtime as the default on port 8811
- allow `MCP_HOST`, `MCP_PORT`, and `MCP_TRANSPORT` to override mounted config files for Docker deployments
- bump release metadata to v0.4.7 and document the new Docker MCP HTTP path

## Validation

- `python -m pytest -q` -> 77 passed, 1 skipped
- `python -m build` -> built sdist and wheel for 0.4.7
- `python -m twine check dist\*` -> passed
- Streamable HTTP probe against `/mcp` -> initialize returned HTTP 200

## Notes

Docker image build was attempted locally but Docker Desktop/daemon was not running on this machine, so local image build could not connect to the Docker API. The GitHub GHCR workflow should perform the container build after release publication.

Fixes #84.
