### PR TITLE
[codex] release v0.5.0 OpenAPI security baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,7 @@ jobs:
 
     - name: pip-audit
       run: |
-        # CVE-2026-44405 has no fixed Paramiko release on PyPI yet.
-        # Tracked in docs/security/paramiko-cve-2026-44405.md.
-        pip-audit -r requirements.txt --ignore-vuln CVE-2026-44405
+        pip-audit -r requirements.txt
 
     - name: Validate Manifest JSON
       run: |

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ python main.py
 ```bash
 export PROXMOX_API_KEY="${PROXMOX_API_KEY:-$(openssl rand -hex 32)}"
 docker compose up -d
+curl -f http://localhost:8811/livez
 curl -f -H "Authorization: Bearer $PROXMOX_API_KEY" http://localhost:8811/health
 curl -H "Authorization: Bearer $PROXMOX_API_KEY" http://localhost:8811/openapi.json
 ```
@@ -193,7 +194,7 @@ Client-specific examples for Claude Desktop and Open WebUI are in the [Integrati
 
 ## Demo
 
-This demo is a direct terminal recording of `qwen/qwen3.6-plus` driving a live MCP session in English against a local Proxmox lab. It shows natural-language control flowing through MCP tools to create and start an LXC, execute a container command, and confirm the HTTP `/health` surface.
+This demo is a direct terminal recording of `qwen/qwen3.6-plus` driving a live MCP session in English against a local Proxmox lab. It shows natural-language control flowing through MCP tools to create and start an LXC, execute a container command, and confirm the authenticated HTTP `/health` surface.
 
 ![Recorded demo gif](docs/assets/proxmoxmcp-demo.gif)
 
@@ -217,16 +218,16 @@ Supported workflow areas:
 | Persistent job store for long tasks | Available |
 | MCP job control tools (`list_jobs`, `get_job`, `poll_job`, `cancel_job`, `retry_job`) | Available |
 | OpenAPI `/jobs` endpoints with explicit status codes | Available |
-| Local OpenAPI `/health` and schema | Available |
+| Local OpenAPI `/livez`, `/readyz`, `/health`, and schema | Available |
 | Docker native MCP Streamable HTTP at `/mcp` | Available |
-| Docker image build and `/health` | Available |
+| Docker image build and `/livez` | Available |
 
 Validation and contract entry points in this repository:
 
 - `pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=60`
 - `ruff check .`
 - `mypy src --ignore-missing-imports`
-- `pip-audit -r requirements.txt --ignore-vuln CVE-2026-44405`
+- `pip-audit -r requirements.txt`
 - `tests/integration/test_real_contract.py`
 - `tests/scripts/run_real_e2e.py`
 
@@ -342,11 +343,11 @@ Published wiki:
 pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=60
 ruff check .
 mypy src --ignore-missing-imports
-pip-audit -r requirements.txt --ignore-vuln CVE-2026-44405
+pip-audit -r requirements.txt
 python -m build
 ```
 
-The Paramiko audit exception is temporary. It is tracked in `docs/security/paramiko-cve-2026-44405.md` until a patched PyPI release is available.
+Paramiko 5.0.0 or newer is required so `pip-audit` can run without a `CVE-2026-44405` exception.
 
 ## License
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   proxmox-mcp-api:
     build: .
@@ -15,7 +13,7 @@ services:
       - API_PORT=8811
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "curl -f -H \"Authorization: Bearer $$PROXMOX_API_KEY\" http://localhost:8811/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8811/livez"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -4,7 +4,7 @@
 
 Record a short GIF or video that shows:
 
-`Claude Desktop or Open WebUI -> Proxmox action -> /health OK`
+`Claude Desktop or Open WebUI -> Proxmox action -> authenticated /health OK`
 
 ## Shot list
 
@@ -19,7 +19,7 @@ Create a small Proxmox test VM, snapshot it, and confirm the OpenAPI bridge is h
 
 - VM created or started
 - snapshot created
-- `/health` returns `{"status":"ok","connected_to_mcp":true}`
+- authenticated `/health` returns `{"status":"ok","connected_to_mcp":true}`
 
 4. End frame:
 
@@ -31,4 +31,4 @@ Create a small Proxmox test VM, snapshot it, and confirm the OpenAPI bridge is h
 - keep the clip under 30 seconds
 - avoid terminal noise that does not prove value
 - show one prompt and one concrete Proxmox result
-- end with `/health` because it is easy to understand even for non-Proxmox users
+- end with authenticated `/health` because it is easy to understand even for non-Proxmox users

--- a/docs/examples/create-test-vm.md
+++ b/docs/examples/create-test-vm.md
@@ -14,7 +14,10 @@ Use the best available storage automatically, then start it and show me the resu
 ## Example OpenAPI request
 
 ```bash
+export PROXMOX_API_KEY="${PROXMOX_API_KEY:?Set PROXMOX_API_KEY first}"
+
 curl -X POST http://localhost:8811/create_vm \
+  -H "Authorization: Bearer $PROXMOX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "node": "pve",
@@ -30,6 +33,7 @@ Then start it:
 
 ```bash
 curl -X POST http://localhost:8811/start_vm \
+  -H "Authorization: Bearer $PROXMOX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "node": "pve",

--- a/docs/examples/download-iso-and-create-lxc.md
+++ b/docs/examples/download-iso-and-create-lxc.md
@@ -16,7 +16,10 @@ start it, and tell me whether the HTTP/OpenAPI bridge is healthy.
 Download an ISO:
 
 ```bash
+export PROXMOX_API_KEY="${PROXMOX_API_KEY:?Set PROXMOX_API_KEY first}"
+
 curl -X POST http://localhost:8811/download_iso \
+  -H "Authorization: Bearer $PROXMOX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "node": "pve",
@@ -30,6 +33,7 @@ Create an LXC:
 
 ```bash
 curl -X POST http://localhost:8811/create_container \
+  -H "Authorization: Bearer $PROXMOX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "node": "pve",
@@ -43,7 +47,8 @@ curl -X POST http://localhost:8811/create_container \
 Check the bridge:
 
 ```bash
-curl -f http://localhost:8811/health
+curl -f -H "Authorization: Bearer $PROXMOX_API_KEY" http://localhost:8811/health
+curl -f http://localhost:8811/livez
 ```
 
 ## Expected operator outcome

--- a/docs/examples/rollback-snapshot.md
+++ b/docs/examples/rollback-snapshot.md
@@ -16,7 +16,10 @@ If the post-change validation fails, roll back that snapshot and confirm the VM 
 Create the snapshot:
 
 ```bash
+export PROXMOX_API_KEY="${PROXMOX_API_KEY:?Set PROXMOX_API_KEY first}"
+
 curl -X POST http://localhost:8811/create_snapshot \
+  -H "Authorization: Bearer $PROXMOX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "node": "pve",
@@ -30,6 +33,7 @@ Roll it back:
 
 ```bash
 curl -X POST http://localhost:8811/rollback_snapshot \
+  -H "Authorization: Bearer $PROXMOX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "node": "pve",

--- a/docs/launch-post.md
+++ b/docs/launch-post.md
@@ -25,8 +25,8 @@ I verified these paths against a live Proxmox environment:
 - ISO download / delete
 - LXC create / start / stop / delete
 - container SSH-backed command execution
-- OpenAPI `/health`
-- Docker image build and `/health`
+- OpenAPI authenticated `/health`
+- Docker image build and `/livez`
 
 Repo:
 
@@ -58,6 +58,6 @@ So I built `ProxmoxMCP-Plus`, which exposes Proxmox operations through:
 
 The main thing I wanted to prove was that it is not just a wrapper around documentation.
 
-I tested live workflows for VM, LXC, snapshot, backup, restore, ISO, container SSH execution, local `/health`, and Docker `/health`.
+I tested live workflows for VM, LXC, snapshot, backup, restore, ISO, container SSH execution, local authenticated `/health`, and Docker `/livez`.
 
 Repo: https://github.com/RekklesNA/ProxmoxMCP-Plus

--- a/docs/releases/v0.5.0.md
+++ b/docs/releases/v0.5.0.md
@@ -1,0 +1,30 @@
+# ProxmoxMCP-Plus v0.5.0
+
+This release changes the OpenAPI security baseline. OpenAPI mode now refuses to start without `PROXMOX_API_KEY` unless `PROXMOX_ALLOW_NO_AUTH=true` is explicitly set for local unauthenticated development. HTTP clients must send `Authorization: Bearer <PROXMOX_API_KEY>`.
+
+## Highlights
+
+- OpenAPI auth is enforced by a project-owned middleware using constant-time API key comparison.
+- Auth failures now pass through the rate limiter, so repeated 401/403 responses can be throttled.
+- `/livez` provides unauthenticated process liveness, while `/readyz` and `/health` remain authenticated readiness endpoints.
+- Live E2E OpenAPI checks now set `PROXMOX_API_KEY` and send Bearer auth to `/health` and `/openapi.json`.
+- OpenAPI examples now include `Authorization` headers.
+- `scripts/start_openapi.sh` now launches the proxy with `.venv/bin/python` and checks `mcpo` in that virtual environment.
+- Paramiko is upgraded to `>=5.0.0,<6.0.0`, removing the temporary `CVE-2026-44405` audit exception.
+
+## Upgrade Notes
+
+- Set `PROXMOX_API_KEY` before starting OpenAPI mode through Docker, Compose, or `python -m proxmox_mcp.openapi_proxy`.
+- Update HTTP/OpenAPI clients to include `Authorization: Bearer <PROXMOX_API_KEY>`.
+- Use `/livez` for unauthenticated container or orchestrator liveness checks.
+- Use `/readyz` or `/health` with auth when you need MCP backend readiness details.
+- Only set `PROXMOX_ALLOW_NO_AUTH=true` for local development where unauthenticated access is intentional.
+- Paramiko 5 removes legacy RSA/SHA-1 signatures, SHA-1 key exchange algorithms, and GSSAPI support. Update old SSH endpoints before upgrading if they depend on those algorithms.
+
+## Validation
+
+- `pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=60`
+- `ruff check .`
+- `mypy src --ignore-missing-imports`
+- `pip-audit -r requirements.txt`
+- `python -m build`

--- a/docs/security/paramiko-cve-2026-44405.md
+++ b/docs/security/paramiko-cve-2026-44405.md
@@ -1,20 +1,19 @@
-# Paramiko CVE-2026-44405 Tracking
+# Paramiko CVE-2026-44405 Resolution
 
-Status as of 2026-05-09:
+Status as of 2026-05-11:
 
 - Ubuntu lists CVE-2026-44405 for Paramiko through 4.0.0 before commit `a448945`, in RSA/SHA-1 handling.
-- PyPI currently lists Paramiko 4.0.0 as the latest release.
-- `python -m pip_audit -r requirements.txt` resolves Paramiko 4.0.0 and still reports CVE-2026-44405 with no fixed version available.
+- PyPI now publishes Paramiko 5.0.0.
+- The repository now requires `paramiko>=5.0.0,<6.0.0`.
+- CI runs `pip-audit -r requirements.txt` without a CVE exception.
 
-Repository action:
+Compatibility note:
 
-- Runtime dependency constraints now allow Paramiko 4.x with `paramiko>=4.0.0,<5.0.0`, so the next patched 4.x release can be adopted without another upper-bound change.
-- CI temporarily ignores only `CVE-2026-44405` while no fixed PyPI release exists.
-- Remove `--ignore-vuln CVE-2026-44405` from CI and docs once a patched Paramiko release is published and `pip-audit -r requirements.txt` passes without the exception.
-- Paramiko 4 compatibility is covered by the regular unit, lint, type, audit, and build gates.
+- Paramiko 5 removes legacy RSA/SHA-1 signatures, SHA-1 key exchange algorithms, and GSSAPI support. Operators using old SSH servers or deprecated SSH crypto should update those endpoints before upgrading.
+- The ProxmoxMCP-Plus container command path uses standard SSH client and `SSHClient` APIs that are still covered by unit tests.
 
 References:
 
 - [Ubuntu CVE-2026-44405](https://ubuntu.com/security/CVE-2026-44405)
-- [Paramiko commit a448945](https://github.com/paramiko/paramiko/commit/a4489456b6f65281e172380cc4826cee5e851dbb)
+- [Paramiko 5.0.0 changelog](https://www.paramiko.org/changelog.html)
 - [PyPI Paramiko](https://pypi.org/project/paramiko/)

--- a/docs/wiki/API & Tool Reference.md
+++ b/docs/wiki/API & Tool Reference.md
@@ -31,7 +31,9 @@ When the OpenAPI wrapper is enabled, the primary endpoints are:
 | `/` | service metadata | basic wrapper metadata |
 | `/docs` | Swagger UI | interactive API docs for the currently running tool set |
 | `/openapi.json` | generated OpenAPI schema | reflects conditional tool registration such as SSH-backed tools |
-| `/health` | health and backend status | validates wrapper availability and MCP backend connectivity |
+| `/livez` | liveness check | unauthenticated, minimal process liveness |
+| `/readyz` | readiness check | requires OpenAPI auth and reports MCP backend connectivity |
+| `/health` | readiness alias | requires OpenAPI auth and matches `/readyz` |
 | `/metrics` | Prometheus metrics | includes per-route labels for `route`, `method`, and `status` |
 | `/jobs` | persistent job list | requires a local `JobStore` in the OpenAPI process |
 
@@ -40,6 +42,7 @@ When the OpenAPI wrapper is enabled, the primary endpoints are:
 ### Authentication and Authorization
 
 - Proxmox API access requires a valid `proxmox` and `auth` configuration.
+- OpenAPI access requires `Authorization: Bearer <PROXMOX_API_KEY>` by default. Startup without an API key requires the explicit local-development override `PROXMOX_ALLOW_NO_AUTH=true`.
 - SSH-backed container command workflows require a valid `ssh` configuration.
 - Command-execution tools are subject to command-policy checks. Depending on policy, a request can be allowed, denied, or require an `approval_token`.
 - Detailed policy behavior lives in the [Security Guide](Security-Guide).

--- a/docs/wiki/Developer Guide.md
+++ b/docs/wiki/Developer Guide.md
@@ -18,14 +18,15 @@ Set `proxmox-config/config.json` to a real environment or use a test config path
 pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=60
 ruff check .
 mypy src --ignore-missing-imports
-pip-audit -r requirements.txt --ignore-vuln CVE-2026-44405
+pip-audit -r requirements.txt
 black .
 python main.py
+export PROXMOX_API_KEY="${PROXMOX_API_KEY:-$(openssl rand -hex 32)}"
 python -m proxmox_mcp.openapi_proxy --host 0.0.0.0 --port 8811 -- python main.py
 ```
 
 The coverage gate starts at 60% so CI tracks regressions while coverage is expanded around high-risk tools and the JobStore/OpenAPI boundary.
-The Paramiko audit exception is temporary and tracked in `docs/security/paramiko-cve-2026-44405.md`.
+OpenAPI mode requires `PROXMOX_API_KEY` by default. For local unauthenticated development only, set `PROXMOX_ALLOW_NO_AUTH=true`.
 
 ## Project Layout
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -18,7 +18,7 @@ Use the root `README.md` for the fast project overview. Use this wiki when you n
 | Connect Claude Desktop, Open WebUI, or HTTP clients | [Integrations Guide](Integrations-Guide) |
 | Understand auth, command policy, and execution safety | [Security Guide](Security-Guide) |
 | Browse the exact tool surface and prerequisites | [API & Tool Reference](API-&-Tool-Reference) |
-| Debug startup, auth, SSH, or `/health` issues | [Troubleshooting](Troubleshooting) |
+| Debug startup, auth, SSH, `/livez`, or `/health` issues | [Troubleshooting](Troubleshooting) |
 | Review release history and upgrade notes | [Release & Upgrade Notes](Release-&-Upgrade-Notes) |
 
 ## What The Project Covers
@@ -35,7 +35,7 @@ Use the root `README.md` for the fast project overview. Use this wiki when you n
 
 - `main.py` starts the MCP server entrypoint
 - `src/proxmox_mcp/server.py` registers MCP tools
-- `src/proxmox_mcp/openapi_proxy.py` exposes `/`, `/docs`, `/openapi.json`, `/health`, `/metrics`, and `/jobs`
+- `src/proxmox_mcp/openapi_proxy.py` exposes `/`, `/docs`, `/openapi.json`, `/livez`, `/readyz`, `/health`, `/metrics`, and `/jobs`
 - `src/proxmox_mcp/config/` validates configuration and runtime settings
 - `src/proxmox_mcp/security/command_policy.py` applies allow and deny rules for execution requests
 - `src/proxmox_mcp/services/jobs.py` persists long-running job state in SQLite
@@ -52,15 +52,15 @@ The repository includes live-environment verification entry points for:
 - LXC create, start, stop, and delete
 - container SSH-backed command execution
 - container authorized_keys update
-- local OpenAPI `/health` and schema
-- Docker image build and `/health`
+- local OpenAPI `/livez`, `/readyz`, `/health`, and schema
+- Docker image build and `/livez`
 
 Primary validation entry points:
 
 - `pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=60`
 - `ruff check .`
 - `mypy src --ignore-missing-imports`
-- `pip-audit -r requirements.txt --ignore-vuln CVE-2026-44405`
+- `pip-audit -r requirements.txt`
 - `tests/integration/test_real_contract.py`
 - `tests/scripts/run_real_e2e.py`
 

--- a/docs/wiki/Integrations Guide.md
+++ b/docs/wiki/Integrations Guide.md
@@ -72,7 +72,9 @@ For HTTP-native clients, run the OpenAPI wrapper and connect to:
 - root: `http://<host>:8811/`
 - docs: `http://<host>:8811/docs`
 - schema: `http://<host>:8811/openapi.json`
-- health: `http://<host>:8811/health`
+- liveness: `http://<host>:8811/livez`
+- readiness: `http://<host>:8811/readyz`
+- health readiness alias: `http://<host>:8811/health`
 
 This path works well for:
 
@@ -101,14 +103,14 @@ After connecting a client, verify:
 
 - the server starts without config validation errors
 - read-only tools such as `get_nodes` and `get_vms` are listed
-- OpenAPI mode returns `/docs` and `/health`
+- OpenAPI mode returns unauthenticated `/livez`, plus authenticated `/docs` and `/health`
 - container SSH tools appear only when the `ssh` config exists
 
 ## Common Integration Mistakes
 
 - `PYTHONPATH` not set when running from source
 - `PROXMOX_MCP_CONFIG` points to the wrong file
-- OpenAPI proxy runs, but `/health` stays degraded because the MCP subprocess did not start
+- OpenAPI proxy runs, but authenticated `/health` stays degraded because the MCP subprocess did not start
 - TLS verification disabled in config while `dev_mode` is false
 - assuming `execute_container_command` should exist without an `ssh` section
 

--- a/docs/wiki/Operator Guide.md
+++ b/docs/wiki/Operator Guide.md
@@ -111,7 +111,9 @@ Available routes:
 - `/` returns basic service metadata
 - `/docs` serves Swagger UI
 - `/openapi.json` serves the generated schema
-- `/health` returns `503` until the proxy is connected to the MCP backend, then `200`
+- `/livez` returns minimal unauthenticated process liveness
+- `/readyz` returns `503` until the proxy is connected to the MCP backend, then `200`
+- `/health` is a readiness alias for `/readyz`
 - `/metrics` exposes Prometheus-style request metrics
 - `/jobs` exposes direct job query and control routes when a local `JobStore` is available
 
@@ -127,7 +129,7 @@ Default Compose behavior:
 - Keeps OpenAPI mode as the default Docker runtime
 - Sets `PROXMOX_MCP_CONFIG=/app/proxmox-config/config.json`
 - Requires `PROXMOX_API_KEY` from your shell or Compose `.env` file
-- Adds a container health check against `http://localhost:8811/health`
+- Adds a container liveness health check against `http://localhost:8811/livez`
 
 Start it with:
 
@@ -163,9 +165,9 @@ Before exposing the service to users:
 - Confirm the Proxmox API token has only the permissions you intend to expose
 - Keep `proxmox.verify_ssl=true` unless you are explicitly in development mode
 - Keep `security.dev_mode=false` outside local testing
-- Set an API key when exposing the OpenAPI endpoint outside a private dev machine
+- Set `PROXMOX_API_KEY` for OpenAPI mode; only use `PROXMOX_ALLOW_NO_AUTH=true` for local unauthenticated development
 - Restrict ingress to networks you control
-- Monitor the `/health` endpoint if you run the OpenAPI proxy
+- Monitor `/livez` for process liveness and authenticated `/health` or `/readyz` for backend readiness
 - Monitor `/metrics` if you scrape the service with Prometheus-compatible tooling
 - Persist the configured `jobs.sqlite_path` on durable storage if job history matters across restarts
 - Store logs somewhere persistent if you need auditability
@@ -205,7 +207,7 @@ After deployment, test in this order:
 
 1. Start the service and confirm there are no config validation errors
 2. Call read-only tools first: `get_nodes`, `get_vms`, `get_storage`, `get_cluster_status`
-3. In OpenAPI mode, confirm `/health` and `/docs` both respond
+3. In OpenAPI mode, confirm `/livez` responds and authenticated `/health` and `/docs` requests work
 4. Confirm `/jobs` responds if you expect persistent job tracking
 5. If you enabled SSH-backed container commands, confirm `execute_container_command` appears in the tool list
 6. Only then test mutating tools such as create, start, delete, snapshot, or backup
@@ -215,7 +217,7 @@ After deployment, test in this order:
 - Application logging is configured under the `logging` section
 - `main.py` prints early startup messages to stderr to make bootstrap failures visible
 - The OpenAPI wrapper reports `degraded` until it is connected to the MCP subprocess
-- `/health` reports whether direct job routes are enabled in the OpenAPI process
+- authenticated `/health` reports whether direct job routes are enabled in the OpenAPI process
 
 ## Related Pages
 

--- a/docs/wiki/Release & Upgrade Notes.md
+++ b/docs/wiki/Release & Upgrade Notes.md
@@ -18,6 +18,48 @@ Use this page to track version-level behavior changes, upgrade steps, and rollba
 
 ## Release History
 
+### Version `0.5.0`
+
+- Release date: 2026-05-11
+- Summary: OpenAPI security baseline release with required API-key startup, project-owned constant-time auth middleware, auth-failure rate limiting, split liveness/readiness probes, live E2E auth updates, and Paramiko 5.0.0.
+- New tools or endpoints:
+  - `/livez` for unauthenticated process liveness
+  - `/readyz` for authenticated backend readiness
+- Changed behavior:
+  - OpenAPI mode refuses to start without `PROXMOX_API_KEY` unless `PROXMOX_ALLOW_NO_AUTH=true` is set
+  - OpenAPI requests require `Authorization: Bearer <PROXMOX_API_KEY>` by default
+  - OpenAPI API key verification uses project-owned constant-time comparison
+  - auth failures pass through rate limiting before the auth decision
+  - `/health` remains available as an authenticated readiness alias
+  - live E2E and Docker OpenAPI checks send Bearer auth
+  - `scripts/start_openapi.sh` uses `.venv/bin/python` for proxy startup and dependency checks
+- Removed or deprecated behavior:
+  - unauthenticated OpenAPI startup is no longer the default
+  - the temporary `CVE-2026-44405` `pip-audit` exception is removed
+- Config changes:
+  - `PROXMOX_API_KEY` is required for OpenAPI mode unless `PROXMOX_ALLOW_NO_AUTH=true`
+  - runtime dependency support now requires `paramiko>=5.0.0,<6.0.0`
+- Docs updated:
+  - `README.md`
+  - `docs/examples/*.md`
+  - `docs/releases/v0.5.0.md`
+  - `docs/security/paramiko-cve-2026-44405.md`
+  - `docs/wiki/API & Tool Reference.md`
+  - `docs/wiki/Developer Guide.md`
+  - `docs/wiki/Home.md`
+  - `docs/wiki/Integrations Guide.md`
+  - `docs/wiki/Operator Guide.md`
+  - `docs/wiki/Release & Upgrade Notes.md`
+  - `docs/wiki/Security Guide.md`
+- Upgrade steps:
+  - set `PROXMOX_API_KEY` before starting OpenAPI mode
+  - update HTTP clients to send `Authorization: Bearer <PROXMOX_API_KEY>`
+  - use `/livez` for unauthenticated process liveness
+  - use authenticated `/readyz` or `/health` for backend readiness
+  - verify SSH endpoints do not depend on legacy RSA/SHA-1, SHA-1 KEX, or GSSAPI before adopting Paramiko 5
+- Rollback notes:
+  - downgrade to `v0.4.9` if clients cannot yet send OpenAPI auth headers, but keep the Paramiko CVE tracking and OpenAPI no-auth exposure in mind
+
 ### Version `0.4.9`
 
 - Release date: 2026-05-09
@@ -246,7 +288,7 @@ Before upgrading:
 
 - review changes to config examples
 - review command policy defaults
-- review OpenAPI wrapper behavior if your deployment depends on `/health` or auth
+- review OpenAPI wrapper behavior if your deployment depends on `/livez`, `/readyz`, `/health`, or auth
 - check whether any new tool requires extra credentials or runtime dependencies
 
 After upgrading:
@@ -254,7 +296,7 @@ After upgrading:
 - start the service and confirm config validation still passes
 - call `get_nodes` and `get_cluster_status`
 - verify expected tools are still registered
-- verify `/health` and `/docs` if you run the OpenAPI proxy
+- verify unauthenticated `/livez` plus authenticated `/readyz`, `/health`, and `/docs` if you run the OpenAPI proxy
 - test at least one mutating workflow in a safe environment
 
 ## Suggested Release Checklist
@@ -262,7 +304,7 @@ After upgrading:
 - run `pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=60`
 - run `ruff check .`
 - run `mypy src --ignore-missing-imports`
-- run `pip-audit -r requirements.txt --ignore-vuln CVE-2026-44405`
+- run `pip-audit -r requirements.txt`
 - build the package
 - confirm `README.md` and `docs/wiki/` reflect the released behavior
 - note any user-visible changes here

--- a/docs/wiki/Security Guide.md
+++ b/docs/wiki/Security Guide.md
@@ -8,7 +8,7 @@ ProxmoxMCP-Plus sits between clients and the Proxmox API. The main controls are:
 
 - Proxmox API token authentication
 - TLS verification for Proxmox API connections
-- optional API key protection for OpenAPI exposure
+- required API key protection for OpenAPI exposure, unless `PROXMOX_ALLOW_NO_AUTH=true` is explicitly set for local development
 - command policy checks for `execute_*` tools
 - optional SSH configuration for container command execution
 
@@ -17,6 +17,7 @@ ProxmoxMCP-Plus sits between clients and the Proxmox API. The main controls are:
 - Use least-privilege Proxmox API tokens
 - Keep `proxmox.verify_ssl=true`
 - Only use `security.dev_mode=true` for local development
+- Set `PROXMOX_API_KEY` before starting OpenAPI mode
 - Restrict who can reach the OpenAPI endpoint
 - Keep logs for sensitive operations
 
@@ -76,7 +77,7 @@ If you run the OpenAPI proxy:
 - configure `PROXMOX_API_KEY`; startup refuses no-auth mode unless `PROXMOX_ALLOW_NO_AUTH=true` is set
 - place it behind TLS termination
 - restrict ingress to networks you control
-- monitor `/health`
+- monitor unauthenticated `/livez` for process liveness and authenticated `/health` or `/readyz` for backend readiness
 - avoid exposing it directly to the public internet without additional controls
 
 ## Credential Handling

--- a/docs/wiki/Troubleshooting.md
+++ b/docs/wiki/Troubleshooting.md
@@ -30,7 +30,7 @@ Check:
 
 The script now refuses to treat the default `proxmox-config/config.json` as a live target when it still points at a local-only API address.
 
-## `/health` Returns `degraded`
+## Authenticated `/health` Returns `degraded`
 
 This usually means the OpenAPI wrapper started but did not connect to the MCP subprocess yet.
 
@@ -41,6 +41,19 @@ Check:
 - stderr output from `main.py` for startup errors
 
 If the payload shows `"jobs": {"enabled": false}`, the OpenAPI wrapper started without a local `JobStore`. In that case `/jobs` routes return `503` even if MCP tool calls still work.
+
+## OpenAPI Requests Return `401` Or `403`
+
+OpenAPI mode requires API key auth by default.
+
+Check:
+
+- `PROXMOX_API_KEY` is set in the server environment
+- clients send `Authorization: Bearer <PROXMOX_API_KEY>`
+- Docker Compose was started with `PROXMOX_API_KEY` exported or present in `.env`
+- local no-auth development explicitly sets `PROXMOX_ALLOW_NO_AUTH=true`
+
+Use `/livez` for unauthenticated liveness checks. Use authenticated `/readyz` or `/health` for backend readiness.
 
 ## OpenAPI `/docs` Works But Tool Calls Fail
 
@@ -151,7 +164,7 @@ Start with:
 
 1. validate the config path
 2. run a read-only tool such as `get_nodes`
-3. confirm `/health` in OpenAPI mode
+3. confirm `/livez`, then authenticated `/health` in OpenAPI mode
 4. inspect logs or stderr
 5. verify whether the missing behavior is transport-specific or affects both MCP and OpenAPI
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": "0.4",
     "name": "proxmox-mcp-plus",
     "display_name": "ProxmoxMCP-Plus",
-    "version": "0.4.9",
+    "version": "0.5.0",
     "description": "An enhanced MCP server for managing Proxmox virtualization platforms.",
     "long_description": "ProxmoxMCP-Plus is an enhanced Model Context Protocol (MCP) server that provides comprehensive tools for managing Proxmox virtualization environments, including VM lifecycle, container management, snapshot operations, and backup/restore capabilities.",
     "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "proxmox-mcp-plus"
-version = "0.4.9"
+version = "0.5.0"
 description = "Enhanced Proxmox MCP Server"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -27,7 +27,7 @@ dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.30.0",
     "mcpo>=0.0.17",
-    "paramiko>=4.0.0,<5.0.0",
+    "paramiko>=5.0.0,<6.0.0",
     "anyio>=4.0.0",
 ]
 
@@ -40,7 +40,7 @@ dev = [
     "mypy>=1.0.0,<2.0.0",
     "ruff>=0.1.0,<0.2.0",
     "build>=1.2.0,<2.0.0",
-    "types-paramiko>=4.0.0.20250822,<5.0.0",
+    "types-paramiko>=4.0.0.20260508,<5.0.0",
     "types-requests>=2.31.0,<3.0.0",
 ]
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -6,5 +6,5 @@ pydantic>=2.0.0,<3.0.0
 fastapi>=0.115.0
 uvicorn[standard]>=0.30.0
 mcpo>=0.0.17
-paramiko>=4.0.0,<5.0.0
+paramiko>=5.0.0,<6.0.0
 anyio>=4.0.0

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -13,5 +13,5 @@ ruff>=0.1.0,<0.2.0
 build>=1.2.0,<2.0.0
 
 # Type stubs
-types-paramiko>=4.0.0.20250822,<5.0.0
+types-paramiko>=4.0.0.20260508,<5.0.0
 types-requests>=2.31.0,<3.0.0

--- a/scripts/start_openapi.sh
+++ b/scripts/start_openapi.sh
@@ -13,20 +13,27 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 HOST="${OPENAPI_HOST:-127.0.0.1}"
 PORT="${OPENAPI_PORT:-8811}"
 VENV_DIR="${REPO_ROOT}/.venv"
+PYTHON_BIN="${VENV_DIR}/bin/python"
 CONFIG_FILE="${REPO_ROOT}/proxmox-config/config.json"
 
 echo "Starting Proxmox MCP OpenAPI server..."
 echo
 
-if ! command -v mcpo >/dev/null 2>&1; then
-    echo "mcpo is not installed; installing it now..."
-    pip install mcpo
-fi
-
 if [ ! -d "${VENV_DIR}" ]; then
     echo "Virtual environment not found at ${VENV_DIR}"
     echo "Run the project installation steps first."
     exit 1
+fi
+
+if [ ! -x "${PYTHON_BIN}" ]; then
+    echo "Python executable not found at ${PYTHON_BIN}"
+    echo "Recreate the virtual environment with: uv venv && uv pip install -e '.[dev]'"
+    exit 1
+fi
+
+if ! "${PYTHON_BIN}" -c "import mcpo" >/dev/null 2>&1; then
+    echo "mcpo is not installed in ${VENV_DIR}; installing it now..."
+    "${PYTHON_BIN}" -m pip install mcpo
 fi
 
 if [ ! -f "${CONFIG_FILE}" ]; then
@@ -57,5 +64,5 @@ echo
 export PROXMOX_MCP_CONFIG="${CONFIG_FILE}"
 
 cd "${REPO_ROOT}"
-python -m proxmox_mcp.openapi_proxy --host "${HOST}" --port "${PORT}" -- \
+"${PYTHON_BIN}" -m proxmox_mcp.openapi_proxy --host "${HOST}" --port "${PORT}" -- \
   /bin/bash -c "cd '${REPO_ROOT}' && source '${VENV_DIR}/bin/activate' && python -c 'from proxmox_mcp.server import main; main()'"

--- a/server.json
+++ b/server.json
@@ -18,13 +18,13 @@
     "url": "https://github.com/RekklesNA/ProxmoxMCP-Plus",
     "source": "github"
   },
-  "version": "0.4.9",
+  "version": "0.5.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "proxmox-mcp-plus",
-      "version": "0.4.9",
+      "version": "0.5.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/proxmox_mcp/__init__.py
+++ b/src/proxmox_mcp/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .server import ProxmoxMCPServer
 
-__version__ = "0.4.9"
+__version__ = "0.5.0"
 __all__ = ["ProxmoxMCPServer"]
 
 

--- a/src/proxmox_mcp/openapi_proxy.py
+++ b/src/proxmox_mcp/openapi_proxy.py
@@ -3,19 +3,22 @@
 from __future__ import annotations
 
 import argparse
+import base64
+import binascii
+import hmac
 import logging
 import os
 import sys
 import time
 from collections import deque
+from dataclasses import dataclass
 from typing import Any, Optional, cast
 
 import uvicorn
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, PlainTextResponse
 from mcpo.main import lifespan
-from mcpo.utils.auth import APIKeyMiddleware, get_verify_api_key
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from proxmox_mcp.observability import HttpRequestMetrics
@@ -33,6 +36,77 @@ def _parse_cors_allow_origins(value: Optional[str]) -> list[str]:
     if not value:
         return ["*"]
     return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def _constant_time_equal(provided: str, expected: str) -> bool:
+    return hmac.compare_digest(
+        provided.encode("utf-8"),
+        expected.encode("utf-8"),
+    )
+
+
+@dataclass(frozen=True)
+class AuthFailure:
+    status_code: int
+    content: dict[str, str]
+    headers: dict[str, str] | None = None
+
+
+def _verify_authorization_header(authorization: str | None, api_key: str) -> AuthFailure | None:
+    authenticate_headers = {"WWW-Authenticate": "Bearer, Basic"}
+    if not authorization:
+        return AuthFailure(
+            status.HTTP_401_UNAUTHORIZED,
+            {"detail": "Missing or invalid Authorization header"},
+            authenticate_headers,
+        )
+
+    scheme, separator, credentials = authorization.partition(" ")
+    if not separator or not credentials:
+        return AuthFailure(
+            status.HTTP_401_UNAUTHORIZED,
+            {"detail": "Missing or invalid Authorization header"},
+            authenticate_headers,
+        )
+
+    scheme = scheme.lower()
+    if scheme == "bearer":
+        if not _constant_time_equal(credentials, api_key):
+            return AuthFailure(status.HTTP_403_FORBIDDEN, {"detail": "Invalid API key"})
+        return None
+
+    if scheme == "basic":
+        try:
+            decoded = base64.b64decode(credentials, validate=True).decode("utf-8")
+            _, password = decoded.split(":", 1)
+        except (binascii.Error, UnicodeDecodeError, ValueError):
+            return AuthFailure(
+                status.HTTP_401_UNAUTHORIZED,
+                {"detail": "Invalid Basic Authentication format"},
+                authenticate_headers,
+            )
+        if not _constant_time_equal(password, api_key):
+            return AuthFailure(status.HTTP_403_FORBIDDEN, {"detail": "Invalid credentials"})
+        return None
+
+    return AuthFailure(
+        status.HTTP_401_UNAUTHORIZED,
+        {"detail": "Unsupported authorization method"},
+        authenticate_headers,
+    )
+
+
+def _get_verify_api_key(api_key: str):
+    async def verify_api_key(request: Request) -> None:
+        failure = _verify_authorization_header(request.headers.get("Authorization"), api_key)
+        if failure is not None:
+            raise HTTPException(
+                status_code=failure.status_code,
+                detail=failure.content["detail"],
+                headers=failure.headers,
+            )
+
+    return verify_api_key
 
 
 def _security_warnings(*, api_key: Optional[str], strict_auth: bool, cors_allow_origins: list[str]) -> list[str]:
@@ -101,6 +175,29 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
+class OpenAPIAuthMiddleware(BaseHTTPMiddleware):
+    """Enforce Bearer or Basic API key auth with constant-time token comparison."""
+
+    EXEMPT_PATHS = {"/livez"}
+
+    def __init__(self, app: Any, *, api_key: str) -> None:
+        super().__init__(app)
+        self.api_key = api_key
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        if request.method == "OPTIONS" or request.url.path in self.EXEMPT_PATHS:
+            return await call_next(request)
+
+        failure = _verify_authorization_header(request.headers.get("Authorization"), self.api_key)
+        if failure is not None:
+            return JSONResponse(
+                status_code=failure.status_code,
+                content=failure.content,
+                headers=failure.headers,
+            )
+        return await call_next(request)
+
+
 def create_app(
     server_command: list[str],
     *,
@@ -117,7 +214,7 @@ def create_app(
     command_policy: Any | None = None,
 ) -> FastAPI:
     """Create a FastAPI app that mirrors mcpo behavior and adds ops routes."""
-    api_dependency = get_verify_api_key(api_key) if api_key else None
+    api_dependency = _get_verify_api_key(api_key) if api_key else None
 
     app = FastAPI(
         title=name,
@@ -130,10 +227,6 @@ def create_app(
     app.state.started_at = time.time()
     app.state.http_metrics = HttpRequestMetrics()
     app.state.rate_limit_rpm = rate_limit_rpm
-    app.add_middleware(ProxyMetricsMiddleware)
-    if rate_limit_rpm > 0:
-        app.add_middleware(cast(Any, RateLimitMiddleware), requests_per_minute=rate_limit_rpm)
-
     app.add_middleware(
         CORSMiddleware,
         allow_origins=cors_allow_origins,
@@ -143,7 +236,10 @@ def create_app(
     )
 
     if api_key and strict_auth:
-        app.add_middleware(APIKeyMiddleware, api_key=api_key)
+        app.add_middleware(OpenAPIAuthMiddleware, api_key=api_key)
+    if rate_limit_rpm > 0:
+        app.add_middleware(cast(Any, RateLimitMiddleware), requests_per_minute=rate_limit_rpm)
+    app.add_middleware(ProxyMetricsMiddleware)
 
     app.state.path_prefix = path_prefix
     app.state.server_type = "stdio"
@@ -169,12 +265,13 @@ def create_app(
             "docs": "/docs",
             "openapi": "/openapi.json",
             "health": "/health",
+            "livez": "/livez",
+            "readyz": "/readyz",
             "metrics": "/metrics",
             "jobs": "/jobs",
         }
 
-    @app.get("/health", include_in_schema=False)
-    async def health() -> JSONResponse:
+    def _readiness_response() -> JSONResponse:
         is_connected = bool(getattr(app.state, "is_connected", False))
         uptime_seconds = round(time.time() - app.state.started_at, 3)
         status_code = 200 if is_connected else 503
@@ -201,6 +298,18 @@ def create_app(
                 "security_warnings": app.state.security_warnings,
             },
         )
+
+    @app.get("/livez", include_in_schema=False)
+    async def livez() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/readyz", include_in_schema=False)
+    async def readyz() -> JSONResponse:
+        return _readiness_response()
+
+    @app.get("/health", include_in_schema=False)
+    async def health() -> JSONResponse:
+        return _readiness_response()
 
     @app.get("/metrics", include_in_schema=False)
     async def metrics() -> PlainTextResponse:

--- a/tests/scripts/run_real_e2e.py
+++ b/tests/scripts/run_real_e2e.py
@@ -26,6 +26,7 @@ if str(SRC) not in sys.path:
 
 TASK_RE = re.compile(r"Task ID:\s*(\S+)")
 TEST_KEY = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICodexLiveE2ETestKey codex-live-e2e"
+OPENAPI_E2E_API_KEY = "codex-live-e2e-openapi-token"
 
 
 def log(message: str) -> None:
@@ -321,12 +322,20 @@ def newest_backup(api: Any, node: str, storage: str, vmid: int) -> str:
     return str(backups[0]["volid"])
 
 
-def wait_for_http(url: str, timeout: int = 120) -> requests.Response:
+def openapi_headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {OPENAPI_E2E_API_KEY}"}
+
+
+def wait_for_http(
+    url: str,
+    timeout: int = 120,
+    headers: dict[str, str] | None = None,
+) -> requests.Response:
     deadline = time.time() + timeout
     last_error: Exception | None = None
     while time.time() < deadline:
         try:
-            response = requests.get(url, timeout=5)
+            response = requests.get(url, headers=headers, timeout=5)
             if response.ok:
                 return response
         except Exception as exc:  # noqa: BLE001
@@ -346,6 +355,7 @@ def run_local_openapi(config_path: Path) -> None:
     port = free_port()
     env = os.environ.copy()
     env["PROXMOX_MCP_CONFIG"] = str(config_path)
+    env["PROXMOX_API_KEY"] = OPENAPI_E2E_API_KEY
     env["PYTHONPATH"] = str(SRC)
     command = [
         sys.executable,
@@ -368,9 +378,15 @@ def run_local_openapi(config_path: Path) -> None:
         text=True,
     )
     try:
-        health = wait_for_http(f"http://127.0.0.1:{port}/health")
+        livez = wait_for_http(f"http://127.0.0.1:{port}/livez")
+        log(f"Local OpenAPI liveness: {livez.text}")
+        health = wait_for_http(f"http://127.0.0.1:{port}/health", headers=openapi_headers())
         log(f"Local OpenAPI health: {health.text}")
-        schema = requests.get(f"http://127.0.0.1:{port}/openapi.json", timeout=10)
+        schema = requests.get(
+            f"http://127.0.0.1:{port}/openapi.json",
+            headers=openapi_headers(),
+            timeout=10,
+        )
         schema.raise_for_status()
         paths = schema.json().get("paths", {})
         if not paths:
@@ -396,6 +412,8 @@ def run_docker_openapi(config_path: Path) -> None:
         "-d",
         "-p",
         f"{port}:8811",
+        "-e",
+        f"PROXMOX_API_KEY={OPENAPI_E2E_API_KEY}",
         "-v",
         f"{config_path}:/app/proxmox-config/config.json:ro",
         tag,
@@ -404,9 +422,15 @@ def run_docker_openapi(config_path: Path) -> None:
     subprocess.run(build_cmd, cwd=ROOT, check=True)
     try:
         container_id = subprocess.check_output(run_cmd, cwd=ROOT, text=True).strip()
-        health = wait_for_http(f"http://127.0.0.1:{port}/health")
+        livez = wait_for_http(f"http://127.0.0.1:{port}/livez")
+        log(f"Docker OpenAPI liveness: {livez.text}")
+        health = wait_for_http(f"http://127.0.0.1:{port}/health", headers=openapi_headers())
         log(f"Docker OpenAPI health: {health.text}")
-        schema = requests.get(f"http://127.0.0.1:{port}/openapi.json", timeout=10)
+        schema = requests.get(
+            f"http://127.0.0.1:{port}/openapi.json",
+            headers=openapi_headers(),
+            timeout=10,
+        )
         schema.raise_for_status()
         paths = schema.json().get("paths", {})
         if not paths:

--- a/tests/test_openapi_proxy.py
+++ b/tests/test_openapi_proxy.py
@@ -1,6 +1,7 @@
 """Tests for OpenAPI proxy wrapper."""
 
 import asyncio
+import base64
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -60,6 +61,8 @@ def test_root_endpoint_returns_service_links():
     assert payload["docs"] == "/docs"
     assert payload["openapi"] == "/openapi.json"
     assert payload["health"] == "/health"
+    assert payload["livez"] == "/livez"
+    assert payload["readyz"] == "/readyz"
     assert payload["metrics"] == "/metrics"
     assert payload["jobs"] == "/jobs"
 
@@ -80,6 +83,112 @@ def test_health_endpoint_includes_auth_and_rate_limit_details():
     assert '"strict_auth":true' in payload
     assert '"requests_per_minute":42' in payload
     assert '"enabled":false' in payload
+
+
+def test_livez_is_available_without_auth_when_strict_auth_enabled():
+    app = create_app(
+        server_command=["python", "-c", "print('ok')"],
+        api_key="secret",
+        strict_auth=True,
+        cors_allow_origins=["https://example.test"],
+    )
+    client = TestClient(app)
+
+    response = client.get("/livez")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_readyz_requires_auth_when_strict_auth_enabled():
+    app = create_app(
+        server_command=["python", "-c", "print('ok')"],
+        api_key="secret",
+        strict_auth=True,
+        cors_allow_origins=["https://example.test"],
+    )
+    client = TestClient(app)
+
+    response = client.get("/readyz")
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Missing or invalid Authorization header"
+
+
+def test_openapi_auth_accepts_bearer_token():
+    app = create_app(
+        server_command=["python", "-c", "print('ok')"],
+        api_key="secret",
+        strict_auth=True,
+        cors_allow_origins=["https://example.test"],
+    )
+    client = TestClient(app)
+
+    response = client.get("/", headers={"Authorization": "Bearer secret"})
+
+    assert response.status_code == 200
+
+
+def test_openapi_auth_rejects_wrong_bearer_token():
+    app = create_app(
+        server_command=["python", "-c", "print('ok')"],
+        api_key="secret",
+        strict_auth=True,
+        cors_allow_origins=["https://example.test"],
+    )
+    client = TestClient(app)
+
+    response = client.get("/", headers={"Authorization": "Bearer wrong"})
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Invalid API key"
+
+
+def test_openapi_auth_accepts_basic_password():
+    credentials = base64.b64encode(b"operator:secret").decode("ascii")
+    app = create_app(
+        server_command=["python", "-c", "print('ok')"],
+        api_key="secret",
+        strict_auth=True,
+        cors_allow_origins=["https://example.test"],
+    )
+    client = TestClient(app)
+
+    response = client.get("/", headers={"Authorization": f"Basic {credentials}"})
+
+    assert response.status_code == 200
+
+
+def test_openapi_auth_rejects_malformed_basic_header():
+    app = create_app(
+        server_command=["python", "-c", "print('ok')"],
+        api_key="secret",
+        strict_auth=True,
+        cors_allow_origins=["https://example.test"],
+    )
+    client = TestClient(app)
+
+    response = client.get("/", headers={"Authorization": "Basic not-base64"})
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid Basic Authentication format"
+
+
+def test_auth_failures_are_rate_limited():
+    app = create_app(
+        server_command=["python", "-c", "print('ok')"],
+        api_key="secret",
+        strict_auth=True,
+        cors_allow_origins=["https://example.test"],
+        rate_limit_rpm=1,
+    )
+    client = TestClient(app)
+
+    first = client.get("/")
+    second = client.get("/")
+
+    assert first.status_code == 401
+    assert second.status_code == 429
 
 
 def test_health_endpoint_reports_security_warnings_for_unsafe_defaults():


### PR DESCRIPTION
## Summary
- prepare v0.5.0 as the breaking OpenAPI auth release, with migration/release notes
- replace mcpo OpenAPI API key middleware with project-owned constant-time Bearer/Basic auth, add unauthenticated `/livez`, authenticated `/readyz`, and rate-limit auth failures
- update live E2E, examples, operator/developer/security docs, Docker healthcheck, and `scripts/start_openapi.sh`
- move Paramiko to `>=5.0.0,<6.0.0` and remove the CI pip-audit CVE ignore

## Validation
- `pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=60`
- `ruff check .`
- `mypy src --ignore-missing-imports`
- `pip-audit -r requirements.txt`
- `python -m build`
- `twine check dist\*`
- `docker compose config` with `PROXMOX_API_KEY=test-token`
- `bash -n scripts/start_openapi.sh`
- JSON validation for `manifest.json`, `server.json`, `glama.json`
- `pip check`