### PR TITLE
Prepare v0.4.9 reliability release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,11 @@ jobs:
 
     - name: Run tests
       run: |
-        pytest -q
+        pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=60
 
     - name: Ruff
       run: |
-        ruff check . --select E9,F63,F7,F82
+        ruff check .
 
     - name: Mypy
       run: |
@@ -49,7 +49,9 @@ jobs:
 
     - name: pip-audit
       run: |
-        pip-audit -r requirements.txt
+        # CVE-2026-44405 has no fixed Paramiko release on PyPI yet.
+        # Tracked in docs/security/paramiko-cve-2026-44405.md.
+        pip-audit -r requirements.txt --ignore-vuln CVE-2026-44405
 
     - name: Validate Manifest JSON
       run: |

--- a/README.md
+++ b/README.md
@@ -218,7 +218,10 @@ Supported workflow areas:
 
 Validation and contract entry points in this repository:
 
-- `pytest -q`
+- `pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=60`
+- `ruff check .`
+- `mypy src --ignore-missing-imports`
+- `pip-audit -r requirements.txt --ignore-vuln CVE-2026-44405`
 - `tests/integration/test_real_contract.py`
 - `tests/scripts/run_real_e2e.py`
 
@@ -331,11 +334,14 @@ Published wiki:
 ## Development Checks
 
 ```bash
-pytest -q
+pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=60
 ruff check .
-mypy src tests main.py tests/scripts/run_real_e2e.py
+mypy src --ignore-missing-imports
+pip-audit -r requirements.txt --ignore-vuln CVE-2026-44405
 python -m build
 ```
+
+The Paramiko audit exception is temporary. It is tracked in `docs/security/paramiko-cve-2026-44405.md` until a patched PyPI release is available.
 
 ## License
 

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -14,7 +14,10 @@ This release is aimed at LLM, AI agent, homelab, and self-hosted users who want 
 
 ## Validation
 
-- `pytest -q`
+- `pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=60`
+- `ruff check .`
+- `mypy src --ignore-missing-imports`
+- `pip-audit -r requirements.txt --ignore-vuln CVE-2026-44405`
 - `tests/integration/test_real_contract.py`
 - `tests/scripts/run_real_e2e.py`
 - `python -m build`

--- a/docs/releases/v0.4.8.md
+++ b/docs/releases/v0.4.8.md
@@ -1,0 +1,30 @@
+# ProxmoxMCP-Plus v0.4.8
+
+This release hardens production behavior for persistent jobs, OpenAPI job controls, inventory reads, metrics cardinality, and release quality gates.
+
+## What Changed
+
+- Hardened the SQLite-backed `JobStore` with WAL mode, busy timeout, schema migration tracking, indexes, SQL-side filtering/limits, and explicit connection close lifecycle.
+- Added policy checks to high-risk job retry paths in both MCP and OpenAPI, including approval-token enforcement.
+- Fixed VM guest-agent command execution to poll `exec-status` until the command exits and to report non-zero exits as failures.
+- Reduced large-cluster list overhead by using cluster resource inventory for VM and LXC list defaults, with expensive stats now opt-in for containers.
+- Changed OpenAPI Prometheus request labels to use route templates instead of raw request paths, avoiding high-cardinality `/jobs/{uuid}` series.
+- Registered `clone_vm` with the persistent job store, including a persisted `vm.clone` retry recipe and plain-text task/job output.
+- Widened Paramiko runtime support to `paramiko>=4.0.0,<5.0.0` so patched 4.x releases can be adopted without another upper-bound change.
+- Added a tracked temporary `pip-audit` exception for `CVE-2026-44405` while PyPI has no fixed Paramiko release.
+- Aligned CI and documentation around full `ruff check .`, `mypy src --ignore-missing-imports`, `pip-audit`, and a 60% coverage gate.
+
+## Upgrade Notes
+
+- `get_containers` now defaults `include_stats=false`; pass `include_stats=true` when per-container status/config/RRD detail is required.
+- `clone_vm` responses now include a stable `Job ID` in addition to the raw Proxmox task ID.
+- CI intentionally ignores only `CVE-2026-44405` until a fixed Paramiko release is available. Remove the exception once `pip-audit -r requirements.txt` passes cleanly.
+
+## Validation
+
+- `python -m pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=60`
+- `python -m ruff check .`
+- `python -m mypy src --ignore-missing-imports`
+- `python -m pip_audit -r requirements.txt --ignore-vuln CVE-2026-44405`
+- `python -m build`
+- `python -m twine check dist\*`

--- a/docs/releases/v0.4.8.md
+++ b/docs/releases/v0.4.8.md
@@ -1,5 +1,7 @@
 # ProxmoxMCP-Plus v0.4.8
 
+Superseded by v0.4.9.
+
 This release hardens production behavior for persistent jobs, OpenAPI job controls, inventory reads, metrics cardinality, and release quality gates.
 
 ## What Changed

--- a/docs/releases/v0.4.9.md
+++ b/docs/releases/v0.4.9.md
@@ -1,0 +1,31 @@
+# ProxmoxMCP-Plus v0.4.9
+
+This release supersedes v0.4.8 with the same production reliability work plus a CodeQL-blocking log-injection fix.
+
+## What Changed
+
+- Sanitized high-risk retry audit log values before writing them to logs, preventing forged log lines from job IDs or persisted tool names.
+- Kept the v0.4.8 reliability hardening:
+  - SQLite `JobStore` WAL, busy timeout, migration tracking, indexes, SQL filtering/limits, and explicit close lifecycle.
+  - Policy checks for high-risk job retries in MCP and OpenAPI.
+  - VM guest-agent command polling until `exec-status` exits, with non-zero exits reported as failures.
+  - Cluster resource inventory for VM and default LXC list calls.
+  - Route-template labels for OpenAPI Prometheus metrics.
+  - Persistent `clone_vm` JobStore registration and `vm.clone` retry recipe.
+  - Paramiko 4.x dependency support with a tracked temporary `CVE-2026-44405` audit exception.
+  - Aligned CI/docs quality gates.
+
+## Upgrade Notes
+
+- Prefer v0.4.9 over v0.4.8.
+- `get_containers` still defaults `include_stats=false`; pass `include_stats=true` when detailed per-container stats are required.
+- Remove the temporary Paramiko audit exception once a fixed PyPI release is available.
+
+## Validation
+
+- `python -m pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=60`
+- `python -m ruff check .`
+- `python -m mypy src --ignore-missing-imports`
+- `python -m pip_audit -r requirements.txt --ignore-vuln CVE-2026-44405`
+- `python -m build`
+- `python -m twine check dist\*`

--- a/docs/security/paramiko-cve-2026-44405.md
+++ b/docs/security/paramiko-cve-2026-44405.md
@@ -1,0 +1,20 @@
+# Paramiko CVE-2026-44405 Tracking
+
+Status as of 2026-05-09:
+
+- Ubuntu lists CVE-2026-44405 for Paramiko through 4.0.0 before commit `a448945`, in RSA/SHA-1 handling.
+- PyPI currently lists Paramiko 4.0.0 as the latest release.
+- `python -m pip_audit -r requirements.txt` resolves Paramiko 4.0.0 and still reports CVE-2026-44405 with no fixed version available.
+
+Repository action:
+
+- Runtime dependency constraints now allow Paramiko 4.x with `paramiko>=4.0.0,<5.0.0`, so the next patched 4.x release can be adopted without another upper-bound change.
+- CI temporarily ignores only `CVE-2026-44405` while no fixed PyPI release exists.
+- Remove `--ignore-vuln CVE-2026-44405` from CI and docs once a patched Paramiko release is published and `pip-audit -r requirements.txt` passes without the exception.
+- Paramiko 4 compatibility is covered by the regular unit, lint, type, audit, and build gates.
+
+References:
+
+- [Ubuntu CVE-2026-44405](https://ubuntu.com/security/CVE-2026-44405)
+- [Paramiko commit a448945](https://github.com/paramiko/paramiko/commit/a4489456b6f65281e172380cc4826cee5e851dbb)
+- [PyPI Paramiko](https://pypi.org/project/paramiko/)

--- a/docs/wiki/API & Tool Reference.md
+++ b/docs/wiki/API & Tool Reference.md
@@ -99,6 +99,7 @@ Selector-based tools fail when no container matches the selector or when a bulk 
 | --- | --- | --- | --- | --- | --- |
 | `get_vms` | Read-only | none | none | Proxmox API reachable | partial node-query failures may reduce returned coverage |
 | `create_vm` | Mutating | `node`, `vmid`, `name`, `cpus`, `memory`, `disk_size` | `storage`, `ostype`, `network_bridge` | target node exists and selected storage is valid | duplicate `vmid`, invalid storage, insufficient resources |
+| `clone_vm` | Mutating | `node`, `source_vmid`, `target_vmid` | `name`, `target_node`, `full=true`, `storage`, `pool`, `snapname` | source VM exists and target VM ID is free | duplicate target VM ID, clone permission failure, invalid storage or snapshot |
 | `start_vm` | Mutating | `node`, `vmid` | none | VM exists | VM not found, node mismatch |
 | `stop_vm` | Mutating | `node`, `vmid` | none | VM exists | VM not found, stop failure from Proxmox |
 | `shutdown_vm` | Mutating | `node`, `vmid` | none | VM exists | guest shutdown unavailable or timeout on guest side |
@@ -110,13 +111,13 @@ Selector-based tools fail when no container matches the selector or when a bulk 
 
 - `stop_vm` is the force-stop path. Use `shutdown_vm` for graceful guest shutdown when supported.
 - `execute_vm_command` is not a generic SSH shell. It is mediated through QEMU Guest Agent and command-policy checks.
-- `create_vm`, `start_vm`, `stop_vm`, `shutdown_vm`, `reset_vm`, and `delete_vm` register persistent jobs when they return asynchronous Proxmox tasks.
+- `create_vm`, `clone_vm`, `start_vm`, `stop_vm`, `shutdown_vm`, `reset_vm`, and `delete_vm` register persistent jobs when they return asynchronous Proxmox tasks.
 
 ## Container Tools
 
 | Tool | Mode | Required Inputs | Optional Inputs | Prerequisites | Common Failures |
 | --- | --- | --- | --- | --- | --- |
-| `get_containers` | Read-only | none | `node`, `include_stats=true`, `include_raw=false`, `format_style=pretty\|json`, legacy `payload` object | Proxmox API reachable | invalid payload shape, auth failure |
+| `get_containers` | Read-only | none | `node`, `include_stats=false`, `include_raw=false`, `format_style=pretty\|json`, legacy `payload` object | Proxmox API reachable | invalid payload shape, auth failure |
 | `start_container` | Mutating | `selector` | `format_style=pretty\|json` | selector resolves to one or more containers | no selector match, start failure from Proxmox |
 | `stop_container` | Mutating | `selector` | `graceful=true`, `timeout_seconds=10`, `format_style=pretty\|json` | selector resolves to one or more containers | no selector match, timeout on graceful shutdown, container already stopped |
 | `restart_container` | Mutating | `selector` | `timeout_seconds=10`, `format_style=pretty\|json` | selector resolves to one or more containers | no selector match, reboot failure |

--- a/docs/wiki/Developer Guide.md
+++ b/docs/wiki/Developer Guide.md
@@ -15,13 +15,17 @@ Set `proxmox-config/config.json` to a real environment or use a test config path
 ## Common Commands
 
 ```bash
-pytest
-ruff .
-mypy .
+pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=60
+ruff check .
+mypy src --ignore-missing-imports
+pip-audit -r requirements.txt --ignore-vuln CVE-2026-44405
 black .
 python main.py
 python -m proxmox_mcp.openapi_proxy --host 0.0.0.0 --port 8811 -- python main.py
 ```
+
+The coverage gate starts at 60% so CI tracks regressions while coverage is expanded around high-risk tools and the JobStore/OpenAPI boundary.
+The Paramiko audit exception is temporary and tracked in `docs/security/paramiko-cve-2026-44405.md`.
 
 ## Project Layout
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -57,7 +57,10 @@ The repository includes live-environment verification entry points for:
 
 Primary validation entry points:
 
-- `pytest -q`
+- `pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=60`
+- `ruff check .`
+- `mypy src --ignore-missing-imports`
+- `pip-audit -r requirements.txt --ignore-vuln CVE-2026-44405`
 - `tests/integration/test_real_contract.py`
 - `tests/scripts/run_real_e2e.py`
 

--- a/docs/wiki/Release & Upgrade Notes.md
+++ b/docs/wiki/Release & Upgrade Notes.md
@@ -18,6 +18,37 @@ Use this page to track version-level behavior changes, upgrade steps, and rollba
 
 ## Release History
 
+### Version `0.4.8`
+
+- Release date: 2026-05-09
+- Summary: production reliability and release-quality hardening for persistent jobs, inventory reads, OpenAPI job controls, metrics, Paramiko tracking, and `clone_vm`.
+- New tools or endpoints:
+  - no new tools
+- Changed behavior:
+  - `clone_vm` now registers persistent jobs and returns a stable Job ID
+  - high-risk job retries now pass through the same approval-token policy checks as direct tool execution
+  - VM guest-agent commands poll until exit and report non-zero exit codes as failures
+  - `get_vms` and default `get_containers` use cluster resource inventory to avoid large N+1 scans
+  - `get_containers` defaults `include_stats=false`; detailed per-container status/config/RRD remains opt-in
+  - OpenAPI metrics use route templates instead of raw paths for request labels
+  - `JobStore` SQLite uses WAL, busy timeout, migration tracking, indexes, SQL filtering/limits, and explicit close lifecycle
+- Config changes:
+  - no required config migration
+  - runtime dependency support now allows `paramiko>=4.0.0,<5.0.0`
+- Docs updated:
+  - `README.md`
+  - `docs/releases/v0.4.8.md`
+  - `docs/security/paramiko-cve-2026-44405.md`
+  - `docs/wiki/API & Tool Reference.md`
+  - `docs/wiki/Developer Guide.md`
+  - `docs/wiki/Home.md`
+  - `docs/wiki/Release & Upgrade Notes.md`
+- Upgrade steps:
+  - pass `include_stats=true` to `get_containers` if callers require detailed stats by default
+  - monitor Paramiko releases and remove the temporary `CVE-2026-44405` audit exception once a fixed PyPI release exists
+- Rollback notes:
+  - downgrade to `v0.4.7` if clients depend on default container stats, but keep the Paramiko CVE tracking in mind
+
 ### Version `0.4.7`
 
 - Release date: 2026-05-08
@@ -208,9 +239,10 @@ After upgrading:
 
 ## Suggested Release Checklist
 
-- run `pytest`
-- run `ruff .`
-- run `mypy .`
+- run `pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=60`
+- run `ruff check .`
+- run `mypy src --ignore-missing-imports`
+- run `pip-audit -r requirements.txt --ignore-vuln CVE-2026-44405`
 - build the package
 - confirm `README.md` and `docs/wiki/` reflect the released behavior
 - note any user-visible changes here

--- a/docs/wiki/Release & Upgrade Notes.md
+++ b/docs/wiki/Release & Upgrade Notes.md
@@ -18,6 +18,26 @@ Use this page to track version-level behavior changes, upgrade steps, and rollba
 
 ## Release History
 
+### Version `0.4.9`
+
+- Release date: 2026-05-09
+- Summary: supersedes `v0.4.8` with the same reliability hardening plus a CodeQL-blocking log-injection fix for high-risk retry audit logs.
+- New tools or endpoints:
+  - no new tools
+- Changed behavior:
+  - high-risk retry audit logs sanitize job IDs and persisted tool names before logging
+  - all `v0.4.8` production reliability changes are included
+- Config changes:
+  - no required config migration
+- Docs updated:
+  - `docs/releases/v0.4.9.md`
+  - `docs/wiki/Release & Upgrade Notes.md`
+- Upgrade steps:
+  - prefer `v0.4.9` over `v0.4.8`
+  - continue passing `include_stats=true` to `get_containers` if callers require detailed stats by default
+- Rollback notes:
+  - use `v0.4.7` rather than `v0.4.8` if rollback is required for the log-sanitization fix
+
 ### Version `0.4.8`
 
 - Release date: 2026-05-09

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": "0.4",
     "name": "proxmox-mcp-plus",
     "display_name": "ProxmoxMCP-Plus",
-    "version": "0.4.8",
+    "version": "0.4.9",
     "description": "An enhanced MCP server for managing Proxmox virtualization platforms.",
     "long_description": "ProxmoxMCP-Plus is an enhanced Model Context Protocol (MCP) server that provides comprehensive tools for managing Proxmox virtualization environments, including VM lifecycle, container management, snapshot operations, and backup/restore capabilities.",
     "author": {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": "0.4",
     "name": "proxmox-mcp-plus",
     "display_name": "ProxmoxMCP-Plus",
-    "version": "0.4.7",
+    "version": "0.4.8",
     "description": "An enhanced MCP server for managing Proxmox virtualization platforms.",
     "long_description": "ProxmoxMCP-Plus is an enhanced Model Context Protocol (MCP) server that provides comprehensive tools for managing Proxmox virtualization environments, including VM lifecycle, container management, snapshot operations, and backup/restore capabilities.",
     "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "proxmox-mcp-plus"
-version = "0.4.8"
+version = "0.4.9"
 description = "Enhanced Proxmox MCP Server"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "proxmox-mcp-plus"
-version = "0.4.7"
+version = "0.4.8"
 description = "Enhanced Proxmox MCP Server"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -27,7 +27,7 @@ dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.30.0",
     "mcpo>=0.0.17",
-    "paramiko>=3.0.0,<4.0.0",
+    "paramiko>=4.0.0,<5.0.0",
     "anyio>=4.0.0",
 ]
 
@@ -35,6 +35,7 @@ dependencies = [
 dev = [
     "pytest>=7.0.0,<8.0.0",
     "pytest-asyncio>=0.21.0,<0.22.0",
+    "pytest-cov>=4.1.0,<7.0.0",
     "black>=24.3.0,<27.0.0",
     "mypy>=1.0.0,<2.0.0",
     "ruff>=0.1.0,<0.2.0",

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -6,5 +6,5 @@ pydantic>=2.0.0,<3.0.0
 fastapi>=0.115.0
 uvicorn[standard]>=0.30.0
 mcpo>=0.0.17
-paramiko>=3.0.0,<4.0.0
+paramiko>=4.0.0,<5.0.0
 anyio>=4.0.0

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -4,6 +4,7 @@
 # Testing
 pytest>=7.0.0,<8.0.0
 pytest-asyncio>=0.21.0,<0.22.0
+pytest-cov>=4.1.0,<7.0.0
 
 # Code quality
 black>=24.3.0,<27.0.0

--- a/server.json
+++ b/server.json
@@ -18,13 +18,13 @@
     "url": "https://github.com/RekklesNA/ProxmoxMCP-Plus",
     "source": "github"
   },
-  "version": "0.4.7",
+  "version": "0.4.8",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "proxmox-mcp-plus",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -18,13 +18,13 @@
     "url": "https://github.com/RekklesNA/ProxmoxMCP-Plus",
     "source": "github"
   },
-  "version": "0.4.8",
+  "version": "0.4.9",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "proxmox-mcp-plus",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="proxmox-mcp-plus",
-    version="0.4.7",
+    version="0.4.8",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     python_requires=">=3.11",
@@ -23,12 +23,13 @@ setup(
         "fastapi>=0.115.0",
         "uvicorn[standard]>=0.30.0",
         "mcpo>=0.0.17",
-        "paramiko>=3.0.0,<4.0.0",
+        "paramiko>=4.0.0,<5.0.0",
         "anyio>=4.0.0",
     ],
     extras_require={
         "dev": [
             "pytest>=7.0.0,<8.0.0",
+            "pytest-cov>=4.1.0,<7.0.0",
             "black>=24.3.0,<27.0.0",
             "mypy>=1.0.0,<2.0.0",
             "pytest-asyncio>=0.21.0,<0.22.0",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="proxmox-mcp-plus",
-    version="0.4.8",
+    version="0.4.9",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     python_requires=">=3.11",

--- a/src/proxmox_mcp/__init__.py
+++ b/src/proxmox_mcp/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .server import ProxmoxMCPServer
 
-__version__ = "0.4.6"
+__version__ = "0.4.8"
 __all__ = ["ProxmoxMCPServer"]
 
 

--- a/src/proxmox_mcp/__init__.py
+++ b/src/proxmox_mcp/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .server import ProxmoxMCPServer
 
-__version__ = "0.4.8"
+__version__ = "0.4.9"
 __all__ = ["ProxmoxMCPServer"]
 
 

--- a/src/proxmox_mcp/config/loader.py
+++ b/src/proxmox_mcp/config/loader.py
@@ -16,6 +16,12 @@ from typing import Any, Dict, Optional
 from proxmox_mcp.config.models import Config
 
 
+def _parse_csv_env(name: str) -> list[str] | None:
+    if name not in os.environ:
+        return None
+    return [item.strip() for item in os.environ[name].split(",") if item.strip()]
+
+
 def _apply_mcp_env_overrides(config_data: Dict[str, Any]) -> None:
     """Allow deployment-specific MCP transport settings to override file config."""
     env_map = {
@@ -88,6 +94,22 @@ def load_config(config_path: Optional[str] = None) -> Config:
     if not config_path or not os.path.exists(config_path):
         # Fallback to environment variables
         log_level_raw = os.getenv("LOG_LEVEL")
+        command_policy = {
+            'mode': os.getenv("COMMAND_POLICY_MODE", "deny_all"),
+            'allow_patterns': _parse_csv_env("COMMAND_POLICY_ALLOW_PATTERNS") or [],
+            'require_approval_token': os.getenv("COMMAND_POLICY_REQUIRE_APPROVAL_TOKEN", "false").lower() == "true",
+            'approval_token': os.getenv("COMMAND_POLICY_APPROVAL_TOKEN"),
+            'high_risk_mode': os.getenv("COMMAND_POLICY_HIGH_RISK_MODE", "audit_only"),
+            'high_risk_require_approval_token': os.getenv("COMMAND_POLICY_HIGH_RISK_REQUIRE_APPROVAL_TOKEN", "false").lower() == "true",
+            'high_risk_approval_token': os.getenv("COMMAND_POLICY_HIGH_RISK_APPROVAL_TOKEN"),
+        }
+        deny_patterns = _parse_csv_env("COMMAND_POLICY_DENY_PATTERNS")
+        if deny_patterns is not None:
+            command_policy["deny_patterns"] = deny_patterns
+        high_risk_operations = _parse_csv_env("COMMAND_POLICY_HIGH_RISK_OPERATIONS")
+        if high_risk_operations is not None:
+            command_policy["high_risk_operations"] = high_risk_operations
+
         config_data = {
             'proxmox': {
                 'host': os.getenv("PROXMOX_HOST"),
@@ -124,17 +146,7 @@ def load_config(config_path: Optional[str] = None) -> Config:
             'jobs': {
                 'sqlite_path': os.getenv("PROXMOX_JOBS_SQLITE_PATH", "proxmox-jobs.sqlite3"),
             },
-            'command_policy': {
-                'mode': os.getenv("COMMAND_POLICY_MODE", "deny_all"),
-                'allow_patterns': [p.strip() for p in os.getenv("COMMAND_POLICY_ALLOW_PATTERNS", "").split(",") if p.strip()],
-                'deny_patterns': [p.strip() for p in os.getenv("COMMAND_POLICY_DENY_PATTERNS", "").split(",") if p.strip()],
-                'require_approval_token': os.getenv("COMMAND_POLICY_REQUIRE_APPROVAL_TOKEN", "false").lower() == "true",
-                'approval_token': os.getenv("COMMAND_POLICY_APPROVAL_TOKEN"),
-                'high_risk_mode': os.getenv("COMMAND_POLICY_HIGH_RISK_MODE", "audit_only"),
-                'high_risk_operations': [p.strip() for p in os.getenv("COMMAND_POLICY_HIGH_RISK_OPERATIONS", "").split(",") if p.strip()],
-                'high_risk_require_approval_token': os.getenv("COMMAND_POLICY_HIGH_RISK_REQUIRE_APPROVAL_TOKEN", "false").lower() == "true",
-                'high_risk_approval_token': os.getenv("COMMAND_POLICY_HIGH_RISK_APPROVAL_TOKEN"),
-            },
+            'command_policy': command_policy,
         }
         
         api_tunnel_config = config_data.get("api_tunnel")

--- a/src/proxmox_mcp/openapi_proxy.py
+++ b/src/proxmox_mcp/openapi_proxy.py
@@ -53,7 +53,9 @@ class ProxyMetricsMiddleware(BaseHTTPMiddleware):
         finally:
             latency_ms = (time.perf_counter() - start) * 1000.0
             status_code = response.status_code if response is not None else 500
-            metrics.observe(request.url.path, request.method, status_code, latency_ms)
+            route = request.scope.get("route")
+            route_path = getattr(route, "path", None) or request.url.path
+            metrics.observe(route_path, request.method, status_code, latency_ms)
 
 
 class RateLimitMiddleware(BaseHTTPMiddleware):
@@ -102,6 +104,7 @@ def create_app(
     path_prefix: str = "/",
     root_path: str = "",
     rate_limit_rpm: int = 0,
+    command_policy: Any | None = None,
 ) -> FastAPI:
     """Create a FastAPI app that mirrors mcpo behavior and adds ops routes."""
     api_dependency = get_verify_api_key(api_key) if api_key else None
@@ -141,6 +144,7 @@ def create_app(
     app.state.api_key_configured = bool(api_key)
     app.state.strict_auth = strict_auth
     app.state.job_store = job_store
+    app.state.command_policy = command_policy
     app.state.security_warnings = _security_warnings(
         api_key=api_key,
         strict_auth=strict_auth,
@@ -205,11 +209,32 @@ def create_app(
         LOGGER.warning("Job route error: %s", error, exc_info=True)
         if isinstance(error, JobNotFoundError):
             return JSONResponse(status_code=404, content={"status": "not_found", "message": "Job was not found"})
+        if isinstance(error, PermissionError):
+            return JSONResponse(status_code=403, content={"status": "forbidden", "message": "Job operation requires approval"})
         if isinstance(error, JobConflictError):
             return JSONResponse(status_code=409, content={"status": "conflict", "message": "Job cannot perform that operation right now"})
         if isinstance(error, RuntimeError):
             return JSONResponse(status_code=503, content={"status": "unavailable", "message": "Job service is unavailable in this process"})
         return JSONResponse(status_code=400, content={"status": "error", "message": "Job request failed"})
+
+    def _enforce_job_retry_policy(job_id: str, approval_token: Optional[str]) -> None:
+        policy = getattr(app.state, "command_policy", None)
+        if policy is None:
+            return
+        job = _require_job_store().get_job(job_id)
+        operation_name = str(job.get("tool_name") or "")
+        decision = policy.evaluate_operation(
+            operation_name,
+            approval_token=approval_token,
+        )
+        if decision.code == "OP_POLICY_AUDIT_ALLOW":
+            LOGGER.warning(
+                "Retrying high-risk job in audit-only mode: %s (%s)",
+                job_id,
+                operation_name,
+            )
+        if not decision.allowed:
+            raise PermissionError(decision.message)
 
     @app.get("/jobs")
     async def list_jobs(
@@ -249,8 +274,9 @@ def create_app(
             return _job_error_response(exc)
 
     @app.post("/jobs/{job_id}/retry")
-    async def retry_job(job_id: str) -> JSONResponse:
+    async def retry_job(job_id: str, approval_token: Optional[str] = None) -> JSONResponse:
         try:
+            _enforce_job_retry_policy(job_id, approval_token)
             payload = _require_job_store().retry_job(job_id)
             return JSONResponse(status_code=202, content=payload)
         except Exception as exc:  # noqa: BLE001
@@ -318,14 +344,17 @@ def main() -> None:
         LOGGER.warning("OpenAPI security warning: %s", warning)
 
     job_store = None
+    command_policy = None
     config_path = os.getenv("PROXMOX_MCP_CONFIG")
     if config_path:
         try:
             from proxmox_mcp.config.loader import load_config
             from proxmox_mcp.core.proxmox import ProxmoxManager
+            from proxmox_mcp.security import CommandPolicyGate
             from proxmox_mcp.services import JobStore
 
             config = load_config(config_path)
+            command_policy = CommandPolicyGate(config.command_policy)
             proxmox = ProxmoxManager(
                 config.proxmox,
                 config.auth,
@@ -345,6 +374,7 @@ def main() -> None:
         path_prefix=args.path_prefix,
         root_path=args.root_path,
         rate_limit_rpm=args.rate_limit_rpm,
+        command_policy=command_policy,
     )
     uvicorn.run(app, host=args.host, port=args.port)
 

--- a/src/proxmox_mcp/openapi_proxy.py
+++ b/src/proxmox_mcp/openapi_proxy.py
@@ -23,6 +23,11 @@ from proxmox_mcp.services.jobs import JobConflictError, JobNotFoundError
 LOGGER = logging.getLogger(__name__)
 
 
+def _log_safe(value: object, max_length: int = 200) -> str:
+    text = str(value).replace("\r", "").replace("\n", "")
+    return text[:max_length]
+
+
 def _parse_cors_allow_origins(value: Optional[str]) -> list[str]:
     if not value:
         return ["*"]
@@ -228,10 +233,12 @@ def create_app(
             approval_token=approval_token,
         )
         if decision.code == "OP_POLICY_AUDIT_ALLOW":
+            safe_job_id = _log_safe(job_id)
+            safe_operation_name = _log_safe(operation_name)
             LOGGER.warning(
                 "Retrying high-risk job in audit-only mode: %s (%s)",
-                job_id,
-                operation_name,
+                safe_job_id,
+                safe_operation_name,
             )
         if not decision.allowed:
             raise PermissionError(decision.message)

--- a/src/proxmox_mcp/server.py
+++ b/src/proxmox_mcp/server.py
@@ -101,12 +101,16 @@ class ProxmoxMCPServer:
         self.tool_registry.add(BackupToolsPlugin())
         self.tool_registry.register_all(self)
 
+    def close(self) -> None:
+        self.job_store.close()
+
     def start(self) -> None:
         """Start the MCP server with the configured transport."""
         import anyio
 
         def signal_handler(signum: int, frame: object) -> None:
             self.logger.info("Received signal to shutdown...")
+            self.close()
             sys.exit(0)
 
         signal.signal(signal.SIGINT, signal_handler)
@@ -130,6 +134,8 @@ class ProxmoxMCPServer:
         except Exception as e:
             self.logger.error("Server execution failed: %s", e)
             sys.exit(1)
+        finally:
+            self.close()
 
 
 def main() -> None:

--- a/src/proxmox_mcp/services/builtin_tool_plugins.py
+++ b/src/proxmox_mcp/services/builtin_tool_plugins.py
@@ -55,7 +55,7 @@ from proxmox_mcp.services.tool_registry import ToolRegistryPlugin
 
 class GetContainersPayload(BaseModel):
     node: Optional[str] = Field(None, description="Optional node name (e.g. 'pve1')")
-    include_stats: bool = Field(True, description="Include live stats and fallbacks")
+    include_stats: bool = Field(False, description="Fetch per-container live stats and fallbacks")
     include_raw: bool = Field(False, description="Include raw status/config")
     format_style: Literal["pretty", "json"] = Field("pretty", description="'pretty' or 'json'")
 
@@ -79,6 +79,27 @@ class RegistryPluginBase(ToolRegistryPlugin):
         )
         if decision.code == "OP_POLICY_AUDIT_ALLOW":
             server.logger.warning("High-risk tool invoked in audit-only mode: %s", tool_name)
+        if not decision.allowed:
+            raise ValueError(decision.message)
+
+    def _enforce_job_retry_policy(
+        self,
+        server: Any,
+        job_id: str,
+        approval_token: str | None,
+    ) -> None:
+        job = server.job_store.get_job(job_id)
+        operation_name = str(job.get("tool_name") or "")
+        decision = server.command_policy.evaluate_operation(
+            operation_name,
+            approval_token=approval_token,
+        )
+        if decision.code == "OP_POLICY_AUDIT_ALLOW":
+            server.logger.warning(
+                "Retrying high-risk job in audit-only mode: %s (%s)",
+                job_id,
+                operation_name,
+            )
         if not decision.allowed:
             raise ValueError(decision.message)
 
@@ -199,8 +220,17 @@ class JobsToolsPlugin(RegistryPluginBase):
         @server.mcp.tool(description=RETRY_JOB_DESC)
         def retry_job(
             job_id: Annotated[str, Field(description="Stable job identifier")],
+            approval_token: Annotated[Optional[str], Field(description="Optional approval token for high-risk job retries", default=None)] = None,
         ) -> Any:
-            return self._wrap_sync(server, "retry_job", server.jobs_tools.retry_job)(job_id=job_id)
+            def guarded_retry(job_id: str) -> Any:
+                self._enforce_job_retry_policy(
+                    server,
+                    job_id,
+                    approval_token if isinstance(approval_token, str) else None,
+                )
+                return server.jobs_tools.retry_job(job_id=job_id)
+
+            return self._wrap_sync(server, "retry_job", guarded_retry)(job_id=job_id)
 
 
 class VMToolsPlugin(RegistryPluginBase):
@@ -319,7 +349,7 @@ class ContainerToolsPlugin(RegistryPluginBase):
         @server.mcp.tool(description=GET_CONTAINERS_DESC)
         def get_containers(
             node: Annotated[Optional[str], Field(description="Optional node name (e.g. 'pve1')")] = None,
-            include_stats: Annotated[bool, Field(description="Include live stats and fallbacks")] = True,
+            include_stats: Annotated[bool, Field(description="Fetch per-container live stats and fallbacks")] = False,
             include_raw: Annotated[bool, Field(description="Include raw status/config")] = False,
             format_style: Annotated[Literal["pretty", "json"], Field(description="'pretty' or 'json'")] = "pretty",
             payload: Annotated[Optional[dict[str, Any]], Field(description="Legacy container query options")] = None,

--- a/src/proxmox_mcp/services/builtin_tool_plugins.py
+++ b/src/proxmox_mcp/services/builtin_tool_plugins.py
@@ -53,6 +53,11 @@ from proxmox_mcp.tools.definitions import (
 from proxmox_mcp.services.tool_registry import ToolRegistryPlugin
 
 
+def _log_safe(value: object, max_length: int = 200) -> str:
+    text = str(value).replace("\r", "").replace("\n", "")
+    return text[:max_length]
+
+
 class GetContainersPayload(BaseModel):
     node: Optional[str] = Field(None, description="Optional node name (e.g. 'pve1')")
     include_stats: bool = Field(False, description="Fetch per-container live stats and fallbacks")
@@ -78,7 +83,7 @@ class RegistryPluginBase(ToolRegistryPlugin):
             approval_token=approval_token,
         )
         if decision.code == "OP_POLICY_AUDIT_ALLOW":
-            server.logger.warning("High-risk tool invoked in audit-only mode: %s", tool_name)
+            server.logger.warning("High-risk tool invoked in audit-only mode: %s", _log_safe(tool_name))
         if not decision.allowed:
             raise ValueError(decision.message)
 
@@ -95,10 +100,12 @@ class RegistryPluginBase(ToolRegistryPlugin):
             approval_token=approval_token,
         )
         if decision.code == "OP_POLICY_AUDIT_ALLOW":
+            safe_job_id = _log_safe(job_id)
+            safe_operation_name = _log_safe(operation_name)
             server.logger.warning(
                 "Retrying high-risk job in audit-only mode: %s (%s)",
-                job_id,
-                operation_name,
+                safe_job_id,
+                safe_operation_name,
             )
         if not decision.allowed:
             raise ValueError(decision.message)

--- a/src/proxmox_mcp/services/jobs.py
+++ b/src/proxmox_mcp/services/jobs.py
@@ -102,11 +102,28 @@ class JobStore:
         self._jobs: dict[str, JobRecord] = {}
         self._lock = threading.RLock()
         self._retry_handlers: dict[str, Callable[[dict[str, Any]], Any]] = {}
-        self._conn = sqlite3.connect(self.sqlite_path, check_same_thread=False)
+        self._conn = sqlite3.connect(self.sqlite_path, check_same_thread=False, timeout=30.0)
         self._conn.row_factory = sqlite3.Row
+        self._configure_connection()
         self._init_db()
         self._register_builtin_retry_handlers()
         self._load_records()
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()
+
+    def __enter__(self) -> "JobStore":
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
 
     def register_retry_handler(self, kind: str, handler: Callable[[dict[str, Any]], Any]) -> None:
         self._retry_handlers[kind] = handler
@@ -152,27 +169,16 @@ class JobStore:
         limit: int = 100,
     ) -> list[dict[str, Any]]:
         with self._lock:
-            self._refresh_records_from_db()
-            rows = list(self._jobs.values())
-        rows.sort(key=lambda item: item.created_at, reverse=True)
-        filtered: list[JobRecord] = []
-        for item in rows:
-            if status and item.status != status:
-                continue
-            if tool_name and item.tool_name != tool_name:
-                continue
-            filtered.append(item)
-        return [item.as_dict() for item in filtered[:limit]]
+            rows = self._query_records(status=status, tool_name=tool_name, limit=limit)
+            return [item.as_dict() for item in rows]
 
     def get_job(self, job_id: str) -> dict[str, Any]:
         with self._lock:
-            self._refresh_records_from_db()
-            return self._get_record(job_id).as_dict()
+            return self._load_record_from_db(job_id).as_dict()
 
     def poll_job(self, job_id: str) -> dict[str, Any]:
         with self._lock:
-            self._refresh_records_from_db()
-            record = self._get_record(job_id)
+            record = self._load_record_from_db(job_id)
             if not record.upid or not record.node:
                 record.add_audit("poll_skipped", reason="missing_upid_or_node")
                 self._save_record(record)
@@ -186,8 +192,7 @@ class JobStore:
         status, last_error, completed_at = self._normalize_status(status_payload)
 
         with self._lock:
-            self._refresh_records_from_db()
-            record = self._get_record(job_id)
+            record = self._load_record_from_db(job_id)
             record.progress = progress
             record.status = status
             record.last_error = last_error
@@ -204,8 +209,7 @@ class JobStore:
 
     def cancel_job(self, job_id: str) -> dict[str, Any]:
         with self._lock:
-            self._refresh_records_from_db()
-            record = self._get_record(job_id)
+            record = self._load_record_from_db(job_id)
             if not record.upid or not record.node:
                 raise JobConflictError(f"Job {job_id} has no task UPID to cancel")
             upid = record.upid
@@ -218,8 +222,7 @@ class JobStore:
             self.proxmox.nodes(node).tasks(upid).status.stop.post()
 
         with self._lock:
-            self._refresh_records_from_db()
-            record = self._get_record(job_id)
+            record = self._load_record_from_db(job_id)
             record.status = "cancel_requested"
             record.add_audit("cancel_requested", upid=upid)
             self._save_record(record)
@@ -227,8 +230,7 @@ class JobStore:
 
     def retry_job(self, job_id: str) -> dict[str, Any]:
         with self._lock:
-            self._refresh_records_from_db()
-            record = self._get_record(job_id)
+            record = self._load_record_from_db(job_id)
             retry_factory = record.retry_factory
             retry_spec = dict(record.retry_spec or {})
 
@@ -247,8 +249,7 @@ class JobStore:
             new_upid = handler(params)
 
         with self._lock:
-            self._refresh_records_from_db()
-            record = self._get_record(job_id)
+            record = self._load_record_from_db(job_id)
             if record.upid:
                 record.previous_upids.append(record.upid)
             record.upid = str(new_upid)
@@ -269,7 +270,21 @@ class JobStore:
         except KeyError as exc:
             raise JobNotFoundError(f"Unknown job_id: {job_id}") from exc
 
+    def _configure_connection(self) -> None:
+        self._conn.execute("PRAGMA busy_timeout = 5000")
+        self._conn.execute("PRAGMA journal_mode = WAL")
+        self._conn.execute("PRAGMA synchronous = NORMAL")
+        self._conn.execute("PRAGMA foreign_keys = ON")
+
     def _init_db(self) -> None:
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS schema_migrations (
+                version INTEGER PRIMARY KEY,
+                applied_at TEXT NOT NULL
+            )
+            """
+        )
         self._conn.execute(
             """
             CREATE TABLE IF NOT EXISTS jobs (
@@ -294,49 +309,87 @@ class JobStore:
             )
             """
         )
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_jobs_created_at ON jobs (created_at DESC)")
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_jobs_status_created_at ON jobs (status, created_at DESC)")
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_jobs_tool_created_at ON jobs (tool_name, created_at DESC)")
+        self._conn.execute(
+            "INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (?, ?)",
+            (1, _utcnow()),
+        )
         self._conn.commit()
 
     def _load_records(self) -> None:
         with self._lock:
-            self._refresh_records_from_db()
+            for record in self._query_records(limit=500):
+                self._jobs[record.job_id] = record
 
-    def _refresh_records_from_db(self) -> None:
-        rows = self._conn.execute("SELECT * FROM jobs").fetchall()
-        refreshed: dict[str, JobRecord] = {}
-        for row in rows:
-            job_id = str(row["job_id"])
-            existing = self._jobs.get(job_id)
-            record = JobRecord(
-                job_id=job_id,
-                tool_name=str(row["tool_name"]),
-                summary=str(row["summary"]),
-                node=row["node"],
-                upid=row["upid"],
-                created_at=str(row["created_at"]),
-                updated_at=str(row["updated_at"]),
-                status=str(row["status"]),
-                progress=row["progress"],
-                attempts=int(row["attempts"]),
-                retry_count=int(row["retry_count"]),
-                last_error=row["last_error"],
-                completed_at=row["completed_at"],
-                result=json.loads(row["result_json"]) if row["result_json"] else None,
-                metadata=json.loads(row["metadata_json"]) if row["metadata_json"] else {},
-                previous_upids=json.loads(row["previous_upids_json"]) if row["previous_upids_json"] else [],
-                audit_log=[
-                    JobAuditEvent(
-                        timestamp=item["timestamp"],
-                        event=item["event"],
-                        details=item.get("details", {}),
-                    )
-                    for item in (json.loads(row["audit_log_json"]) if row["audit_log_json"] else [])
-                ],
-                retry_spec=json.loads(row["retry_spec_json"]) if row["retry_spec_json"] else None,
-                retry_factory=existing.retry_factory if existing is not None else None,
-                cancel_factory=existing.cancel_factory if existing is not None else None,
-            )
-            refreshed[record.job_id] = record
-        self._jobs = refreshed
+    def _row_to_record(self, row: sqlite3.Row) -> JobRecord:
+        job_id = str(row["job_id"])
+        existing = self._jobs.get(job_id)
+        return JobRecord(
+            job_id=job_id,
+            tool_name=str(row["tool_name"]),
+            summary=str(row["summary"]),
+            node=row["node"],
+            upid=row["upid"],
+            created_at=str(row["created_at"]),
+            updated_at=str(row["updated_at"]),
+            status=str(row["status"]),
+            progress=row["progress"],
+            attempts=int(row["attempts"]),
+            retry_count=int(row["retry_count"]),
+            last_error=row["last_error"],
+            completed_at=row["completed_at"],
+            result=json.loads(row["result_json"]) if row["result_json"] else None,
+            metadata=json.loads(row["metadata_json"]) if row["metadata_json"] else {},
+            previous_upids=json.loads(row["previous_upids_json"]) if row["previous_upids_json"] else [],
+            audit_log=[
+                JobAuditEvent(
+                    timestamp=item["timestamp"],
+                    event=item["event"],
+                    details=item.get("details", {}),
+                )
+                for item in (json.loads(row["audit_log_json"]) if row["audit_log_json"] else [])
+            ],
+            retry_spec=json.loads(row["retry_spec_json"]) if row["retry_spec_json"] else None,
+            retry_factory=existing.retry_factory if existing is not None else None,
+            cancel_factory=existing.cancel_factory if existing is not None else None,
+        )
+
+    def _load_record_from_db(self, job_id: str) -> JobRecord:
+        row = self._conn.execute("SELECT * FROM jobs WHERE job_id = ?", (job_id,)).fetchone()
+        if row is None:
+            self._jobs.pop(job_id, None)
+            raise JobNotFoundError(f"Unknown job_id: {job_id}")
+        record = self._row_to_record(row)
+        self._jobs[record.job_id] = record
+        return record
+
+    def _query_records(
+        self,
+        *,
+        status: Optional[str] = None,
+        tool_name: Optional[str] = None,
+        limit: int = 100,
+    ) -> list[JobRecord]:
+        safe_limit = max(1, min(int(limit), 500))
+        where: list[str] = []
+        params: list[Any] = []
+        if status:
+            where.append("status = ?")
+            params.append(status)
+        if tool_name:
+            where.append("tool_name = ?")
+            params.append(tool_name)
+        where_clause = f"WHERE {' AND '.join(where)}" if where else ""
+        rows = self._conn.execute(
+            f"SELECT * FROM jobs {where_clause} ORDER BY created_at DESC LIMIT ?",
+            (*params, safe_limit),
+        ).fetchall()
+        records = [self._row_to_record(row) for row in rows]
+        for record in records:
+            self._jobs[record.job_id] = record
+        return records
 
     def _save_record(self, record: JobRecord) -> None:
         self._conn.execute(
@@ -408,6 +461,10 @@ class JobStore:
 
     def _register_builtin_retry_handlers(self) -> None:
         self.register_retry_handler("vm.create", lambda params: self.proxmox.nodes(params["node"]).qemu.create(**params["vm_config"]))
+        self.register_retry_handler(
+            "vm.clone",
+            lambda params: self.proxmox.nodes(params["node"]).qemu(params["source_vmid"]).clone.post(**params["clone_payload"]),
+        )
         self.register_retry_handler("vm.start", lambda params: self.proxmox.nodes(params["node"]).qemu(params["vmid"]).status.start.post())
         self.register_retry_handler("vm.stop", lambda params: self.proxmox.nodes(params["node"]).qemu(params["vmid"]).status.stop.post())
         self.register_retry_handler("vm.shutdown", lambda params: self.proxmox.nodes(params["node"]).qemu(params["vmid"]).status.shutdown.post())

--- a/src/proxmox_mcp/tools/console/manager.py
+++ b/src/proxmox_mcp/tools/console/manager.py
@@ -14,6 +14,7 @@ The module implements a robust command execution system with:
 - Comprehensive error handling
 """
 
+import asyncio
 import logging
 from typing import Dict, Any
 
@@ -41,6 +42,54 @@ class VMConsoleManager:
         """
         self.proxmox = proxmox_api
         self.logger = logging.getLogger("proxmox-mcp.vm-console")
+
+    async def _wait_for_exec_status(
+        self,
+        endpoint: Any,
+        pid: int,
+        *,
+        timeout_seconds: int = 60,
+        poll_interval_seconds: float = 1.0,
+    ) -> Dict[str, Any]:
+        """Poll QEMU guest-agent exec-status until completion or timeout."""
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout_seconds
+        last_status: Dict[str, Any] = {}
+
+        while True:
+            try:
+                self.logger.debug(f"Getting status for PID {pid}...")
+                console = endpoint("exec-status").get(pid=pid)
+                self.logger.debug(f"Raw exec-status response: {console}")
+                if not console:
+                    raise RuntimeError("No response from exec-status")
+                if not isinstance(console, dict):
+                    return {
+                        "out-data": str(console),
+                        "err-data": "",
+                        "exitcode": 0,
+                        "exited": 1,
+                    }
+                last_status = console
+            except Exception as e:
+                self.logger.error(f"Failed to get command status: {str(e)}")
+                raise RuntimeError(f"Failed to get command status: {str(e)}")
+
+            if last_status.get("exited", 0):
+                return last_status
+
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                timed_out = dict(last_status)
+                timed_out["timed_out"] = True
+                timed_out.setdefault("exitcode", -1)
+                timed_out.setdefault(
+                    "err-data",
+                    f"Command did not complete within {timeout_seconds} seconds",
+                )
+                return timed_out
+
+            await asyncio.sleep(min(poll_interval_seconds, remaining))
 
     async def execute_command(self, node: str, vmid: str, command: str) -> Dict[str, Any]:
         """Execute a command in a VM's console via QEMU guest agent.
@@ -119,20 +168,7 @@ class VMConsoleManager:
                 pid = exec_result['pid']
                 self.logger.info(f"Waiting for command completion (PID: {pid})...")
 
-                # Add a small delay to allow command to complete
-                import asyncio
-                await asyncio.sleep(1)
-
-                # Get command output using exec-status
-                try:
-                    self.logger.debug(f"Getting status for PID {pid}...")
-                    console = endpoint("exec-status").get(pid=pid)
-                    self.logger.debug(f"Raw exec-status response: {console}")
-                    if not console:
-                        raise RuntimeError("No response from exec-status")
-                except Exception as e:
-                    self.logger.error(f"Failed to get command status: {str(e)}")
-                    raise RuntimeError(f"Failed to get command status: {str(e)}")
+                console = await self._wait_for_exec_status(endpoint, pid)
                 self.logger.info(f"Command completed with status: {console}")
             except Exception as e:
                 self.logger.error(f"API call failed: {str(e)}")
@@ -147,8 +183,11 @@ class VMConsoleManager:
                 error = console.get("err-data", "")
                 exit_code = console.get("exitcode", 0)
                 exited = console.get("exited", 0)
+                timed_out = bool(console.get("timed_out", False))
                 
-                if not exited:
+                if timed_out:
+                    self.logger.warning("Command did not complete before timeout")
+                elif not exited:
                     self.logger.warning("Command may not have completed")
             else:
                 # Some versions might return data differently
@@ -156,18 +195,26 @@ class VMConsoleManager:
                 output = str(console)
                 error = ""
                 exit_code = 0
+                exited = 1
+                timed_out = False
             
             self.logger.debug(f"Processed output: {output}")
             self.logger.debug(f"Processed error: {error}")
             self.logger.debug(f"Processed exit code: {exit_code}")
             
             self.logger.debug(f"Executed command '{command}' on VM {vmid} (node: {node})")
+            try:
+                exit_code_int = int(exit_code)
+            except (TypeError, ValueError):
+                exit_code_int = -1
 
             return {
-                "success": True,
+                "success": bool(exited) and exit_code_int == 0 and not timed_out,
                 "output": output,
                 "error": error,
-                "exit_code": exit_code
+                "exit_code": exit_code_int,
+                "exited": bool(exited),
+                "timed_out": timed_out,
             }
 
         except ValueError:

--- a/src/proxmox_mcp/tools/containers.py
+++ b/src/proxmox_mcp/tools/containers.py
@@ -84,8 +84,40 @@ class ContainerTools(ProxmoxTool):
         self._handle_error(action, e)
 
     # ---------- helpers ----------
+    def _cluster_ct_pairs(self, node: Optional[str]) -> Optional[List[Tuple[str, Dict]]]:
+        try:
+            resources = self.proxmox.cluster.resources.get(type="vm")
+        except Exception as error:
+            self.logger.debug("Cluster container inventory unavailable, falling back to node scan: %s", error)
+            return None
+        if not isinstance(resources, list):
+            return None
+
+        out: List[Tuple[str, Dict]] = []
+        for item in resources:
+            if not isinstance(item, dict) or item.get("type") != "lxc":
+                continue
+            node_name = _get(item, "node")
+            if not node_name:
+                continue
+            if node and node_name != node:
+                continue
+            vmid = _get(item, "vmid")
+            if vmid is None:
+                resource_id = str(_get(item, "id", ""))
+                if "/" in resource_id:
+                    vmid = resource_id.rsplit("/", 1)[-1]
+            if vmid is None:
+                continue
+            out.append((node_name, dict(item, vmid=vmid)))
+        return out if out else None
+
     def _list_ct_pairs(self, node: Optional[str]) -> List[Tuple[str, Dict]]:
         """Yield (node_name, ct_dict). Coerce odd shapes into dicts with vmid."""
+        cluster_pairs = self._cluster_ct_pairs(node)
+        if cluster_pairs is not None:
+            return cluster_pairs
+
         out: List[Tuple[str, Dict]] = []
         if node:
             try:
@@ -198,14 +230,14 @@ class ContainerTools(ProxmoxTool):
     def get_containers(
         self,
         node: Optional[str] = None,
-        include_stats: bool = True,
+        include_stats: bool = False,
         include_raw: bool = False,
         format_style: str = "pretty",
     ) -> List[Content]:
         """
         List containers cluster-wide or by node.
 
-        - `include_stats=True` fetches live CPU/mem from /status/current
+        - `include_stats=True` fetches per-container CPU/mem from /status/current
         - RRD fallback is used if live returns zeros
         - `format_style='json'` returns raw JSON list (sanitized)
         - `format_style='pretty'` renders a human-friendly table
@@ -229,6 +261,30 @@ class ContainerTools(ProxmoxTool):
                     "node": nname,
                     "status": _get(ct, "status"),
                 }
+                base_cpu = _get(ct, "cpu")
+                base_mem = _get(ct, "mem")
+                base_maxmem = _get(ct, "maxmem")
+                base_maxcpu = _get(ct, "maxcpu")
+                if base_cpu is not None:
+                    try:
+                        rec["cpu_pct"] = round(float(base_cpu) * 100.0, 2)
+                    except Exception:
+                        pass
+                if base_mem is not None:
+                    try:
+                        rec["mem_bytes"] = int(base_mem)
+                    except Exception:
+                        pass
+                if base_maxmem is not None:
+                    try:
+                        maxmem_int = int(base_maxmem)
+                        rec["maxmem_bytes"] = maxmem_int
+                        mem_int = int(rec.get("mem_bytes") or 0)
+                        rec["mem_pct"] = round((mem_int / maxmem_int * 100.0), 2) if maxmem_int > 0 else None
+                    except Exception:
+                        pass
+                if base_maxcpu is not None:
+                    rec["cores"] = base_maxcpu
 
                 if include_stats and vmid_int is not None:
                     raw_status, raw_config = self._status_and_config(nname, vmid_int)

--- a/src/proxmox_mcp/tools/definitions.py
+++ b/src/proxmox_mcp/tools/definitions.py
@@ -152,7 +152,7 @@ GET_CONTAINERS_DESC = """List LXC containers across the cluster (or filter by no
 
 Parameters:
 - node (optional): Node name to filter (e.g. 'pve1')
-- include_stats (bool, default true): Include live CPU/memory stats
+- include_stats (bool, default false): Fetch per-container live CPU/memory stats
 - include_raw (bool, default false): Include raw Proxmox API payloads for debugging
 - format_style ('pretty'|'json', default 'pretty'): Pretty text or raw JSON list
 

--- a/src/proxmox_mcp/tools/vm.py
+++ b/src/proxmox_mcp/tools/vm.py
@@ -53,6 +53,39 @@ class VMTools(ProxmoxTool):
         self.console_manager = VMConsoleManager(proxmox_api)
         self.command_policy = command_policy
 
+    def _get_cluster_vm_inventory(self) -> Optional[list[dict[str, Any]]]:
+        try:
+            resources = self.proxmox.cluster.resources.get(type="vm")
+        except Exception as error:
+            self.logger.debug("Cluster VM inventory unavailable, falling back to node scan: %s", error)
+            return None
+        if not isinstance(resources, list):
+            return None
+
+        result: list[dict[str, Any]] = []
+        for vm in resources:
+            if not isinstance(vm, dict) or vm.get("type") != "qemu":
+                continue
+            vmid = vm.get("vmid")
+            if vmid is None:
+                resource_id = str(vm.get("id", ""))
+                if "/" in resource_id:
+                    vmid = resource_id.rsplit("/", 1)[-1]
+            if vmid is None:
+                continue
+            result.append({
+                "vmid": vmid,
+                "name": vm.get("name") or f"VM-{vmid}",
+                "status": vm.get("status", "unknown"),
+                "node": vm.get("node", "unknown"),
+                "cpus": vm.get("maxcpu", vm.get("cpus", "N/A")),
+                "memory": {
+                    "used": vm.get("mem", 0),
+                    "total": vm.get("maxmem", 0),
+                },
+            })
+        return result if result else None
+
     def get_vms(self) -> List[Content]:
         """List all virtual machines across the cluster with detailed status.
 
@@ -84,6 +117,10 @@ class VMTools(ProxmoxTool):
         Raises:
             RuntimeError: If the cluster-wide VM query fails
         """
+        cluster_inventory = self._get_cluster_vm_inventory()
+        if cluster_inventory is not None:
+            return self._format_response(cluster_inventory, "vms")
+
         try:
             nodes = self.proxmox.nodes.get()
         except Exception as e:
@@ -363,25 +400,43 @@ Next steps:
         except Exception as e:
             self._handle_error(f"clone VM {source_vmid} -> {target_vmid}", e)
 
-        result_text = f"""📑 VM clone initiated successfully!
+        job = self._register_background_job(
+            tool_name="clone_vm",
+            summary=f"Clone VM {source_vmid} to {target_vmid} on {node}",
+            node=node,
+            upid=task_result,
+            metadata={
+                "source_vmid": source_vmid,
+                "target_vmid": target_vmid,
+                "source_node": node,
+                "target_node": destination_node,
+                "full": full,
+                "name": name,
+            },
+            retry_spec={"kind": "vm.clone", "params": {"node": node, "source_vmid": source_vmid, "clone_payload": clone_payload}},
+            retry_factory=lambda: self.proxmox.nodes(node).qemu(source_vmid).clone.post(**clone_payload),
+            cancel_factory=lambda upid: self.proxmox.nodes(node).tasks(upid).status.stop.post(),
+        )
 
-📋 Clone Configuration:
-  • Source VM: {source_vmid} ({source_name})
-  • Source Node: {node}
-  • Target VM ID: {target_vmid}
-  • Target Node: {destination_node}
-  • Clone Type: {"full" if full else "linked"}"""
+        result_text = f"""VM clone initiated successfully
+
+Clone Configuration:
+  - Source VM: {source_vmid} ({source_name})
+  - Source Node: {node}
+  - Target VM ID: {target_vmid}
+  - Target Node: {destination_node}
+  - Clone Type: {"full" if full else "linked"}"""
 
         if name:
-            result_text += f"\n  • Target Name: {name}"
+            result_text += f"\n  - Target Name: {name}"
         if storage:
-            result_text += f"\n  • Storage: {storage}"
+            result_text += f"\n  - Storage: {storage}"
         if pool:
-            result_text += f"\n  • Pool: {pool}"
+            result_text += f"\n  - Pool: {pool}"
         if snapname:
-            result_text += f"\n  • Snapshot: {snapname}"
+            result_text += f"\n  - Snapshot: {snapname}"
 
-        result_text += f"\n\n🔧 Task ID: {task_result}"
+        result_text += f"\n\nTask ID: {task_result}\nJob ID: {job['job_id'] if job else 'n/a'}"
 
         return [Content(type="text", text=result_text)]
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -128,6 +128,80 @@ def test_job_store_persists_to_sqlite(tmp_path: Path):
     assert loaded["retry_spec"]["kind"] == "iso.delete"
 
 
+def test_job_store_configures_sqlite_for_concurrency(tmp_path: Path):
+    proxmox = Mock()
+    db_path = tmp_path / "jobs.sqlite3"
+
+    store = JobStore(proxmox, sqlite_path=str(db_path))
+
+    journal_mode = store._conn.execute("PRAGMA journal_mode").fetchone()[0]
+    busy_timeout = store._conn.execute("PRAGMA busy_timeout").fetchone()[0]
+    schema_version = store._conn.execute("SELECT version FROM schema_migrations").fetchone()[0]
+    indexes = {
+        row[1]
+        for row in store._conn.execute("PRAGMA index_list('jobs')").fetchall()
+    }
+
+    assert journal_mode.lower() == "wal"
+    assert busy_timeout == 5000
+    assert schema_version == 1
+    assert "idx_jobs_status_created_at" in indexes
+    assert "idx_jobs_tool_created_at" in indexes
+
+
+def test_job_store_list_jobs_filters_and_limits_in_sql_order(tmp_path: Path):
+    proxmox = Mock()
+    db_path = tmp_path / "jobs.sqlite3"
+    store = JobStore(proxmox, sqlite_path=str(db_path))
+
+    first = store.register_task(
+        tool_name="start_vm",
+        summary="Start first",
+        node="pve",
+        upid="UPID:first",
+    )
+    second = store.register_task(
+        tool_name="delete_vm",
+        summary="Delete second",
+        node="pve",
+        upid="UPID:second",
+    )
+    third = store.register_task(
+        tool_name="start_vm",
+        summary="Start third",
+        node="pve",
+        upid="UPID:third",
+    )
+
+    store._conn.execute(
+        "UPDATE jobs SET status = 'failed', created_at = '2024-01-01T00:00:00+00:00' WHERE job_id = ?",
+        (first["job_id"],),
+    )
+    store._conn.execute(
+        "UPDATE jobs SET created_at = '2024-01-02T00:00:00+00:00' WHERE job_id = ?",
+        (second["job_id"],),
+    )
+    store._conn.execute(
+        "UPDATE jobs SET created_at = '2024-01-03T00:00:00+00:00' WHERE job_id = ?",
+        (third["job_id"],),
+    )
+    store._conn.commit()
+
+    running_start_jobs = store.list_jobs(status="running", tool_name="start_vm", limit=1)
+
+    assert [job["job_id"] for job in running_start_jobs] == [third["job_id"]]
+
+
+def test_job_store_close_releases_connection(tmp_path: Path):
+    proxmox = Mock()
+    store = JobStore(proxmox, sqlite_path=str(tmp_path / "jobs.sqlite3"))
+
+    store.close()
+
+    with pytest.raises(sqlite3.ProgrammingError):
+        store._conn.execute("SELECT 1")
+
+
 def test_job_store_refreshes_records_written_by_another_instance(tmp_path: Path):
     proxmox = Mock()
     db_path = tmp_path / "jobs.sqlite3"
@@ -167,6 +241,38 @@ def test_job_store_retry_uses_persisted_retry_spec(tmp_path: Path):
     retried = second.retry_job(created["job_id"])
 
     assert retried["upid"] == "UPID:retry-from-sqlite"
+    assert retried["attempts"] == 2
+
+
+def test_job_store_retry_vm_clone_from_persisted_recipe(tmp_path: Path):
+    proxmox = Mock()
+    source_vm_api = proxmox.nodes.return_value.qemu.return_value
+    source_vm_api.clone.post.return_value = "UPID:clone-retry"
+    db_path = tmp_path / "jobs.sqlite3"
+
+    first = JobStore(proxmox, sqlite_path=str(db_path))
+    created = first.register_task(
+        tool_name="clone_vm",
+        summary="Clone VM",
+        node="pve",
+        upid="UPID:clone-original",
+        retry_spec={
+            "kind": "vm.clone",
+            "params": {
+                "node": "pve",
+                "source_vmid": "9000",
+                "clone_payload": {"newid": 9100, "full": 1, "name": "cloned-vm"},
+            },
+        },
+    )
+
+    second = JobStore(proxmox, sqlite_path=str(db_path))
+    retried = second.retry_job(created["job_id"])
+
+    proxmox.nodes.assert_called_with("pve")
+    proxmox.nodes.return_value.qemu.assert_called_with("9000")
+    source_vm_api.clone.post.assert_called_once_with(newid=9100, full=1, name="cloned-vm")
+    assert retried["upid"] == "UPID:clone-retry"
     assert retried["attempts"] == 2
 
 

--- a/tests/test_openapi_proxy.py
+++ b/tests/test_openapi_proxy.py
@@ -1,6 +1,8 @@
 """Tests for OpenAPI proxy wrapper."""
 
 import asyncio
+from types import SimpleNamespace
+
 from fastapi.testclient import TestClient
 
 from proxmox_mcp.openapi_proxy import create_app
@@ -109,6 +111,23 @@ def test_metrics_endpoint_renders_labeled_series():
     assert 'status="200"' in body
 
 
+def test_http_metrics_use_route_templates_for_dynamic_paths():
+    app = create_app(
+        server_command=["python", "-c", "print('ok')"],
+        api_key=None,
+        strict_auth=False,
+        cors_allow_origins=["*"],
+        job_store=_FakeJobStore(),
+    )
+    client = TestClient(app)
+
+    client.get("/jobs/job-1")
+    body = client.get("/metrics").text
+
+    assert 'route="/jobs/{job_id}"' in body
+    assert 'route="/jobs/job-1"' not in body
+
+
 class _FakeJobStore:
     def list_jobs(self, **kwargs):
         return [{"job_id": "job-1", "status": kwargs.get("status") or "running"}]
@@ -116,7 +135,8 @@ class _FakeJobStore:
     def get_job(self, job_id: str):
         if job_id == "missing":
             raise JobNotFoundError("missing")
-        return {"job_id": job_id, "status": "running"}
+        tool_name = "delete_vm" if job_id == "danger" else "start_vm"
+        return {"job_id": job_id, "status": "running", "tool_name": tool_name}
 
     def poll_job(self, job_id: str):
         return {"job_id": job_id, "status": "completed"}
@@ -128,6 +148,21 @@ class _FakeJobStore:
 
     def retry_job(self, job_id: str):
         return {"job_id": job_id, "status": "running", "attempts": 2}
+
+
+class _FakeCommandPolicy:
+    def __init__(self):
+        self.calls = []
+
+    def evaluate_operation(self, operation_name: str, *, approval_token: str | None = None):
+        self.calls.append((operation_name, approval_token))
+        if operation_name == "delete_vm" and approval_token != "approve-me":
+            return SimpleNamespace(
+                allowed=False,
+                code="OP_POLICY_APPROVAL_REQUIRED",
+                message="approval required",
+            )
+        return SimpleNamespace(allowed=True, code="OP_POLICY_ALLOW", message="allowed")
 
 
 def test_jobs_routes_return_expected_status_codes():
@@ -167,6 +202,31 @@ def test_jobs_routes_return_expected_status_codes():
     retry_response = client.post("/jobs/job-1/retry")
     assert retry_response.status_code == 202
     assert retry_response.json()["attempts"] == 2
+
+
+def test_retry_job_route_enforces_high_risk_policy():
+    policy = _FakeCommandPolicy()
+    app = create_app(
+        server_command=["python", "-c", "print('ok')"],
+        api_key=None,
+        strict_auth=False,
+        cors_allow_origins=["*"],
+        job_store=_FakeJobStore(),
+        command_policy=policy,
+    )
+    client = TestClient(app)
+
+    denied_response = client.post("/jobs/danger/retry")
+    assert denied_response.status_code == 403
+    assert denied_response.json()["message"] == "Job operation requires approval"
+
+    approved_response = client.post("/jobs/danger/retry", params={"approval_token": "approve-me"})
+    assert approved_response.status_code == 202
+    assert approved_response.json()["attempts"] == 2
+    assert policy.calls == [
+        ("delete_vm", None),
+        ("delete_vm", "approve-me"),
+    ]
 
 
 def test_jobs_routes_hide_internal_error_details():

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -52,6 +52,7 @@ def mock_env_vars(tmp_path):
         "PROXMOX_TOKEN_VALUE": "test_value",
         "LOG_LEVEL": "DEBUG",
         "COMMAND_POLICY_MODE": "audit_only",
+        "PROXMOX_JOBS_SQLITE_PATH": str(tmp_path / "jobs.sqlite3"),
     }
     with patch.dict(os.environ, env_vars):
         yield env_vars
@@ -174,6 +175,22 @@ def test_loader_allows_insecure_tls_in_dev_mode(tmp_path):
     assert config.proxmox.verify_ssl is False
 
 
+def test_loader_env_preserves_policy_default_lists(monkeypatch):
+    monkeypatch.setenv("PROXMOX_HOST", "test.proxmox.com")
+    monkeypatch.setenv("PROXMOX_USER", "test@pve")
+    monkeypatch.setenv("PROXMOX_TOKEN_NAME", "test_token")
+    monkeypatch.setenv("PROXMOX_TOKEN_VALUE", "test_value")
+    monkeypatch.setenv("PROXMOX_VERIFY_SSL", "true")
+    monkeypatch.delenv("COMMAND_POLICY_DENY_PATTERNS", raising=False)
+    monkeypatch.delenv("COMMAND_POLICY_HIGH_RISK_OPERATIONS", raising=False)
+
+    config = load_config(None)
+
+    assert config.command_policy.deny_patterns
+    assert any("rm" in pattern for pattern in config.command_policy.deny_patterns)
+    assert "delete_vm" in config.command_policy.high_risk_operations
+
+
 @pytest.mark.asyncio
 async def test_list_tools(server):
     """Test listing available tools. Config has no ssh section, so execute_container_command must be absent."""
@@ -292,6 +309,41 @@ async def test_get_vms(server, mock_proxmox):
     assert "vm1" in text
     assert "vm2" in text
 
+
+@pytest.mark.asyncio
+async def test_get_vms_uses_cluster_resource_inventory(server, mock_proxmox):
+    """Cluster resources avoid per-VM config lookups for large inventories."""
+    proxmox = mock_proxmox.return_value
+    proxmox.cluster.resources.get.return_value = [
+        {
+            "type": "qemu",
+            "vmid": "100",
+            "name": "vm1",
+            "status": "running",
+            "node": "node1",
+            "maxcpu": 2,
+            "mem": 512,
+            "maxmem": 2048,
+        },
+        {
+            "type": "lxc",
+            "vmid": "200",
+            "name": "ct1",
+            "status": "running",
+            "node": "node1",
+        },
+    ]
+    proxmox.nodes.reset_mock()
+
+    response = await server.mcp.call_tool("get_vms", {})
+    text = response[0].text
+
+    assert "vm1" in text
+    assert "ct1" not in text
+    proxmox.cluster.resources.get.assert_called_once_with(type="vm")
+    proxmox.nodes.assert_not_called()
+
+
 @pytest.mark.asyncio
 async def test_get_vms_skips_offline_node(server, mock_proxmox):
     """Test get_vms tool skips nodes that error."""
@@ -339,6 +391,42 @@ async def test_get_containers(server, mock_proxmox):
     assert len(result) > 0
     assert result[0]["name"] == "container1"
     assert result[1]["name"] == "container2"
+
+
+@pytest.mark.asyncio
+async def test_get_containers_uses_cluster_inventory_without_stats(server, mock_proxmox):
+    """Default container inventory should avoid node and per-container status scans."""
+    proxmox = mock_proxmox.return_value
+    proxmox.cluster.resources.get.return_value = [
+        {
+            "type": "lxc",
+            "vmid": "200",
+            "name": "container1",
+            "status": "running",
+            "node": "node1",
+            "cpu": 0.25,
+            "mem": 512,
+            "maxmem": 2048,
+            "maxcpu": 2,
+        },
+        {
+            "type": "qemu",
+            "vmid": "100",
+            "name": "vm1",
+            "status": "running",
+            "node": "node1",
+        },
+    ]
+    proxmox.nodes.reset_mock()
+
+    response = await server.mcp.call_tool("get_containers", {"format_style": "json"})
+    result = json.loads(response[0].text)
+
+    assert result[0]["name"] == "container1"
+    assert result[0]["cpu_pct"] == 25.0
+    assert result[0]["mem_pct"] == 25.0
+    proxmox.cluster.resources.get.assert_called_once_with(type="vm")
+    proxmox.nodes.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -636,6 +724,50 @@ async def test_execute_vm_command_success(server, mock_proxmox):
     assert "Status: SUCCESS" in text
     assert "command output" in text
 
+
+@pytest.mark.asyncio
+async def test_execute_vm_command_polls_until_command_exits(server, mock_proxmox, monkeypatch):
+    """VM command execution should keep polling exec-status until completion."""
+    mock_proxmox.return_value.nodes.return_value.qemu.return_value.status.current.get.return_value = {
+        "status": "running"
+    }
+    exec_endpoint = Mock()
+    exec_endpoint.post.return_value = {"pid": 321}
+    status_endpoint = Mock()
+    status_endpoint.get.side_effect = [
+        {
+            "out-data": "",
+            "err-data": "",
+            "exitcode": 0,
+            "exited": 0,
+        },
+        {
+            "out-data": "done",
+            "err-data": "",
+            "exitcode": 0,
+            "exited": 1,
+        },
+    ]
+    mock_proxmox.return_value.nodes.return_value.qemu.return_value.agent.side_effect = (
+        lambda action: exec_endpoint if action == "exec" else status_endpoint
+    )
+
+    async def fast_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr("proxmox_mcp.tools.console.manager.asyncio.sleep", fast_sleep)
+
+    response = await server.mcp.call_tool("execute_vm_command", {
+        "node": "node1",
+        "vmid": "100",
+        "command": "sleep 2 && echo done"
+    })
+
+    assert status_endpoint.get.call_count == 2
+    assert "Status: SUCCESS" in response[0].text
+    assert "done" in response[0].text
+
+
 @pytest.mark.asyncio
 async def test_execute_vm_command_missing_parameters(server):
     """Test VM command execution with missing parameters."""
@@ -684,7 +816,7 @@ async def test_execute_vm_command_with_error(server, mock_proxmox):
     })
     text = response[0].text
     assert "Console Command Result" in text
-    assert "Status: SUCCESS" in text
+    assert "Status: FAILED" in text
     assert "command not found" in text
 
 
@@ -755,7 +887,21 @@ async def test_clone_vm(server, mock_proxmox):
     )
 
     assert "clone initiated successfully" in response[0].text
+    assert "Job ID:" in response[0].text
     source_vm_api.clone.post.assert_called_once_with(newid=9100, full=1, name="cloned-vm")
+
+    jobs = await server.mcp.call_tool("list_jobs", {"tool_name": "clone_vm", "limit": 1})
+    jobs_payload = json.loads(jobs[0].text)
+    assert len(jobs_payload) == 1
+    assert jobs_payload[0]["tool_name"] == "clone_vm"
+    assert jobs_payload[0]["retry_spec"] == {
+        "kind": "vm.clone",
+        "params": {
+            "node": "node1",
+            "source_vmid": "9000",
+            "clone_payload": {"newid": 9100, "full": 1, "name": "cloned-vm"},
+        },
+    }
 
 
 @pytest.mark.asyncio
@@ -987,3 +1133,44 @@ async def test_high_risk_operation_requires_approval_token(mock_proxmox, tmp_pat
             "delete_vm",
             {"node": "node1", "vmid": "100", "force": False},
         )
+
+
+@pytest.mark.asyncio
+async def test_high_risk_job_retry_requires_approval_token(mock_proxmox, tmp_path):
+    config_path = tmp_path / "config_high_risk_retry.json"
+    config_path.write_text(json.dumps({
+        "proxmox": {"host": "test.proxmox.com", "port": 8006, "verify_ssl": True, "service": "PVE"},
+        "auth": {"user": "test@pve", "token_name": "test_token", "token_value": "test_value"},
+        "logging": {"level": "DEBUG"},
+        "jobs": {"sqlite_path": str(tmp_path / "jobs.sqlite3")},
+        "command_policy": {
+            "mode": "audit_only",
+            "high_risk_mode": "enforce",
+            "high_risk_require_approval_token": True,
+            "high_risk_approval_token": "approve-me",
+        },
+    }))
+
+    policy_server = ProxmoxMCPServer(str(config_path))
+    retry_factory = Mock(return_value="UPID:retry-delete")
+    job = policy_server.job_store.register_task(
+        tool_name="delete_vm",
+        summary="Delete VM 100",
+        node="node1",
+        upid="UPID:delete-original",
+        retry_factory=retry_factory,
+    )
+
+    with pytest.raises(ToolError, match="requires an approval token"):
+        await policy_server.mcp.call_tool("retry_job", {"job_id": job["job_id"]})
+
+    retry_factory.assert_not_called()
+
+    response = await policy_server.mcp.call_tool(
+        "retry_job",
+        {"job_id": job["job_id"], "approval_token": "approve-me"},
+    )
+    payload = json.loads(response[0].text)
+
+    assert payload["upid"] == "UPID:retry-delete"
+    retry_factory.assert_called_once()


### PR DESCRIPTION
## Summary

Prepare the v0.4.9 reliability release.

This change hardens persistent job storage, OpenAPI job retry policy, large-cluster inventory reads, HTTP metrics labels, and release quality gates. It also publishes tracking for Paramiko CVE-2026-44405, wires clone_vm into the persistent JobStore retry model, and sanitizes high-risk retry audit log values to satisfy CodeQL log-injection rules.

## Release

- Version bumped to 0.4.9 across package metadata, manifest.json, server.json, and __version__.
- v0.4.9 supersedes v0.4.8.
- GitHub Release v0.4.9 will be published from commit 1990db7.

## Validation

- python -m pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=60
- python -m ruff check .
- python -m mypy src --ignore-missing-imports
- python -m pip_audit -r requirements.txt --ignore-vuln CVE-2026-44405
- python -m build
- python -m twine check dist\\*
- GitHub PR CI and CodeQL passed