### PR TITLE
fix: tighten OpenAPI bind, SSH argv, and token comparison

### DIFF
--- a/scripts/start_openapi.sh
+++ b/scripts/start_openapi.sh
@@ -7,7 +7,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-HOST="${OPENAPI_HOST:-localhost}"
+# Bind to loopback by default. To expose the proxy on all interfaces, set
+# OPENAPI_HOST=0.0.0.0 explicitly. Using 127.0.0.1 (rather than "localhost")
+# avoids surprises from /etc/hosts or IPv6 resolution differences.
+HOST="${OPENAPI_HOST:-127.0.0.1}"
 PORT="${OPENAPI_PORT:-8811}"
 VENV_DIR="${REPO_ROOT}/.venv"
 CONFIG_FILE="${REPO_ROOT}/proxmox-config/config.json"
@@ -42,5 +45,5 @@ echo
 export PROXMOX_MCP_CONFIG="${CONFIG_FILE}"
 
 cd "${REPO_ROOT}"
-python -m proxmox_mcp.openapi_proxy --host 0.0.0.0 --port "${PORT}" -- \
+python -m proxmox_mcp.openapi_proxy --host "${HOST}" --port "${PORT}" -- \
   /bin/bash -c "cd '${REPO_ROOT}' && source '${VENV_DIR}/bin/activate' && python -c 'from proxmox_mcp.server import main; main()'"

--- a/src/proxmox_mcp/security/command_policy.py
+++ b/src/proxmox_mcp/security/command_policy.py
@@ -2,11 +2,19 @@
 
 from __future__ import annotations
 
+import hmac
 import re
 from dataclasses import dataclass
 from typing import Iterable, Pattern
 
 from proxmox_mcp.config.models import CommandPolicyConfig
+
+
+def _tokens_match(provided: str | None, expected: str | None) -> bool:
+    """Constant-time comparison guarded against None/non-str inputs."""
+    if not provided or not expected:
+        return False
+    return hmac.compare_digest(provided, expected)
 
 
 @dataclass(frozen=True)
@@ -62,7 +70,7 @@ class CommandPolicyGate:
                     "CMD_POLICY_APPROVAL_NOT_CONFIGURED",
                     "Approval token required but not configured on server",
                 )
-            if approval_token != self.config.approval_token:
+            if not _tokens_match(approval_token, self.config.approval_token):
                 return CommandPolicyDecision(
                     False,
                     "CMD_POLICY_APPROVAL_REQUIRED",
@@ -99,7 +107,7 @@ class CommandPolicyGate:
                     "OP_POLICY_APPROVAL_NOT_CONFIGURED",
                     "High-risk approval token required but not configured on server",
                 )
-            if approval_token != expected_token:
+            if not _tokens_match(approval_token, expected_token):
                 return CommandPolicyDecision(
                     False,
                     "OP_POLICY_APPROVAL_REQUIRED",

--- a/src/proxmox_mcp/tools/console/container_manager.py
+++ b/src/proxmox_mcp/tools/console/container_manager.py
@@ -37,7 +37,10 @@ class ContainerConsoleManager:
             ssh_cmd.extend(["-i", os.path.expanduser(key_file)])
         if getattr(self.ssh_cfg, "port", None):
             ssh_cmd.extend(["-p", str(self.ssh_cfg.port)])
-        ssh_cmd.extend([target, cmd])
+        # `--` ends OpenSSH option processing so a target accidentally starting
+        # with "-" (e.g. a misconfigured host_overrides value) cannot be
+        # reinterpreted as a flag like -oProxyCommand=...
+        ssh_cmd.extend(["--", target, cmd])
 
         self.logger.debug("Executing via OpenSSH client: %s", " ".join(shlex.quote(p) for p in ssh_cmd))
         completed = subprocess.run(  # noqa: S603

--- a/tests/test_command_policy.py
+++ b/tests/test_command_policy.py
@@ -1,0 +1,108 @@
+"""Tests for the command and high-risk operation policy gateway."""
+
+from __future__ import annotations
+
+import pytest
+
+from proxmox_mcp.config.models import CommandPolicyConfig
+from proxmox_mcp.security.command_policy import CommandPolicyGate
+
+
+def _gate(**overrides: object) -> CommandPolicyGate:
+    return CommandPolicyGate(CommandPolicyConfig(**overrides))
+
+
+def test_command_approval_token_match_allows():
+    gate = _gate(
+        mode="audit_only",
+        require_approval_token=True,
+        approval_token="s3cret-token",
+    )
+
+    decision = gate.evaluate("uname -a", approval_token="s3cret-token")
+
+    assert decision.allowed is True
+
+
+@pytest.mark.parametrize(
+    "supplied",
+    [
+        None,
+        "",
+        "wrong",
+        "s3cret-toke",   # prefix
+        "s3cret-token!", # suffix
+    ],
+)
+def test_command_approval_token_mismatch_denies(supplied):
+    gate = _gate(
+        mode="audit_only",
+        require_approval_token=True,
+        approval_token="s3cret-token",
+    )
+
+    decision = gate.evaluate("uname -a", approval_token=supplied)
+
+    assert decision.allowed is False
+    assert decision.code == "CMD_POLICY_APPROVAL_REQUIRED"
+
+
+def test_command_approval_token_not_configured_denies():
+    gate = _gate(
+        mode="audit_only",
+        require_approval_token=True,
+        approval_token=None,
+    )
+
+    decision = gate.evaluate("uname -a", approval_token="anything")
+
+    assert decision.allowed is False
+    assert decision.code == "CMD_POLICY_APPROVAL_NOT_CONFIGURED"
+
+
+def test_high_risk_operation_token_match_allows():
+    gate = _gate(
+        high_risk_mode="enforce",
+        high_risk_require_approval_token=True,
+        high_risk_approval_token="approve-me",
+    )
+
+    decision = gate.evaluate_operation("delete_vm", approval_token="approve-me")
+
+    assert decision.allowed is True
+
+
+@pytest.mark.parametrize(
+    "supplied",
+    [
+        None,
+        "",
+        "wrong",
+        "approve-m",
+        "approve-me ",
+    ],
+)
+def test_high_risk_operation_token_mismatch_denies(supplied):
+    gate = _gate(
+        high_risk_mode="enforce",
+        high_risk_require_approval_token=True,
+        high_risk_approval_token="approve-me",
+    )
+
+    decision = gate.evaluate_operation("delete_vm", approval_token=supplied)
+
+    assert decision.allowed is False
+    assert decision.code == "OP_POLICY_APPROVAL_REQUIRED"
+
+
+def test_high_risk_operation_falls_back_to_command_token():
+    """When high_risk_approval_token is None, the command-level approval_token applies."""
+    gate = _gate(
+        high_risk_mode="enforce",
+        approval_token="cmd-token",
+        high_risk_require_approval_token=True,
+        high_risk_approval_token=None,
+    )
+
+    assert gate.evaluate_operation("delete_vm", approval_token="cmd-token").allowed is True
+    assert gate.evaluate_operation("delete_vm", approval_token="other").allowed is False

--- a/tests/test_container_console.py
+++ b/tests/test_container_console.py
@@ -202,3 +202,24 @@ def test_execute_command_via_system_ssh(mock_run, manager, ssh_cfg):
     ssh_command = mock_run.call_args[0][0]
     assert ssh_command[-2] == "ahg1"
     assert "/usr/sbin/pct exec" in ssh_command[-1]
+    # The argv must include "--" before the target so OpenSSH cannot reinterpret
+    # a target beginning with "-" as an option flag.
+    assert ssh_command[-3] == "--"
+
+
+@patch("proxmox_mcp.tools.console.container_manager.subprocess.run")
+def test_system_ssh_uses_double_dash_for_dash_prefixed_target(mock_run, manager, ssh_cfg):
+    """A host_overrides value starting with '-' must not be parsed as an SSH option."""
+    ssh_cfg.prefer_ssh_client = True
+    # Worst-case attacker-controlled override: would be -oProxyCommand=... without `--`.
+    ssh_cfg.host_overrides = {"pve1": "-oProxyCommand=evil"}
+    mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+    manager.execute_command("pve1", "101", "echo ok")
+
+    ssh_command = mock_run.call_args[0][0]
+    # `--` must appear before the target so option processing has ended.
+    assert "--" in ssh_command
+    dash_index = ssh_command.index("--")
+    assert ssh_command[dash_index + 1] == "-oProxyCommand=evil"
+    assert "/usr/sbin/pct exec" in ssh_command[dash_index + 2]


### PR DESCRIPTION
## Summary

Three small hardening fixes to `main`:

1. `scripts/start_openapi.sh` ignored its own `OPENAPI_HOST` variable and hard-coded `--host 0.0.0.0`, so the script always exposed the proxy on every interface regardless of how the operator configured it.
2. `src/proxmox_mcp/security/command_policy.py` compared approval tokens with plain `!=`, which is timing-side-channelable; switch to `hmac.compare_digest`.
3. `src/proxmox_mcp/tools/console/container_manager.py` built the OpenSSH argv as `ssh ... <target> <cmd>` with no `--` separator, so a target whose value starts with `-` (e.g. via a misconfigured `host_overrides` entry) could be reinterpreted as an SSH option flag.

No public API changes. No new dependencies.

## Details

### `scripts/start_openapi.sh`

Before:

```bash
HOST="${OPENAPI_HOST:-localhost}"
...
echo "OpenAPI proxy address: http://${HOST}:${PORT}"
...
python -m proxmox_mcp.openapi_proxy --host 0.0.0.0 --port "${PORT}" -- ...
```

The `HOST` value was logged but the actual bind argument was hard-coded. After the change, `--host "${HOST}"` is used and the default flips from `localhost` to `127.0.0.1` (more explicit; `localhost` resolution can vary between IPv4 and IPv6 depending on `/etc/hosts` and `nsswitch`).

This is the most user-visible change in this PR. It is a behaviour fix that aligns the script with the documented behaviour of the `OPENAPI_HOST` variable. **Operators who relied on the old "always bind 0.0.0.0" behaviour need to set `OPENAPI_HOST=0.0.0.0` explicitly** — this is also documented in a new comment in the script header.

### `src/proxmox_mcp/security/command_policy.py`

Two sites used a plain `!=` against the configured approval token:

- Line ~65 in `evaluate(...)` — `approval_token != self.config.approval_token`
- Line ~102 in `evaluate_operation(...)` — `approval_token != expected_token`

Both now route through a small `_tokens_match` helper that:

- Returns `False` (denying) when either side is `None`/empty, preserving the existing `APPROVAL_NOT_CONFIGURED` / `APPROVAL_REQUIRED` error codes.
- Otherwise compares with `hmac.compare_digest`.

Adds `tests/test_command_policy.py` with parametrised match / mismatch / missing-token / fallback coverage for both `evaluate` and `evaluate_operation`.

### `src/proxmox_mcp/tools/console/container_manager.py`

`_execute_via_system_ssh` previously did:

```python
ssh_cmd.extend([target, cmd])
```

A target that starts with `-` (most plausibly via `ssh.host_overrides`, which is operator-configured but parsed as a free-form string) would be parsed by OpenSSH as an option, e.g. `-oProxyCommand=...`. The fix is to insert `--` so option processing has ended:

```python
ssh_cmd.extend(["--", target, cmd])
```

Paramiko code path is unaffected. Adds a regression test that injects `host_overrides = {"pve1": "-oProxyCommand=evil"}` and asserts `--` precedes the target in the constructed argv. The existing `test_execute_command_via_system_ssh` test continues to assert `ssh_command[-2] == "ahg1"` because the new `--` lives at `[-3]`.

### Note on the original 4th finding (README `verify_ssl: false`)

The internal review that surfaced this PR also called out a stale `"verify_ssl": false` example in `README.md`. On checking the tree, that example is already `verify_ssl: true` upstream (fixed in commit `dcb7f8e`, "security(ssh): enforce strict host key validation by default"), so no doc change is needed here.

## Validation

- `pytest -q` → **92 passed, 1 skipped** (baseline on `main` at `bc382c4` was 77 passed, 1 skipped — 15 new tests added, no pre-existing failures).
- `ruff check . --select E9,F63,F7,F82` → clean.
- `mypy src --ignore-missing-imports` → clean (no issues found in 45 files).

## Compatibility

- `start_openapi.sh` default bind changes from `0.0.0.0` to `127.0.0.1`. Operators relying on the old default need `OPENAPI_HOST=0.0.0.0`. This was the script's documented behaviour all along — the previous code was a bug.
- `hmac.compare_digest` switch is observationally equivalent on the happy and failure paths.
- `--` insertion only changes argv when the target is dash-prefixed (today: a misconfiguration); regular hostnames are unaffected.
