### PR TITLE
feat: add get_vm_config tool for QEMU VM configuration

### DIFF
--- a/docs/wiki/API & Tool Reference.md
+++ b/docs/wiki/API & Tool Reference.md
@@ -109,6 +109,7 @@ Selector-based tools fail when no container matches the selector or when a bulk 
 | `reset_vm` | Mutating | `node`, `vmid` | none | VM exists | VM not found, reset rejected by Proxmox |
 | `delete_vm` | Mutating | `node`, `vmid` | `force=false` | VM exists | running VM without `force`, VM not found |
 | `execute_vm_command` | Mutating | `node`, `vmid`, `command` | `approval_token` | VM running, QEMU Guest Agent installed, policy allows command | guest agent unavailable, VM not running, policy denial |
+| `get_vm_config` | Read-only | `node`, `vmid` | none | VM exists | VM not found, node mismatch |
 
 ### VM Notes
 

--- a/src/proxmox_mcp/services/builtin_tool_plugins.py
+++ b/src/proxmox_mcp/services/builtin_tool_plugins.py
@@ -31,6 +31,7 @@ from proxmox_mcp.tools.definitions import (
     GET_NODE_STATUS_DESC,
     GET_STORAGE_DESC,
     GET_VMS_DESC,
+    GET_VM_CONFIG_DESC,
     LIST_JOBS_DESC,
     LIST_BACKUPS_DESC,
     LIST_ISOS_DESC,
@@ -245,6 +246,16 @@ class VMToolsPlugin(RegistryPluginBase):
         @server.mcp.tool(description=GET_VMS_DESC)
         def get_vms() -> Any:
             return self._wrap_sync(server, "get_vms", server.vm_tools.get_vms)()
+
+        @server.mcp.tool(description=GET_VM_CONFIG_DESC)
+        def get_vm_config(
+            node: Annotated[str, Field(description="Host node name (e.g. 'pve')")],
+            vmid: Annotated[str, Field(description="VM ID number (e.g. '100')")],
+        ) -> Any:
+            return self._wrap_sync(server, "get_vm_config", server.vm_tools.get_vm_config)(
+                node=node,
+                vmid=vmid,
+            )
 
         @server.mcp.tool(description=CREATE_VM_DESC)
         def create_vm(

--- a/src/proxmox_mcp/tools/definitions.py
+++ b/src/proxmox_mcp/tools/definitions.py
@@ -49,6 +49,30 @@ GET_VMS_DESC = """List all virtual machines across the cluster with their status
 Example:
 {"vmid": "100", "name": "ubuntu", "status": "running", "cpu": 2, "memory": 4096}"""
 
+GET_VM_CONFIG_DESC = """Get the full configuration of a QEMU virtual machine.
+
+Returns hardware configuration including CPU, memory, disk, network, BIOS type, boot order, and more.
+This is equivalent to get_container_config but for QEMU VMs.
+
+Parameters:
+node* - Host node name (e.g. 'pve')
+vmid* - VM ID number (e.g. '100')
+
+Example:
+{"vmid": "100", "name": "ubuntu", "cores": 2, "memory": 4096, "scsi0": "local-lvm:vm-100-disk-0,size=20G"}"""
+
+GET_VM_CONFIG_DESC = """Get the full configuration of a QEMU virtual machine.
+
+Returns hardware configuration including CPU, memory, disk, network, BIOS type, boot order, and more.
+This is equivalent to get_container_config but for QEMU VMs.
+
+Parameters:
+node* - Host node name (e.g. 'pve')
+vmid* - VM ID number (e.g. '100')
+
+Example:
+{"vmid": "100", "name": "ubuntu", "cores": 2, "memory": 4096, "scsi0": "local-lvm:vm-100-disk-0,size=20G"}"""
+
 CREATE_VM_DESC = """Create a new virtual machine with specified configuration.
 
 Parameters:

--- a/src/proxmox_mcp/tools/definitions.py
+++ b/src/proxmox_mcp/tools/definitions.py
@@ -61,18 +61,6 @@ vmid* - VM ID number (e.g. '100')
 Example:
 {"vmid": "100", "name": "ubuntu", "cores": 2, "memory": 4096, "scsi0": "local-lvm:vm-100-disk-0,size=20G"}"""
 
-GET_VM_CONFIG_DESC = """Get the full configuration of a QEMU virtual machine.
-
-Returns hardware configuration including CPU, memory, disk, network, BIOS type, boot order, and more.
-This is equivalent to get_container_config but for QEMU VMs.
-
-Parameters:
-node* - Host node name (e.g. 'pve')
-vmid* - VM ID number (e.g. '100')
-
-Example:
-{"vmid": "100", "name": "ubuntu", "cores": 2, "memory": 4096, "scsi0": "local-lvm:vm-100-disk-0,size=20G"}"""
-
 CREATE_VM_DESC = """Create a new virtual machine with specified configuration.
 
 Parameters:

--- a/src/proxmox_mcp/tools/vm.py
+++ b/src/proxmox_mcp/tools/vm.py
@@ -86,6 +86,34 @@ class VMTools(ProxmoxTool):
             })
         return result if result else None
 
+    def get_vm_config(self, node: str, vmid: str) -> List[Content]:
+        """Get the full configuration of a QEMU virtual machine.
+        
+        Returns hardware configuration including CPU, memory, disk, network,
+        BIOS type, boot order, and more.
+        
+        Args:
+            node: Host node name (e.g., 'pve')
+            vmid: VM ID number (e.g., '100')
+            
+        Returns:
+            List of Content objects containing VM configuration
+        """
+        try:
+            # Get VM config from Proxmox API
+            config = self.proxmox.nodes(node).qemu(vmid).config.get()
+            
+            # Ensure vmid is included in response
+            config = dict(config)
+            config.setdefault("vmid", vmid)
+            
+            # Format as JSON (consistent with get_container_config)
+            import json
+            return [Content(type="text", text=json.dumps(config, indent=2, sort_keys=True))]
+            
+        except Exception as e:
+            self._handle_error(f"get VM config for {vmid}", e)
+
     def get_vms(self) -> List[Content]:
         """List all virtual machines across the cluster with detailed status.
 

--- a/src/proxmox_mcp/tools/vm.py
+++ b/src/proxmox_mcp/tools/vm.py
@@ -15,11 +15,22 @@ This module provides tools for managing and interacting with Proxmox VMs:
 The tools implement fallback mechanisms for scenarios where
 detailed VM information might be temporarily unavailable.
 """
-from typing import List, Optional, Any
+import json
+from typing import Any, Dict, List, Optional
 from mcp.types import TextContent as Content
 from proxmox_mcp.models import ToolResult
 from proxmox_mcp.tools.base import ProxmoxTool
 from proxmox_mcp.tools.console.manager import VMConsoleManager
+
+
+def _as_dict(maybe: Any) -> Dict:
+    """Return dict; unwrap {'data': dict}; else {}."""
+    if isinstance(maybe, dict):
+        data = maybe.get("data")
+        if isinstance(data, dict):
+            return data
+        return maybe
+    return {}
 
 class VMTools(ProxmoxTool):
     """Tools for managing Proxmox VMs.
@@ -52,6 +63,14 @@ class VMTools(ProxmoxTool):
         super().__init__(proxmox_api, metrics=metrics, job_store=job_store)
         self.console_manager = VMConsoleManager(proxmox_api)
         self.command_policy = command_policy
+
+    # ---------- error / output ----------
+    def _json_fmt(self, data: Any) -> List[Content]:
+        """Return raw JSON string (never touch project formatters)."""
+        return [Content(type="text", text=json.dumps(data, indent=2, sort_keys=True))]
+
+    def _err(self, action: str, e: Exception) -> List[Content]:
+        self._handle_error(action, e)
 
     def _get_cluster_vm_inventory(self) -> Optional[list[dict[str, Any]]]:
         try:
@@ -87,32 +106,18 @@ class VMTools(ProxmoxTool):
         return result if result else None
 
     def get_vm_config(self, node: str, vmid: str) -> List[Content]:
-        """Get the full configuration of a QEMU virtual machine.
-        
-        Returns hardware configuration including CPU, memory, disk, network,
-        BIOS type, boot order, and more.
-        
-        Args:
-            node: Host node name (e.g., 'pve')
-            vmid: VM ID number (e.g., '100')
-            
-        Returns:
-            List of Content objects containing VM configuration
+        """Return the full configuration of a QEMU virtual machine.
+
+        Parameters:
+            node: Proxmox node name.
+            vmid: VM ID as a string.
         """
         try:
-            # Get VM config from Proxmox API
-            config = self.proxmox.nodes(node).qemu(vmid).config.get()
-            
-            # Ensure vmid is included in response
-            config = dict(config)
+            config = _as_dict(self.proxmox.nodes(node).qemu(vmid).config.get())
             config.setdefault("vmid", vmid)
-            
-            # Format as JSON (consistent with get_container_config)
-            import json
-            return [Content(type="text", text=json.dumps(config, indent=2, sort_keys=True))]
-            
+            return self._json_fmt(config)
         except Exception as e:
-            self._handle_error(f"get VM config for {vmid}", e)
+            return self._err("get_vm_config", e)
 
     def get_vms(self) -> List[Content]:
         """List all virtual machines across the cluster with detailed status.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -211,6 +211,8 @@ async def test_list_tools(server):
     # LXC config tools (no SSH required)
     assert "get_container_config" in tool_names
     assert "get_container_ip" in tool_names
+    # VM config tool
+    assert "get_vm_config" in tool_names
 
 
 @pytest.mark.asyncio
@@ -992,6 +994,43 @@ async def test_get_container_config_missing_parameters(server):
     """get_container_config raises ToolError when required parameters are missing."""
     with pytest.raises(ToolError):
         await server.mcp.call_tool("get_container_config", {})
+
+
+# ---------------------------------------------------------------------------
+# get_vm_config
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_vm_config(server, mock_proxmox):
+    """get_vm_config returns full VM config JSON including vmid."""
+    vm_api = mock_proxmox.return_value.nodes.return_value.qemu.return_value
+    vm_api.config.get.return_value = {
+        "name": "ubuntu",
+        "cores": 2,
+        "memory": 4096,
+        "scsi0": "local-lvm:vm-100-disk-0,size=20G",
+        "net0": "virtio=CE:11:53:B7:B6:79,bridge=vmbr0",
+        "bios": "ovmf",
+        "onboot": 1,
+    }
+
+    response = await server.mcp.call_tool(
+        "get_vm_config", {"node": "node1", "vmid": "100"}
+    )
+    result = json.loads(response[0].text)
+
+    assert result["name"] == "ubuntu"
+    assert result["cores"] == 2
+    assert result["memory"] == 4096
+    assert result["vmid"] == "100"
+    assert "scsi0" in result
+
+
+@pytest.mark.asyncio
+async def test_get_vm_config_missing_parameters(server):
+    """get_vm_config raises ToolError when required parameters are missing."""
+    with pytest.raises(ToolError):
+        await server.mcp.call_tool("get_vm_config", {})
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1033,6 +1033,17 @@ async def test_get_vm_config_missing_parameters(server):
         await server.mcp.call_tool("get_vm_config", {})
 
 
+@pytest.mark.asyncio
+async def test_get_vm_config_api_error(server, mock_proxmox):
+    """get_vm_config surfaces Proxmox API errors via RuntimeError consistently."""
+    mock_proxmox.return_value.nodes.return_value.qemu.return_value.config.get.side_effect = (
+        Exception("VM does not exist")
+    )
+
+    with pytest.raises(ToolError, match="get_vm_config"):
+        await server.mcp.call_tool("get_vm_config", {"node": "node1", "vmid": "999"})
+
+
 # ---------------------------------------------------------------------------
 # get_container_ip
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Adds `get_vm_config` MCP tool to retrieve full hardware configuration for QEMU VMs.
This provides parity with the existing `get_container_config` tool for LXC containers, enabling users to inspect complete VM configurations including CPU, memory, disk, network, BIOS type, boot order, and more.
## Changes
- **Implementation**: Added `get_vm_config(node, vmid)` method to `VMTools` class
- **Registration**: Registered tool in `builtin_tool_plugins.py` with parameter validation
- **Description**: Added tool description in `definitions.py`
- **Tests**: Added 2 unit tests (happy path + missing parameters)
- **Documentation**: Updated `API & Tool Reference.md` with tool details
## How to Test
```bash
# Unit tests
pytest tests/test_server.py::test_get_vm_config tests/test_server.py::test_get_vm_config_missing_parameters
# Live test (requires Proxmox config)
get_vm_config node='pve' vmid='100'
```
## Checklist
- [x] Implementation in `src/proxmox_mcp/tools/vm.py`
- [x] Registration in `src/proxmox_mcp/services/builtin_tool_plugins.py`
- [x] Description in `src/proxmox_mcp/tools/definitions.py`
- [x] Tests in `tests/test_server.py`
- [x] Documentation in `docs/wiki/API & Tool Reference.md`
- [ ] CI checks pass (ruff, mypy, pytest, coverage)
## Screenshots
<details>
<summary>Example Output</summary>

```json
{
  "agent": "1",
  "bios": "ovmf",
  "boot": "order=scsi0;ide2;net0",
  "cores": 6,
  "cpu": "host",
  "memory": "8192",
  "name": "vscode",
  "net0": "virtio=CE:11:53:B7:B6:79,bridge=vmbr0,firewall=1,tag=3",
  "scsi0": "zpool:vm-2004-disk-1,iothread=1,size=200G",
  "vmid": "2004"
}
```

</details>