### PR TITLE
[codex] align OpenAPI auth docs with secure defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,12 @@ proxmox-mcp-plus
 
 #### Docker / GHCR
 
-OpenAPI mode remains the default Docker runtime:
+OpenAPI mode remains the default Docker runtime and requires an API key:
 
 ```bash
+export PROXMOX_API_KEY="$(openssl rand -hex 32)"
 docker run --rm -p 8811:8811 \
+  -e PROXMOX_API_KEY="$PROXMOX_API_KEY" \
   -v "$(pwd)/proxmox-config/config.json:/app/proxmox-config/config.json:ro" \
   ghcr.io/rekklesna/proxmoxmcp-plus:latest
 ```
@@ -147,10 +149,13 @@ python main.py
 ### 3. Run the HTTP/OpenAPI surface
 
 ```bash
+export PROXMOX_API_KEY="${PROXMOX_API_KEY:-$(openssl rand -hex 32)}"
 docker compose up -d
-curl -f http://localhost:8811/health
-curl http://localhost:8811/openapi.json
+curl -f -H "Authorization: Bearer $PROXMOX_API_KEY" http://localhost:8811/health
+curl -H "Authorization: Bearer $PROXMOX_API_KEY" http://localhost:8811/openapi.json
 ```
+
+For local unauthenticated development only, set `PROXMOX_ALLOW_NO_AUTH=true`.
 
 ### 4. Run the native MCP Streamable HTTP surface
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,11 +9,13 @@ services:
       - ./proxmox-config:/app/proxmox-config:ro
     environment:
       - PROXMOX_MCP_CONFIG=/app/proxmox-config/config.json
+      # Set PROXMOX_API_KEY in your shell or .env before starting OpenAPI mode.
+      - PROXMOX_API_KEY=${PROXMOX_API_KEY:?Set PROXMOX_API_KEY before starting OpenAPI mode}
       - API_HOST=0.0.0.0
       - API_PORT=8811
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8811/health"]
+      test: ["CMD-SHELL", "curl -f -H \"Authorization: Bearer $$PROXMOX_API_KEY\" http://localhost:8811/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docs/wiki/Integrations Guide.md
+++ b/docs/wiki/Integrations Guide.md
@@ -85,12 +85,15 @@ This path works well for:
 
 The proxy supports:
 
-- optional API key middleware
-- strict auth mode
+- API key middleware, required by default
+- automatic strict auth when `PROXMOX_API_KEY` is configured
 - configurable CORS allow origins
 - configurable path prefix and root path
 
-If you expose the API outside a dev machine, configure an API key and restrict origin/network access.
+OpenAPI mode refuses to start without `PROXMOX_API_KEY` unless
+`PROXMOX_ALLOW_NO_AUTH=true` is set for local unauthenticated development.
+Send authenticated requests with `Authorization: Bearer <PROXMOX_API_KEY>`.
+If you expose the API outside a dev machine, also restrict origin and network access.
 
 ## Integration Checks
 

--- a/docs/wiki/Operator Guide.md
+++ b/docs/wiki/Operator Guide.md
@@ -98,8 +98,13 @@ This is the correct target for MCP clients that support Streamable HTTP. It is s
 You can run the OpenAPI wrapper directly:
 
 ```bash
+export PROXMOX_API_KEY="$(openssl rand -hex 32)"
 python -m proxmox_mcp.openapi_proxy --host 0.0.0.0 --port 8811 -- python main.py
 ```
+
+OpenAPI mode refuses to start without `PROXMOX_API_KEY` unless
+`PROXMOX_ALLOW_NO_AUTH=true` is set for local unauthenticated development.
+HTTP clients should send the key as `Authorization: Bearer <PROXMOX_API_KEY>`.
 
 Available routes:
 
@@ -121,11 +126,13 @@ Default Compose behavior:
 - Exposes `8811`
 - Keeps OpenAPI mode as the default Docker runtime
 - Sets `PROXMOX_MCP_CONFIG=/app/proxmox-config/config.json`
+- Requires `PROXMOX_API_KEY` from your shell or Compose `.env` file
 - Adds a container health check against `http://localhost:8811/health`
 
 Start it with:
 
 ```bash
+export PROXMOX_API_KEY="${PROXMOX_API_KEY:-$(openssl rand -hex 32)}"
 docker compose up -d --build
 ```
 

--- a/docs/wiki/Security Guide.md
+++ b/docs/wiki/Security Guide.md
@@ -73,7 +73,7 @@ Read the full setup and threat model in [Container Command Execution](Container-
 
 If you run the OpenAPI proxy:
 
-- configure an API key when the service is not strictly local
+- configure `PROXMOX_API_KEY`; startup refuses no-auth mode unless `PROXMOX_ALLOW_NO_AUTH=true` is set
 - place it behind TLS termination
 - restrict ingress to networks you control
 - monitor `/health`

--- a/scripts/start_openapi.sh
+++ b/scripts/start_openapi.sh
@@ -35,11 +35,23 @@ if [ ! -f "${CONFIG_FILE}" ]; then
     exit 1
 fi
 
+ALLOW_NO_AUTH="$(printf '%s' "${PROXMOX_ALLOW_NO_AUTH:-false}" | tr '[:upper:]' '[:lower:]')"
+if [ -z "${PROXMOX_API_KEY:-}" ] && [ "${ALLOW_NO_AUTH}" != "true" ]; then
+    echo "PROXMOX_API_KEY is required before starting the OpenAPI proxy."
+    echo "For local unauthenticated development only, set PROXMOX_ALLOW_NO_AUTH=true."
+    exit 1
+fi
+
 echo "Configuration file: ${CONFIG_FILE}"
 echo "OpenAPI proxy address: http://${HOST}:${PORT}"
 echo "OpenAPI docs: http://${HOST}:${PORT}/docs"
 echo "OpenAPI schema: http://${HOST}:${PORT}/openapi.json"
 echo "Health check: http://${HOST}:${PORT}/health"
+if [ -n "${PROXMOX_API_KEY:-}" ]; then
+    echo "OpenAPI auth: use Authorization: Bearer <PROXMOX_API_KEY>"
+elif [ "${ALLOW_NO_AUTH}" = "true" ]; then
+    echo "OpenAPI auth: disabled by PROXMOX_ALLOW_NO_AUTH=true (not recommended)"
+fi
 echo
 
 export PROXMOX_MCP_CONFIG="${CONFIG_FILE}"

--- a/src/proxmox_mcp/openapi_proxy.py
+++ b/src/proxmox_mcp/openapi_proxy.py
@@ -41,7 +41,7 @@ def _security_warnings(*, api_key: Optional[str], strict_auth: bool, cors_allow_
         warnings.append("OpenAPI proxy is running without PROXMOX_API_KEY.")
     if api_key and not strict_auth:
         warnings.append("PROXMOX_API_KEY is configured but PROXMOX_STRICT_AUTH is disabled.")
-    if os.getenv("PROXMOX_ALLOW_NO_AUTH", "false").lower() == "true":
+    if not api_key and os.getenv("PROXMOX_ALLOW_NO_AUTH", "false").lower() == "true":
         warnings.append(
             "PROXMOX_ALLOW_NO_AUTH=true is set; OpenAPI proxy is running without an API key."
         )

--- a/tests/test_openapi_proxy.py
+++ b/tests/test_openapi_proxy.py
@@ -284,6 +284,22 @@ def test_health_endpoint_warns_when_allow_no_auth_set(monkeypatch):
     assert "PROXMOX_ALLOW_NO_AUTH=true" in payload
 
 
+def test_health_endpoint_does_not_warn_allow_no_auth_when_api_key_set(monkeypatch):
+    monkeypatch.setenv("PROXMOX_ALLOW_NO_AUTH", "true")
+    app = create_app(
+        server_command=["python", "-c", "print('ok')"],
+        api_key="secret",
+        strict_auth=True,
+        cors_allow_origins=["https://example.test"],
+    )
+    endpoint = _get_route_endpoint(app, "/health")
+    response = asyncio.run(endpoint())
+    payload = response.body.decode("utf-8")
+
+    assert "PROXMOX_ALLOW_NO_AUTH=true" not in payload
+    assert "without PROXMOX_API_KEY" not in payload
+
+
 def test_retry_job_route_enforces_high_risk_policy():
     policy = _FakeCommandPolicy()
     app = create_app(


### PR DESCRIPTION
## Summary

- update OpenAPI quick-start and operator docs for the new required `PROXMOX_API_KEY` default
- require `PROXMOX_API_KEY` in Docker Compose and authenticate the container healthcheck
- make `scripts/start_openapi.sh` fail early with a clear auth message
- avoid reporting `PROXMOX_ALLOW_NO_AUTH=true` as active no-auth mode when an API key is configured

## Validation

- `pytest -q` -> 108 passed, 1 skipped
- `ruff check .`
- `mypy src --ignore-missing-imports`
- `PROXMOX_API_KEY=test-token docker compose config`
- `bash -n scripts/start_openapi.sh` using Git Bash