### PR TITLE
Release v0.5.5 quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,17 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
     steps:
     - uses: actions/checkout@v6
 
-    - name: Set up Python 3.11
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
       with:
-        python-version: "3.11"
+        python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
       run: |
@@ -31,7 +35,7 @@ jobs:
 
     - name: Run tests
       run: |
-        pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=70
+        pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=75
 
     - name: Ruff
       run: |

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Supported workflow areas:
 
 Validation and contract entry points in this repository:
 
-- `pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=70`
+- `pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=75`
 - `ruff check .`
 - `mypy src --ignore-missing-imports`
 - `pip-audit -r requirements.txt`
@@ -355,7 +355,7 @@ Published wiki:
 ## Development Checks
 
 ```bash
-pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=70
+pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=75
 ruff check .
 mypy src --ignore-missing-imports
 pip-audit -r requirements.txt

--- a/docs/releases/v0.5.5.md
+++ b/docs/releases/v0.5.5.md
@@ -1,0 +1,20 @@
+# ProxmoxMCP-Plus v0.5.5
+
+Release date: 2026-05-29
+
+## Quality Improvements
+
+- Server shutdown now explicitly closes the Proxmox API SSH tunnel manager, so API tunnel processes are released during graceful stop and test teardown instead of relying only on `atexit`.
+- CI now validates the project on both Python 3.11 and Python 3.12, matching the supported Python versions declared in package metadata.
+- The CI coverage gate is raised from 70% to 75%.
+
+## Tests
+
+- Added SSH tunnel lifecycle coverage for disabled tunnels, reachable endpoints, startup waits, early SSH exits, timeouts, graceful termination, and forced kill cleanup.
+- Added formatting coverage for components, colors, formatters, and theme fallback helpers.
+- Added backup user-path coverage for listing, creating, restoring, and deleting backups.
+
+## Upgrade Notes
+
+- No mandatory config migration is required.
+- API tunnel users should see the same runtime behavior, with cleaner process cleanup during shutdown.

--- a/docs/wiki/Developer Guide.md
+++ b/docs/wiki/Developer Guide.md
@@ -15,7 +15,7 @@ Set `proxmox-config/config.json` to a real environment or use a test config path
 ## Common Commands
 
 ```bash
-pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=70
+pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=75
 ruff check .
 mypy src --ignore-missing-imports
 pip-audit -r requirements.txt

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -57,7 +57,7 @@ The repository includes live-environment verification entry points for:
 
 Primary validation entry points:
 
-- `pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=70`
+- `pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=75`
 - `ruff check .`
 - `mypy src --ignore-missing-imports`
 - `pip-audit -r requirements.txt`

--- a/docs/wiki/Release & Upgrade Notes.md
+++ b/docs/wiki/Release & Upgrade Notes.md
@@ -18,6 +18,29 @@ Use this page to track version-level behavior changes, upgrade steps, and rollba
 
 ## Release History
 
+### Version `0.5.5`
+
+- Release date: 2026-05-29
+- Summary: quality-gate release that closes API SSH tunnels during server shutdown, validates CI on Python 3.11 and 3.12, and raises the enforced coverage gate to 75%.
+- New tools or endpoints:
+  - no new runtime tools or endpoints
+- Changed behavior:
+  - server shutdown now explicitly releases the Proxmox API SSH tunnel manager instead of relying only on process exit cleanup
+  - CI runs the validation stack against Python 3.11 and 3.12
+  - coverage enforcement increased from 70% to 75%
+- Config changes:
+  - no required config migration
+- Docs updated:
+  - `README.md`
+  - `docs/releases/v0.5.5.md`
+  - `docs/wiki/Developer Guide.md`
+  - `docs/wiki/Home.md`
+  - `docs/wiki/Release & Upgrade Notes.md`
+- Upgrade steps:
+  - no required migration
+- Rollback notes:
+  - downgrade to `v0.5.4` only if Python 3.12 CI validation or stricter coverage gates block urgent maintenance work
+
 ### Version `0.5.4`
 
 - Release date: 2026-05-29
@@ -400,7 +423,7 @@ After upgrading:
 
 ## Suggested Release Checklist
 
-- run `pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=70`
+- run `pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=75`
 - run `ruff check .`
 - run `mypy src --ignore-missing-imports`
 - run `pip-audit -r requirements.txt`

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": "0.4",
     "name": "proxmox-mcp-plus",
     "display_name": "ProxmoxMCP-Plus",
-    "version": "0.5.4",
+    "version": "0.5.5",
     "description": "An enhanced MCP server for managing Proxmox virtualization platforms.",
     "long_description": "ProxmoxMCP-Plus is an enhanced Model Context Protocol (MCP) server that provides comprehensive tools for managing Proxmox virtualization environments, including VM lifecycle, container management, snapshot operations, and backup/restore capabilities.",
     "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "proxmox-mcp-plus"
-version = "0.5.4"
+version = "0.5.5"
 description = "Enhanced Proxmox MCP Server"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -18,13 +18,13 @@
     "url": "https://github.com/RekklesNA/ProxmoxMCP-Plus",
     "source": "github"
   },
-  "version": "0.5.4",
+  "version": "0.5.5",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "proxmox-mcp-plus",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="proxmox-mcp-plus",
-    version="0.5.4",
+    version="0.5.5",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     python_requires=">=3.11",

--- a/src/proxmox_mcp/__init__.py
+++ b/src/proxmox_mcp/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .server import ProxmoxMCPServer
 
-__version__ = "0.5.4"
+__version__ = "0.5.5"
 __all__ = ["ProxmoxMCPServer"]
 
 

--- a/src/proxmox_mcp/core/proxmox.py
+++ b/src/proxmox_mcp/core/proxmox.py
@@ -139,3 +139,8 @@ class ProxmoxManager:
             ProxmoxAPI instance ready for making API calls
         """
         return self.api
+
+    def close(self) -> None:
+        """Release resources owned by the Proxmox API manager."""
+        if self.tunnel_manager is not None:
+            self.tunnel_manager.close()

--- a/src/proxmox_mcp/server.py
+++ b/src/proxmox_mcp/server.py
@@ -150,6 +150,7 @@ class ProxmoxMCPServer:
 
     def close(self) -> None:
         self.job_store.close()
+        self.proxmox_manager.close()
 
     def start(self) -> None:
         """Start the MCP server with the configured transport."""

--- a/tests/test_formatting_components.py
+++ b/tests/test_formatting_components.py
@@ -1,0 +1,93 @@
+from proxmox_mcp.formatting.colors import ProxmoxColors
+from proxmox_mcp.formatting.components import ProxmoxComponents
+from proxmox_mcp.formatting.formatters import ProxmoxFormatters
+from proxmox_mcp.formatting.theme import ProxmoxTheme
+
+
+def test_create_table_handles_title_and_multiline_cells(monkeypatch):
+    monkeypatch.setattr(ProxmoxTheme, "USE_COLORS", False)
+
+    table = ProxmoxComponents.create_table(
+        ["Name", "Notes"],
+        [["vm-100", "line 1\nline 2"], ["ct-101", "ok"]],
+        title="Inventory",
+    )
+
+    assert "Inventory" in table
+    assert "line 1" in table
+    assert "line 2" in table
+    assert "ct-101" in table
+
+
+def test_progress_and_resource_usage_select_metric_colors(monkeypatch):
+    monkeypatch.setattr(ProxmoxTheme, "USE_COLORS", False)
+
+    assert ProxmoxComponents.create_progress_bar(50, 100, width=10) == "#####----- 50.0%"
+    assert ProxmoxComponents.create_progress_bar(5, 0, width=4) == "---- 0.0%"
+
+    usage = ProxmoxComponents.create_resource_usage(1024, 2048, "Memory", "[memory]")
+    assert "[memory] Memory:" in usage
+    assert "1.00 KB / 2.00 KB" in usage
+
+
+def test_key_value_grid_and_status_badge(monkeypatch):
+    monkeypatch.setattr(ProxmoxTheme, "USE_COLORS", False)
+
+    grid = ProxmoxComponents.create_key_value_grid(
+        {"Node": "pve1", "Status": "running", "VMID": "100"},
+        columns=2,
+    )
+
+    assert "Node:" in grid
+    assert "pve1" in grid
+    assert "VMID:" in grid
+    assert ProxmoxComponents.create_status_badge("running") == "[running] RUNNING"
+    assert ProxmoxComponents.create_status_badge("missing") == "[unknown] MISSING"
+
+
+def test_color_helpers_cover_status_resource_and_metric_branches(monkeypatch):
+    monkeypatch.setattr(ProxmoxTheme, "USE_COLORS", True)
+
+    assert ProxmoxColors.colorize("ok", ProxmoxColors.GREEN) == "\033[32mok\033[0m"
+    assert ProxmoxColors.colorize("ok", ProxmoxColors.GREEN, ProxmoxColors.BOLD) == "\033[1m\033[32mok\033[0m"
+    assert ProxmoxColors.status_color("running") == ProxmoxColors.GREEN
+    assert ProxmoxColors.status_color("stopped") == ProxmoxColors.RED
+    assert ProxmoxColors.status_color("warning") == ProxmoxColors.YELLOW
+    assert ProxmoxColors.status_color("other") == ProxmoxColors.BLUE
+    assert ProxmoxColors.resource_color("vm") == ProxmoxColors.CYAN
+    assert ProxmoxColors.resource_color("cpu") == ProxmoxColors.YELLOW
+    assert ProxmoxColors.resource_color("storage") == ProxmoxColors.MAGENTA
+    assert ProxmoxColors.resource_color("other") == ProxmoxColors.BLUE
+    assert ProxmoxColors.metric_color(95) == ProxmoxColors.RED
+    assert ProxmoxColors.metric_color(85) == ProxmoxColors.YELLOW
+    assert ProxmoxColors.metric_color(20) == ProxmoxColors.GREEN
+
+
+def test_formatters_cover_common_output_shapes(monkeypatch):
+    monkeypatch.setattr(ProxmoxTheme, "USE_COLORS", False)
+
+    assert ProxmoxFormatters.format_bytes(1024 * 1024) == "1.00 MB"
+    assert ProxmoxFormatters.format_uptime(90061) == "[uptime] 1d 1h 1m"
+    assert ProxmoxFormatters.format_uptime(0) == "0m"
+    assert ProxmoxFormatters.format_percentage(87.5) == "87.5%"
+    assert ProxmoxFormatters.format_status("online") == "[online] ONLINE"
+    assert "vm-100" in ProxmoxFormatters.format_resource_header("vm", "vm-100")
+    assert "Details" in ProxmoxFormatters.format_section_header("Details", "details")
+    assert ProxmoxFormatters.format_key_value("Node", "pve1", "[node]") == "[node] Node: pve1"
+
+    output = ProxmoxFormatters.format_command_output(
+        success=False,
+        command="systemctl status app",
+        output="out\n",
+        error="err\n",
+    )
+    assert "FAILED" in output
+    assert "systemctl status app" in output
+    assert "err" in output
+
+
+def test_theme_fallbacks():
+    assert ProxmoxTheme.get_status_emoji("unknown-status") == "[unknown]"
+    assert ProxmoxTheme.get_resource_emoji("not-a-resource") == ""
+    assert ProxmoxTheme.get_action_emoji("not-an-action") == "[info]"
+    assert ProxmoxTheme.get_section_emoji("not-a-section") == "[details]"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -92,6 +92,16 @@ def test_server_initialization(server, mock_proxmox):
     mock_proxmox.assert_called_once()
 
 
+def test_server_close_releases_job_store_and_proxmox_manager(server):
+    server.job_store.close = Mock()
+    server.proxmox_manager.close = Mock()
+
+    server.close()
+
+    server.job_store.close.assert_called_once()
+    server.proxmox_manager.close.assert_called_once()
+
+
 def test_server_applies_configured_http_host_and_port(mock_proxmox, tmp_path):
     """Test FastMCP receives configured host/port for HTTP transports."""
     config_path = tmp_path / "config_http.json"

--- a/tests/test_ssh_tunnel.py
+++ b/tests/test_ssh_tunnel.py
@@ -4,6 +4,9 @@ import os
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+import pytest
+
+from proxmox_mcp.core.proxmox import ProxmoxManager
 from proxmox_mcp.core.ssh_tunnel import SSHTunnelManager
 
 
@@ -59,3 +62,157 @@ def test_api_tunnel_does_not_duplicate_user_in_ssh_host() -> None:
         manager._start_process()
 
     assert popen.call_args.args[0][-1] == "root@jump-host"
+
+
+def test_disabled_api_tunnel_does_not_start_process() -> None:
+    tunnel_config = SimpleNamespace(enabled=False)
+    manager = SSHTunnelManager(tunnel_config)
+
+    with patch("proxmox_mcp.core.ssh_tunnel.subprocess.Popen") as popen:
+        manager.ensure_tunnel()
+
+    popen.assert_not_called()
+
+
+def test_api_tunnel_reuses_reachable_local_endpoint() -> None:
+    tunnel_config = SimpleNamespace(
+        enabled=True,
+        ssh_host="jump-host",
+        local_host="127.0.0.1",
+        local_port=18006,
+        remote_host="10.0.0.10",
+        remote_port=8006,
+        connect_timeout=15,
+    )
+    manager = SSHTunnelManager(tunnel_config)
+
+    with patch.object(manager, "_is_local_endpoint_reachable", return_value=True), patch.object(
+        manager, "_start_process"
+    ) as start_process:
+        manager.ensure_tunnel()
+
+    start_process.assert_not_called()
+
+
+def test_api_tunnel_starts_and_waits_when_local_endpoint_unreachable() -> None:
+    tunnel_config = SimpleNamespace(
+        enabled=True,
+        ssh_host="jump-host",
+        local_host="127.0.0.1",
+        local_port=18006,
+        remote_host="10.0.0.10",
+        remote_port=8006,
+        connect_timeout=15,
+    )
+    manager = SSHTunnelManager(tunnel_config)
+
+    with patch.object(manager, "_is_local_endpoint_reachable", return_value=False), patch.object(
+        manager, "_start_process"
+    ) as start_process, patch.object(manager, "_wait_for_local_listener") as wait_for_listener:
+        manager.ensure_tunnel()
+
+    start_process.assert_called_once()
+    wait_for_listener.assert_called_once()
+
+
+def test_api_tunnel_close_terminates_running_process() -> None:
+    manager = SSHTunnelManager(SimpleNamespace(enabled=True))
+    process = Mock()
+    process.poll.return_value = None
+    manager._process = process
+
+    manager.close()
+
+    process.terminate.assert_called_once()
+    process.wait.assert_called_once_with(timeout=5)
+    process.kill.assert_not_called()
+    assert manager._process is None
+
+
+def test_api_tunnel_close_kills_process_after_timeout() -> None:
+    manager = SSHTunnelManager(SimpleNamespace(enabled=True))
+    process = Mock()
+    process.poll.return_value = None
+    process.wait.side_effect = TimeoutError()
+    manager._process = process
+
+    with patch("proxmox_mcp.core.ssh_tunnel.subprocess.TimeoutExpired", TimeoutError):
+        manager.close()
+
+    process.terminate.assert_called_once()
+    process.kill.assert_called_once()
+    assert manager._process is None
+
+
+def test_api_tunnel_wait_fails_when_ssh_exits_early() -> None:
+    tunnel_config = SimpleNamespace(
+        ssh_host="jump-host",
+        local_host="127.0.0.1",
+        local_port=18006,
+        remote_host="10.0.0.10",
+        remote_port=8006,
+        connect_timeout=15,
+    )
+    manager = SSHTunnelManager(tunnel_config)
+    process = Mock()
+    process.poll.return_value = 255
+    process.stderr.read.return_value = "bad\nkey"
+    manager._process = process
+
+    with pytest.raises(RuntimeError, match="Failed to establish SSH tunnel"):
+        manager._wait_for_local_listener()
+
+
+def test_api_tunnel_wait_times_out_without_listener() -> None:
+    tunnel_config = SimpleNamespace(
+        ssh_host="jump-host",
+        local_host="127.0.0.1",
+        local_port=18006,
+        remote_host="10.0.0.10",
+        remote_port=8006,
+        connect_timeout=1,
+    )
+    manager = SSHTunnelManager(tunnel_config)
+    process = Mock()
+    process.poll.return_value = None
+    manager._process = process
+
+    with patch.object(manager, "_is_local_endpoint_reachable", return_value=False), patch(
+        "proxmox_mcp.core.ssh_tunnel.time.time", side_effect=[0, 2]
+    ), patch("proxmox_mcp.core.ssh_tunnel.time.sleep"):
+        with pytest.raises(RuntimeError, match="Timed out waiting"):
+            manager._wait_for_local_listener()
+
+
+def test_api_tunnel_wait_returns_when_listener_becomes_reachable() -> None:
+    tunnel_config = SimpleNamespace(
+        ssh_host="jump-host",
+        local_host="127.0.0.1",
+        local_port=18006,
+        remote_host="10.0.0.10",
+        remote_port=8006,
+        connect_timeout=1,
+    )
+    manager = SSHTunnelManager(tunnel_config)
+    process = Mock()
+    process.poll.return_value = None
+    manager._process = process
+
+    with patch.object(manager, "_is_local_endpoint_reachable", return_value=True):
+        manager._wait_for_local_listener()
+
+
+def test_proxmox_manager_close_releases_tunnel_manager() -> None:
+    manager = object.__new__(ProxmoxManager)
+    manager.tunnel_manager = Mock()
+
+    manager.close()
+
+    manager.tunnel_manager.close.assert_called_once()
+
+
+def test_proxmox_manager_close_without_tunnel_is_noop() -> None:
+    manager = object.__new__(ProxmoxManager)
+    manager.tunnel_manager = None
+
+    manager.close()

--- a/tests/test_tool_user_paths.py
+++ b/tests/test_tool_user_paths.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from proxmox_mcp.tools.backup import BackupTools
 from proxmox_mcp.tools.containers import ContainerTools
 from proxmox_mcp.tools.iso import ISOTools
 from proxmox_mcp.tools.snapshots import SnapshotTools
@@ -185,3 +186,103 @@ def test_list_isos_filters_storage_content_by_node_and_storage():
     assert "debian.iso" in response[0].text
     assert "local @ pve1" in response[0].text
     node_api.storage.return_value.content.get.assert_called_once_with(content="iso")
+
+
+def test_list_backups_filters_formats_and_sorts_results():
+    proxmox = Mock()
+    proxmox.nodes.get.return_value = [{"node": "pve1"}, {"node": "pve2"}]
+    node_api = proxmox.nodes.return_value
+    node_api.storage.get.return_value = [
+        {"storage": "local", "content": "backup,iso"},
+        {"storage": "images", "content": "images"},
+    ]
+    node_api.storage.return_value.content.get.return_value = [
+        {
+            "volid": "local:backup/vzdump-qemu-100.vma.zst",
+            "vmid": 100,
+            "size": 1024,
+            "ctime": 1700000000,
+            "notes": "pre-upgrade",
+            "protected": 1,
+            "format": "vma.zst",
+        }
+    ]
+
+    response = BackupTools(proxmox).list_backups(node="pve1", storage="local", vmid="100")
+
+    assert "Available Backups" in response[0].text
+    assert "VM/CT 100" in response[0].text
+    assert "pre-upgrade" in response[0].text
+    assert "Protected" in response[0].text
+    node_api.storage.return_value.content.get.assert_called_once_with(content="backup", vmid=100)
+
+
+def test_list_backups_reports_empty_filtered_result():
+    proxmox = Mock()
+    proxmox.nodes.get.return_value = [{"node": "pve1"}]
+    proxmox.nodes.return_value.storage.get.return_value = [{"storage": "local", "content": "iso"}]
+
+    response = BackupTools(proxmox).list_backups(node="pve1", storage="local", vmid="100")
+
+    assert response[0].text == "No backups found on node pve1 in storage local for VM/CT 100"
+
+
+def test_create_backup_registers_retry_recipe_with_notes():
+    proxmox = Mock()
+    proxmox.nodes.return_value.vzdump.post.return_value = "UPID:backup"
+    job_store = _JobStore()
+
+    response = BackupTools(proxmox, job_store=job_store).create_backup(
+        "pve1",
+        "100",
+        "backup-store",
+        compress="zstd",
+        mode="snapshot",
+        notes="nightly",
+    )
+
+    request = proxmox.nodes.return_value.vzdump.post.call_args.kwargs
+    assert request["notes-template"] == "nightly"
+    assert job_store.registered[0]["retry_spec"]["kind"] == "backup.create"
+    assert "Job ID: job-1" in response[0].text
+
+
+def test_restore_vm_backup_uses_qemu_endpoint_without_unique_macs():
+    proxmox = Mock()
+    proxmox.nodes.return_value.qemu.post.return_value = "UPID:restore-vm"
+    job_store = _JobStore()
+
+    response = BackupTools(proxmox, job_store=job_store).restore_backup(
+        "pve1",
+        "local:backup/vzdump-qemu-100.vma.zst",
+        "300",
+        unique=False,
+    )
+
+    proxmox.nodes.return_value.qemu.post.assert_called_once_with(
+        archive="local:backup/vzdump-qemu-100.vma.zst",
+        vmid=300,
+    )
+    assert "VM Restore Started" in response[0].text
+    assert "Unique MACs: No" in response[0].text
+    assert job_store.registered[0]["retry_spec"]["params"]["is_lxc"] is False
+
+
+def test_delete_backup_registers_delete_job_when_unprotected():
+    proxmox = Mock()
+    storage_api = proxmox.nodes.return_value.storage.return_value
+    storage_api.content.get.return_value = [
+        {"volid": "local:backup/vzdump-qemu-100.vma.zst", "protected": 0}
+    ]
+    storage_api.content.return_value.delete.return_value = "UPID:delete-backup"
+    job_store = _JobStore()
+
+    response = BackupTools(proxmox, job_store=job_store).delete_backup(
+        "pve1",
+        "local",
+        "local:backup/vzdump-qemu-100.vma.zst",
+    )
+
+    storage_api.content.return_value.delete.assert_called_once()
+    assert "Backup Deleted" in response[0].text
+    assert job_store.registered[0]["retry_spec"]["kind"] == "backup.delete"


### PR DESCRIPTION
## Summary
- close the Proxmox API SSH tunnel manager during server shutdown
- validate CI on Python 3.11 and 3.12
- raise the enforced coverage gate to 75% with focused SSH tunnel, formatting, and backup tests
- bump release metadata to v0.5.5 and add release notes

## Validation
- pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=75
- ruff check .
- mypy src --ignore-missing-imports
- pip-audit -r requirements.txt
- python -m build --outdir .codex-run\\dist-0.5.5
- twine check .codex-run\\dist-0.5.5\\*

Note: local Windows environment does not have Python 3.12 installed; the new GitHub Actions matrix covers Python 3.12.