### PR TITLE
Release v0.5.6 documentation experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <img src="docs/assets/logo-proxmoxmcp-plus.png" alt="ProxmoxMCP-Plus Logo" width="160"/>
 </div>
 
-<p align="center"><strong>Control Proxmox VE from LLMs, AI agents, MCP clients, and OpenAPI tooling with one safer interface for VMs, LXCs, backups, snapshots, ISOs, container commands, and persistent long-running jobs.</strong></p>
+<p align="center"><strong>Operate Proxmox VE from MCP clients, AI agents, and OpenAPI tooling through one security-conscious control plane for VMs, LXCs, snapshots, backups, ISOs, container commands, and persistent long-running jobs.</strong></p>
 
 <p align="center">
   <a href="https://pypi.org/project/proxmox-mcp-plus/"><img alt="PyPI" src="https://img.shields.io/pypi/v/proxmox-mcp-plus"></a>
@@ -18,8 +18,10 @@
 
 <p align="center">
   <a href="#quick-start">Quick Start</a> |
+  <a href="#client-install">Client Install</a> |
   <a href="#demo">Demo</a> |
-  <a href="#core-platform-capabilities">Capabilities</a> |
+  <a href="#choose-the-right-tool">Tools</a> |
+  <a href="#safety-model">Safety</a> |
   <a href="#scenario-templates">Scenarios</a> |
   <a href="#documentation">Docs</a> |
   <a href="https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki">Wiki</a>
@@ -27,14 +29,16 @@
 
 ![ProxmoxMCP-Plus architecture and control flow](docs/assets/proxmoxmcp-drawio-hero-main-refresh.svg)
 
-## Platform Overview
+## Why ProxmoxMCP-Plus
 
-ProxmoxMCP-Plus provides a unified Proxmox VE control surface in two forms:
+ProxmoxMCP-Plus sits between AI clients and Proxmox VE so operators do not have to stitch together raw API calls, one-off shell scripts, and custom job polling for every workflow.
 
-- `MCP` for Claude Desktop, Open WebUI, and other LLM or AI agent clients
+It exposes the same operational surface in two ways:
+
+- `MCP` for Claude Desktop, Cursor, VS Code, Open WebUI, Codex, and other MCP-capable agents
 - `OpenAPI` for HTTP automation, dashboards, internal tools, and no-code workflows
 
-Instead of stitching together raw Proxmox API calls, shell scripts, and custom glue code, the project consolidates core operational workflows in one interface:
+What you get:
 
 - VM and LXC lifecycle actions
 - snapshot create, rollback, and delete
@@ -44,28 +48,21 @@ Instead of stitching together raw Proxmox API calls, shell scripts, and custom g
 - SSH-backed container command execution with guardrails
 - persistent job tracking for async Proxmox tasks
 
-## Design Priorities
+## What Makes It Different
 
-ProxmoxMCP-Plus is designed for the gap between low-level Proxmox primitives and production-facing workflows that need to be usable from both LLM-native clients and standard automation systems.
-
-- `Dual-surface architecture`: MCP for conversational workflows, OpenAPI for standard automation
-- `Operator-oriented scope`: focused on day-2 tasks, not just raw low-level endpoints
-- `Safer-by-default execution`: auth, command policy, and explicit execution paths
-- `Observable long-running workflows`: stable `Job ID`s, progress polling, retry, cancel, and audit history
-- `Operationally grounded`: documented workflows are backed by live-environment verification
+| Priority | How the project handles it |
+| --- | --- |
+| Dual access paths | Native MCP for agent workflows and OpenAPI for standard HTTP automation |
+| Proxmox-oriented workflows | Day-2 VM, LXC, snapshot, backup, ISO, storage, and cluster operations |
+| Long-running operations | Stable `job_id`s, Proxmox `UPID` tracking, polling, retry, cancel, and audit history |
+| Safer execution | Proxmox API tokens, OpenAPI bearer auth, command policy, approval tokens, TLS validation, and MCP HTTP Host/Origin controls |
+| Real validation | Unit, integration, Docker/OpenAPI, and live Proxmox e2e entry points are documented in the repo |
 
 ## Quick Start
 
-### 1. Prepare Proxmox access
+### 1. Prepare Proxmox Credentials
 
-Read the official Proxmox docs first if you are setting up a fresh lab:
-
-- [Proxmox VE installation guide](https://pve.proxmox.com/pve-docs/pve-installation-plain.html)
-- [Proxmox VE API guide](https://pve.proxmox.com/wiki/Proxmox_VE_API)
-- [Proxmox VE administration guide](https://pve.proxmox.com/pve-docs/pve-admin-guide.html)
-- [Linux Container guide](https://pve.proxmox.com/wiki/Linux_Container)
-
-Create it from the example first:
+Create a Proxmox API token with only the permissions your workflows need. Then create the local config file:
 
 ```bash
 cp proxmox-config/config.example.json proxmox-config/config.json
@@ -85,7 +82,7 @@ Add a `jobs` section if you want job state persisted somewhere other than the de
 For real live verification, use a separate `proxmox-config/config.live.json` created from `proxmox-config/config.live.example.json`.
 Do not point live e2e at a placeholder or local-only `config.json` unless you intentionally run a local API tunnel there.
 
-Minimal job persistence config:
+Optional job persistence config:
 
 ```json
 {
@@ -95,9 +92,15 @@ Minimal job persistence config:
 }
 ```
 
-### 2. Choose one runtime path
+### 2. Choose One Runtime Path
 
-#### PyPI
+| Path | Best for | Start command | Verify |
+| --- | --- | --- | --- |
+| MCP stdio from PyPI | Claude Desktop, Cursor, VS Code, Codex, local agents | `uvx proxmox-mcp-plus` | client lists `get_nodes`, `get_vms`, and job tools |
+| Native MCP HTTP from Docker | remote MCP clients that support Streamable HTTP | `docker compose --profile mcp-http up -d proxmox-mcp-http` | connect to `http://localhost:8000/mcp` |
+| OpenAPI bridge from Docker | HTTP clients, dashboards, scripts, no-code tools | `docker compose up -d` | `curl -f http://localhost:8811/livez` |
+
+#### MCP stdio with PyPI
 
 ```bash
 uvx proxmox-mcp-plus
@@ -110,19 +113,11 @@ pip install proxmox-mcp-plus
 proxmox-mcp-plus
 ```
 
-#### Docker / GHCR
+Use this path when the MCP client launches a local stdio server.
 
-OpenAPI mode remains the default Docker runtime and requires an API key:
+#### Native MCP HTTP with Docker
 
-```bash
-export PROXMOX_API_KEY="$(openssl rand -hex 32)"
-docker run --rm -p 8811:8811 \
-  -e PROXMOX_API_KEY="$PROXMOX_API_KEY" \
-  -v "$(pwd)/proxmox-config/config.json:/app/proxmox-config/config.json:ro" \
-  ghcr.io/rekklesna/proxmoxmcp-plus:latest
-```
-
-Native MCP Streamable HTTP mode is available from the same image:
+Use this path when a remote MCP client supports Streamable HTTP:
 
 ```bash
 docker run --rm -p 8000:8000 \
@@ -134,9 +129,13 @@ docker run --rm -p 8000:8000 \
   ghcr.io/rekklesna/proxmoxmcp-plus:latest
 ```
 
-Point MCP clients that support Streamable HTTP at `http://<docker-host>:8000/mcp`.
+Point MCP clients at:
 
-When serving MCP HTTP behind a reverse proxy, keep DNS rebinding protection enabled and allow only the proxy hostnames you expect:
+```text
+http://<docker-host>:8000/mcp
+```
+
+When serving MCP HTTP behind a reverse proxy, keep DNS rebinding protection enabled and allow only the hostnames you expect:
 
 ```bash
 docker run --rm -p 8000:8000 \
@@ -151,7 +150,29 @@ docker run --rm -p 8000:8000 \
   ghcr.io/rekklesna/proxmoxmcp-plus:latest
 ```
 
-#### Source
+#### OpenAPI bridge with Docker
+
+OpenAPI mode is the default Docker runtime and requires an API key:
+
+```bash
+export PROXMOX_API_KEY="$(openssl rand -hex 32)"
+docker run --rm -p 8811:8811 \
+  -e PROXMOX_API_KEY="$PROXMOX_API_KEY" \
+  -v "$(pwd)/proxmox-config/config.json:/app/proxmox-config/config.json:ro" \
+  ghcr.io/rekklesna/proxmoxmcp-plus:latest
+```
+
+Verify the OpenAPI surface:
+
+```bash
+curl -f http://localhost:8811/livez
+curl -f -H "Authorization: Bearer $PROXMOX_API_KEY" http://localhost:8811/health
+curl -H "Authorization: Bearer $PROXMOX_API_KEY" http://localhost:8811/openapi.json
+```
+
+For local unauthenticated development only, set `PROXMOX_ALLOW_NO_AUTH=true`.
+
+#### Source checkout
 
 ```bash
 git clone https://github.com/RekklesNA/ProxmoxMCP-Plus.git
@@ -161,42 +182,44 @@ uv pip install -e ".[dev]"
 python main.py
 ```
 
-### 3. Run the HTTP/OpenAPI surface
-
-```bash
-export PROXMOX_API_KEY="${PROXMOX_API_KEY:-$(openssl rand -hex 32)}"
-docker compose up -d
-curl -f http://localhost:8811/livez
-curl -f -H "Authorization: Bearer $PROXMOX_API_KEY" http://localhost:8811/health
-curl -H "Authorization: Bearer $PROXMOX_API_KEY" http://localhost:8811/openapi.json
-```
-
-For local unauthenticated development only, set `PROXMOX_ALLOW_NO_AUTH=true`.
-
-### 4. Run the native MCP Streamable HTTP surface
-
-```bash
-docker compose --profile mcp-http up -d proxmox-mcp-http
-```
-
-Connect a Streamable HTTP MCP client to:
-
-```text
-http://localhost:8000/mcp
-```
-
 The `8811` service is the OpenAPI/REST bridge. The `8000` service is the native MCP HTTP endpoint.
 
-### 5. Point a stdio MCP client at the server
+## Client Install
 
-Minimal MCP client shape:
+Use the one-click buttons when your client supports MCP install deeplinks, or copy the JSON config below.
+
+[![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=proxmox-mcp-plus&inputs=%5B%7B%22id%22%3A%22proxmox_host%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Proxmox%20host%22%7D%2C%7B%22id%22%3A%22proxmox_user%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Proxmox%20user%2C%20for%20example%20root%40pam%22%7D%2C%7B%22id%22%3A%22proxmox_token_name%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Proxmox%20API%20token%20name%22%7D%2C%7B%22id%22%3A%22proxmox_token_value%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Proxmox%20API%20token%20value%22%2C%22password%22%3Atrue%7D%5D&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22proxmox-mcp-plus%22%5D%2C%22env%22%3A%7B%22PROXMOX_HOST%22%3A%22%24%7Binput%3Aproxmox_host%7D%22%2C%22PROXMOX_USER%22%3A%22%24%7Binput%3Aproxmox_user%7D%22%2C%22PROXMOX_TOKEN_NAME%22%3A%22%24%7Binput%3Aproxmox_token_name%7D%22%2C%22PROXMOX_TOKEN_VALUE%22%3A%22%24%7Binput%3Aproxmox_token_value%7D%22%2C%22PROXMOX_VERIFY_SSL%22%3A%22true%22%7D%7D)
+[![Install in Cursor](https://img.shields.io/badge/Cursor-Install_Server-000000?style=flat-square)](https://cursor.com/en/install-mcp?name=proxmox-mcp-plus&config=eyJjb21tYW5kIjoidXZ4IHByb3htb3gtbWNwLXBsdXMiLCJlbnYiOnsiUFJPWE1PWF9IT1NUIjoieW91ci1wcm94bW94LWhvc3QiLCJQUk9YTU9YX1VTRVIiOiJyb290QHBhbSIsIlBST1hNT1hfVE9LRU5fTkFNRSI6Im1jcC10b2tlbiIsIlBST1hNT1hfVE9LRU5fVkFMVUUiOiJ5b3VyLXRva2VuLXNlY3JldCIsIlBST1hNT1hfVkVSSUZZX1NTTCI6InRydWUifX0=)
+
+Recommended stdio config:
 
 ```json
 {
   "mcpServers": {
     "proxmox-mcp-plus": {
-      "command": "python",
-      "args": ["/path/to/ProxmoxMCP-Plus/main.py"],
+      "command": "uvx",
+      "args": ["proxmox-mcp-plus"],
+      "env": {
+        "PROXMOX_HOST": "your-proxmox-host",
+        "PROXMOX_USER": "root@pam",
+        "PROXMOX_TOKEN_NAME": "mcp-token",
+        "PROXMOX_TOKEN_VALUE": "your-token-secret",
+        "PROXMOX_PORT": "8006",
+        "PROXMOX_VERIFY_SSL": "true"
+      }
+    }
+  }
+}
+```
+
+Use a local config file if you prefer not to keep credentials in the client config:
+
+```json
+{
+  "mcpServers": {
+    "proxmox-mcp-plus": {
+      "command": "uvx",
+      "args": ["proxmox-mcp-plus"],
       "env": {
         "PROXMOX_MCP_CONFIG": "/path/to/ProxmoxMCP-Plus/proxmox-config/config.json"
       }
@@ -205,7 +228,7 @@ Minimal MCP client shape:
 }
 ```
 
-Client-specific examples for Claude Desktop and Open WebUI are in the [Integrations Guide](docs/wiki/Integrations%20Guide.md).
+Client-specific examples for Claude Desktop, Cursor, VS Code, Codex, OpenCode, Open WebUI, Streamable HTTP, and OpenAPI are in the [Client Setup Guide](docs/wiki/Client%20Setup.md) and [Integrations Guide](docs/wiki/Integrations%20Guide.md).
 
 ## Demo
 
@@ -214,6 +237,38 @@ This demo is a direct terminal recording of `qwen/qwen3.6-plus` driving a live M
 ![Recorded demo gif](docs/assets/proxmoxmcp-demo.gif)
 
 [Watch the MP4 version](docs/assets/proxmoxmcp-demo.mp4)
+
+## Choose The Right Tool
+
+Start with read-only discovery, then move to mutating tools only after the target node, storage, VMID, and permissions are clear.
+
+| Operator goal | Start with | Then use | Notes |
+| --- | --- | --- | --- |
+| Inspect the cluster | `get_nodes`, `get_cluster_status` | `get_storage`, `get_vms`, `get_containers` | Best first health check after client install |
+| Create or manage a VM | `get_nodes`, `get_storage` | `create_vm`, `start_vm`, `stop_vm`, `delete_vm` | Long-running mutations return `job_id` and Proxmox `task_id` |
+| Manage LXCs | `get_containers`, `get_storage` | `create_container`, `start_container`, `stop_container`, `delete_container` | SSH-backed command tools require the optional `ssh` config |
+| Roll back risky changes | `list_snapshots` with `vm_type=qemu` or `vm_type=lxc` | `create_snapshot`, `rollback_snapshot`, `delete_snapshot` | Create a snapshot before destructive workflow tests |
+| Run commands inside guests | VM or container status tools | `execute_vm_command`, `execute_container_command` | VM path needs QEMU Guest Agent; LXC path needs SSH to the Proxmox node |
+| Track async work | mutation response with `job_id` | `poll_job`, `get_job`, `list_jobs`, `retry_job`, `cancel_job` | Use `job_id` for agent/user conversations and `task_id` for raw Proxmox traceability |
+| Automate from HTTP tools | `/openapi.json` | `/jobs`, `/health`, generated tool routes | Use bearer auth and keep CORS restricted outside local development |
+
+For the full tool map, see the [Tool Selection Guide](docs/wiki/Tool%20Selection%20Guide.md) and [API & Tool Reference](docs/wiki/API%20%26%20Tool%20Reference.md).
+
+## Safety Model
+
+ProxmoxMCP-Plus is an access layer, not a replacement for Proxmox RBAC, network controls, or client-side MCP approval prompts.
+
+The project gives operators several control points:
+
+- Proxmox API tokens decide what the backend can do.
+- `PROXMOX_API_KEY` protects the OpenAPI bridge by default.
+- TLS verification is enforced unless development mode is explicitly enabled.
+- `command_policy` controls command execution and high-risk operations.
+- `approval_token` can gate command execution and high-risk mutating actions.
+- MCP Streamable HTTP deployments can use DNS rebinding protection plus Host and Origin allowlists.
+- Logs are designed to avoid exposing command and credential material.
+
+Read the [Security Guide](docs/wiki/Security%20Guide.md) before exposing the server outside a trusted local environment.
 
 ## Core Platform Capabilities
 
@@ -327,7 +382,10 @@ The README is intentionally optimized for fast GitHub comprehension. Longer oper
 | --- | --- |
 | Understand the project and deployment flow | [Wiki Home](docs/wiki/Home.md) |
 | Configure and run against a Proxmox environment | [Operator Guide](docs/wiki/Operator%20Guide.md) |
-| Connect Claude Desktop or Open WebUI | [Integrations Guide](docs/wiki/Integrations%20Guide.md) |
+| Connect Claude Desktop, Cursor, VS Code, Codex, Open WebUI, or HTTP clients | [Client Setup Guide](docs/wiki/Client%20Setup.md) |
+| Choose the right tool for a workflow | [Tool Selection Guide](docs/wiki/Tool%20Selection%20Guide.md) |
+| Review docs quality goals, media plan, and publishing checklist | [Documentation Quality Plan](docs/wiki/Documentation%20Quality%20Plan.md) |
+| Review integration patterns and transport details | [Integrations Guide](docs/wiki/Integrations%20Guide.md) |
 | Install from MCP-aware IDEs and agents | [Agent Installation](docs/agent-installation.md) |
 | Enable LXC command execution over SSH | [Container Command Execution](docs/container-command-execution.md) |
 | Review security and command policy | [Security Guide](docs/wiki/Security%20Guide.md) |

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,24 @@
+# ProxmoxMCP-Plus Documentation For LLMs
+
+Use these pages as the primary documentation context for ProxmoxMCP-Plus.
+
+- Project overview: ../README.md
+- Client setup: wiki/Client Setup.md
+- Operator guide: wiki/Operator Guide.md
+- Tool selection guide: wiki/Tool Selection Guide.md
+- Security guide: wiki/Security Guide.md
+- Container command execution: wiki/Container Command Execution.md
+- API and tool reference: wiki/API & Tool Reference.md
+- Troubleshooting: wiki/Troubleshooting.md
+- Developer guide: wiki/Developer Guide.md
+- Release and upgrade notes: wiki/Release & Upgrade Notes.md
+- Documentation quality plan: wiki/Documentation Quality Plan.md
+
+Important operating notes:
+
+- Use read-only tools such as `get_nodes`, `get_vms`, `get_containers`, and `get_storage` before mutating Proxmox resources.
+- Use `job_id` for ProxmoxMCP-Plus job tracking and `task_id` for raw Proxmox `UPID` traceability.
+- MCP Streamable HTTP clients should connect to `/mcp` on the service running on port `8000`.
+- OpenAPI clients should use the service on port `8811` and send `Authorization: Bearer <PROXMOX_API_KEY>`.
+- Container command execution appears only when the config includes an `ssh` section.
+- TLS verification should remain enabled outside explicit local development mode.

--- a/docs/releases/v0.5.6.md
+++ b/docs/releases/v0.5.6.md
@@ -1,0 +1,32 @@
+# ProxmoxMCP-Plus v0.5.6
+
+Release date: 2026-05-30
+
+## Documentation Experience Improvements
+
+- Reworked the README first-screen positioning, quick-start flow, and documentation routing so new users can choose between MCP stdio, MCP Streamable HTTP, and OpenAPI without reading the full wiki first.
+- Added one-click install links for supported VS Code and Cursor MCP flows, plus safer copy-ready stdio configuration examples.
+- Added a compact README tool-selection table that maps common Proxmox operator goals to the appropriate MCP and OpenAPI workflows.
+- Added a README safety model summary that routes users to the full security guide before exposing the server outside a trusted local environment.
+
+## Wiki Improvements
+
+- Rebuilt the wiki home page around task-oriented routing and a five-minute installation path.
+- Added `Client Setup` for Claude Desktop, Cursor, VS Code, Codex, OpenCode, Open WebUI, generic stdio clients, Streamable HTTP clients, and HTTP/OpenAPI consumers.
+- Added `Tool Selection Guide` for VM, LXC, snapshot, backup, ISO, command execution, job tracking, and OpenAPI workflows.
+- Added `Documentation Quality Plan` to track README standards, wiki standards, media plans, docs-site plans, LLM documentation entry points, and release documentation checks.
+- Updated the wiki sidebar and wiki seed README to include the new pages.
+
+## LLM Documentation Entry Point
+
+- Added `docs/llms.txt` as a compact documentation index for AI clients and coding agents.
+
+## Runtime Impact
+
+- No runtime code paths, tools, endpoints, or configuration requirements changed in this release.
+- No migration is required from `v0.5.5`.
+
+## Upgrade Notes
+
+- Upgrade normally from PyPI, Docker/GHCR, or source.
+- Review the new Client Setup and Tool Selection Guide pages when onboarding new users or new MCP clients.

--- a/docs/wiki/Client Setup.md
+++ b/docs/wiki/Client Setup.md
@@ -1,0 +1,198 @@
+# Client Setup
+
+This page covers the common ways to connect MCP clients and HTTP clients to ProxmoxMCP-Plus.
+
+## Choose A Connection Pattern
+
+| Client or use case | Recommended pattern | Target |
+| --- | --- | --- |
+| Claude Desktop | MCP stdio | local `uvx proxmox-mcp-plus` or source checkout |
+| Cursor | MCP stdio, or Streamable HTTP if hosted separately | local command or `http://<host>:8000/mcp` |
+| VS Code / GitHub Copilot agent mode | MCP stdio, or Streamable HTTP where supported | local command or remote MCP endpoint |
+| Codex | MCP stdio | local command configured in Codex MCP settings |
+| OpenCode | MCP stdio with env file | examples under `proxmox-config/opencode/` |
+| Open WebUI or HTTP-only tools | OpenAPI bridge | `http://<host>:8811/docs` and `/openapi.json` |
+| Remote MCP clients | MCP Streamable HTTP | `http://<host>:8000/mcp` |
+
+Use MCP stdio when the client can launch the server locally. Use MCP Streamable HTTP when the server runs on another host. Use OpenAPI when the consumer only understands HTTP or Swagger-style schemas.
+
+## One-Click Installs
+
+Use these buttons only if your client supports MCP install deeplinks.
+
+[![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=proxmox-mcp-plus&inputs=%5B%7B%22id%22%3A%22proxmox_host%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Proxmox%20host%22%7D%2C%7B%22id%22%3A%22proxmox_user%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Proxmox%20user%2C%20for%20example%20root%40pam%22%7D%2C%7B%22id%22%3A%22proxmox_token_name%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Proxmox%20API%20token%20name%22%7D%2C%7B%22id%22%3A%22proxmox_token_value%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Proxmox%20API%20token%20value%22%2C%22password%22%3Atrue%7D%5D&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22proxmox-mcp-plus%22%5D%2C%22env%22%3A%7B%22PROXMOX_HOST%22%3A%22%24%7Binput%3Aproxmox_host%7D%22%2C%22PROXMOX_USER%22%3A%22%24%7Binput%3Aproxmox_user%7D%22%2C%22PROXMOX_TOKEN_NAME%22%3A%22%24%7Binput%3Aproxmox_token_name%7D%22%2C%22PROXMOX_TOKEN_VALUE%22%3A%22%24%7Binput%3Aproxmox_token_value%7D%22%2C%22PROXMOX_VERIFY_SSL%22%3A%22true%22%7D%7D)
+[![Install in Cursor](https://img.shields.io/badge/Cursor-Install_Server-000000?style=flat-square)](https://cursor.com/en/install-mcp?name=proxmox-mcp-plus&config=eyJjb21tYW5kIjoidXZ4IHByb3htb3gtbWNwLXBsdXMiLCJlbnYiOnsiUFJPWE1PWF9IT1NUIjoieW91ci1wcm94bW94LWhvc3QiLCJQUk9YTU9YX1VTRVIiOiJyb290QHBhbSIsIlBST1hNT1hfVE9LRU5fTkFNRSI6Im1jcC10b2tlbiIsIlBST1hNT1hfVE9LRU5fVkFMVUUiOiJ5b3VyLXRva2VuLXNlY3JldCIsIlBST1hNT1hfVkVSSUZZX1NTTCI6InRydWUifX0=)
+
+## Stdio Config
+
+This config works for MCP clients that launch local server processes:
+
+```json
+{
+  "mcpServers": {
+    "proxmox-mcp-plus": {
+      "command": "uvx",
+      "args": ["proxmox-mcp-plus"],
+      "env": {
+        "PROXMOX_HOST": "your-proxmox-host",
+        "PROXMOX_USER": "root@pam",
+        "PROXMOX_TOKEN_NAME": "mcp-token",
+        "PROXMOX_TOKEN_VALUE": "your-token-secret",
+        "PROXMOX_PORT": "8006",
+        "PROXMOX_VERIFY_SSL": "true",
+        "LOG_LEVEL": "INFO"
+      }
+    }
+  }
+}
+```
+
+If the repo is cloned locally and you want file-based config:
+
+```json
+{
+  "mcpServers": {
+    "proxmox-mcp-plus": {
+      "command": "uvx",
+      "args": ["proxmox-mcp-plus"],
+      "env": {
+        "PROXMOX_MCP_CONFIG": "/absolute/path/to/ProxmoxMCP-Plus/proxmox-config/config.json"
+      }
+    }
+  }
+}
+```
+
+For source checkouts that launch `main.py` directly:
+
+```json
+{
+  "mcpServers": {
+    "proxmox-mcp-plus": {
+      "command": "python",
+      "args": ["/absolute/path/to/ProxmoxMCP-Plus/main.py"],
+      "env": {
+        "PYTHONPATH": "/absolute/path/to/ProxmoxMCP-Plus/src",
+        "PROXMOX_MCP_CONFIG": "/absolute/path/to/ProxmoxMCP-Plus/proxmox-config/config.json"
+      }
+    }
+  }
+}
+```
+
+## Claude Desktop
+
+An example Claude Desktop config is included at:
+
+```text
+proxmox-config/claude_desktop_config.example.json
+```
+
+Typical workflow:
+
+1. Create and populate `proxmox-config/config.json`.
+2. Update the example paths to your local machine.
+3. Add the server entry to Claude Desktop's MCP config.
+4. Restart Claude Desktop.
+5. Confirm read-only tools such as `get_nodes`, `get_vms`, and `get_storage` appear.
+
+## Cursor
+
+Cursor can use the stdio config above. After adding the server, refresh the MCP server list and verify that read-only tools appear before running mutating workflows.
+
+If the server is hosted remotely, run the Docker Streamable HTTP service and connect Cursor to:
+
+```text
+http://<docker-host>:8000/mcp
+```
+
+## VS Code
+
+Use the install button above if your VS Code build supports MCP install deeplinks. Otherwise add the stdio config manually in the MCP server settings used by your VS Code agent extension.
+
+For a remote Streamable HTTP deployment, use:
+
+```json
+{
+  "type": "http",
+  "url": "http://<host>:8000/mcp"
+}
+```
+
+## Codex
+
+Use the stdio config with `uvx proxmox-mcp-plus`. Prefer a config file path when you already have `proxmox-config/config.json` checked and validated locally.
+
+Minimal server shape:
+
+```toml
+[mcp_servers.proxmox-mcp-plus]
+command = "uvx"
+args = ["proxmox-mcp-plus"]
+
+[mcp_servers.proxmox-mcp-plus.env]
+PROXMOX_MCP_CONFIG = "/absolute/path/to/ProxmoxMCP-Plus/proxmox-config/config.json"
+```
+
+## OpenCode
+
+Examples for OpenCode live under:
+
+```text
+proxmox-config/opencode/
+```
+
+The example command sources environment variables and then launches the package. This is useful when you want to avoid hard-coding credentials in JSON.
+
+## Open WebUI And HTTP Clients
+
+For HTTP-native clients, run the OpenAPI bridge:
+
+```bash
+export PROXMOX_API_KEY="${PROXMOX_API_KEY:-$(openssl rand -hex 32)}"
+docker compose up -d
+```
+
+Then connect to:
+
+| Route | Purpose |
+| --- | --- |
+| `http://<host>:8811/docs` | Swagger UI |
+| `http://<host>:8811/openapi.json` | OpenAPI schema |
+| `http://<host>:8811/livez` | unauthenticated liveness |
+| `http://<host>:8811/readyz` | authenticated readiness |
+| `http://<host>:8811/health` | authenticated readiness alias |
+
+Send authenticated requests with:
+
+```text
+Authorization: Bearer <PROXMOX_API_KEY>
+```
+
+## Post-Install Verification
+
+After connecting any client:
+
+1. Confirm the server starts without config validation errors.
+2. Confirm read-only tools appear: `get_nodes`, `get_vms`, `get_containers`, `get_storage`.
+3. In OpenAPI mode, confirm `/livez` returns `200`.
+4. In OpenAPI mode, confirm authenticated `/health` or `/readyz` is healthy.
+5. Confirm `execute_container_command` appears only if the config includes an `ssh` section.
+6. Run mutating tools only after checking target IDs, storage, permissions, and command policy.
+
+## Common Client Mistakes
+
+- `uvx` is not installed or not on PATH.
+- `PYTHONPATH` is missing when launching from a source checkout.
+- `PROXMOX_MCP_CONFIG` points to the wrong file.
+- The Proxmox API token lacks permissions for the requested operation.
+- TLS verification is disabled but `PROXMOX_DEV_MODE` or `security.dev_mode` is not enabled.
+- A client points to `http://<host>:8811` expecting MCP Streamable HTTP; use `http://<host>:8000/mcp` instead.
+- `execute_container_command` is expected even though the `ssh` config is absent.
+
+## Related Pages
+
+- [Operator Guide](Operator-Guide)
+- [Tool Selection Guide](Tool-Selection-Guide)
+- [Security Guide](Security-Guide)
+- [Troubleshooting](Troubleshooting)

--- a/docs/wiki/Documentation Quality Plan.md
+++ b/docs/wiki/Documentation Quality Plan.md
@@ -1,0 +1,128 @@
+# Documentation Quality Plan
+
+This plan keeps the README, wiki, media, and release documentation useful as the MCP ecosystem changes.
+
+## Documentation Goals
+
+The docs should let a new operator:
+
+1. Understand the project value in the first README screen.
+2. Choose stdio, Streamable HTTP, or OpenAPI without guessing.
+3. Install in a common MCP client in a few minutes.
+4. Verify success with read-only tools before mutating Proxmox.
+5. Understand the security model before exposing the server.
+6. Find the right tool for a VM, LXC, snapshot, backup, ISO, command, or job workflow.
+7. Debug common startup, auth, TLS, SSH, and health-check problems.
+
+## README Standard
+
+The README should stay optimized for GitHub scanning:
+
+- one-sentence positioning statement
+- badges for package, release, CI, container, and license
+- architecture image near the top
+- three quick-start paths: MCP stdio, MCP Streamable HTTP, OpenAPI
+- one-click install buttons where supported
+- short demo section with GIF and MP4 link
+- tool-selection table for common workflows
+- compact safety model
+- clear links into the wiki for long-form details
+
+Avoid moving full reference material into the README. Keep reference detail in wiki pages or generated docs.
+
+## Wiki Standard
+
+The wiki should be task-oriented:
+
+| Page | Purpose |
+| --- | --- |
+| `Home` | routing page and five-minute path |
+| `Client Setup` | client-specific install and verification |
+| `Operator Guide` | runtime modes, config, deployment, health, logs |
+| `Tool Selection Guide` | goal-to-tool workflow guidance |
+| `Security Guide` | auth, TLS, command policy, approval, exposure controls |
+| `Container Command Execution` | SSH-backed LXC command setup |
+| `API & Tool Reference` | exact tools, inputs, prerequisites, failures |
+| `Troubleshooting` | symptom-driven fixes |
+| `Developer Guide` | local dev, tests, release workflow |
+| `Release & Upgrade Notes` | compatibility and upgrade impact |
+
+## Media Plan
+
+Keep existing assets:
+
+- `docs/assets/logo-proxmoxmcp-plus.png`
+- `docs/assets/logo-proxmoxmcp-plus-400.png`
+- `docs/assets/proxmoxmcp-drawio-hero-main-refresh.svg`
+- `docs/assets/proxmoxmcp-demo.gif`
+- `docs/assets/proxmoxmcp-demo.mp4`
+
+Recommended new assets when real screenshots or recordings are available:
+
+| Asset | Purpose |
+| --- | --- |
+| `docs/assets/client-connected-vscode.png` | prove the MCP server is visible in a mainstream IDE |
+| `docs/assets/client-connected-cursor.png` | show client install success for Cursor users |
+| `docs/assets/job-lifecycle.png` | explain natural language request -> MCP tool -> Proxmox `UPID` -> `job_id` |
+| `docs/assets/security-flow.png` | show Proxmox token, OpenAPI bearer auth, TLS, command policy, and Host/Origin checks |
+| YouTube or release-asset demo video | 60-90 second live workflow from install to read-only verification to one controlled mutation |
+
+Do not add placeholder screenshots. Only publish assets captured from a working client or lab.
+
+## Docs Site Plan
+
+The repository can continue publishing `docs/wiki/` to GitHub Wiki. A future docs site should use the repository as the source of truth and publish to GitHub Pages.
+
+Recommended path:
+
+1. Add a lightweight static docs generator such as MkDocs Material.
+2. Treat `docs/wiki/` as the initial content source.
+3. Publish on tags and on `main`.
+4. Generate `llms.txt` and `llms-full.txt` during the docs build.
+5. Keep GitHub Wiki pages as a mirror for users who prefer the GitHub UI.
+
+## LLM Documentation Entry Points
+
+Maintain a small `docs/llms.txt` index for AI clients. It should link to:
+
+- README
+- Client Setup
+- Operator Guide
+- Tool Selection Guide
+- Security Guide
+- API & Tool Reference
+- Troubleshooting
+- Release & Upgrade Notes
+
+If a full docs export is added later, keep it generated rather than hand-maintained.
+
+## Automation Checklist
+
+Add or keep checks that prevent documentation drift:
+
+- markdown formatting check for README and docs
+- link check for relative links
+- JSON validation for config examples and MCP client snippets where possible
+- manifest/runtime parity test for tool registration
+- generated API/tool reference from runtime tool metadata or `manifest.json`
+- asset existence check for README images and video links
+- release checklist entry requiring README/wiki updates for user-facing changes
+
+## Release Documentation Checklist
+
+For each release that changes behavior:
+
+1. Update `README.md` only if the first-run path, capability list, safety model, or install path changed.
+2. Update `docs/wiki/API & Tool Reference.md` for tool names, inputs, prerequisites, and failure modes.
+3. Update `docs/wiki/Operator Guide.md` for config, runtime, Docker, health, or logging changes.
+4. Update `docs/wiki/Security Guide.md` for auth, TLS, command policy, or exposure changes.
+5. Update `docs/wiki/Release & Upgrade Notes.md` with upgrade and rollback guidance.
+6. Update `server.json` and `manifest.json` if package metadata or environment variables changed.
+7. Run the docs validation checklist before publishing.
+
+## Related Pages
+
+- [Home](Home)
+- [Client Setup](Client-Setup)
+- [Tool Selection Guide](Tool-Selection-Guide)
+- [Developer Guide](Developer-Guide)

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,25 +1,44 @@
 # ProxmoxMCP-Plus Wiki
 
-This wiki is the longer-form documentation hub for ProxmoxMCP-Plus.
+This wiki is the task-oriented documentation hub for ProxmoxMCP-Plus.
 
-ProxmoxMCP-Plus gives you one Proxmox VE control surface for both:
+ProxmoxMCP-Plus exposes Proxmox VE operations through:
 
-- MCP clients such as Claude Desktop and Open WebUI
-- HTTP and OpenAPI consumers such as dashboards, internal tools, and automation jobs
+- native MCP stdio for local agents and IDEs
+- native MCP Streamable HTTP at `/mcp` for remote MCP clients
+- an OpenAPI bridge for HTTP automation, dashboards, and no-code workflows
 
-Use the root `README.md` for the fast project overview. Use this wiki when you need setup detail, operating guidance, security notes, or tool-by-tool reference material.
+Use the root `README.md` for the fast project overview. Use this wiki when you need to install a client, choose the right runtime, operate safely, debug a deployment, or inspect the tool surface.
 
 ## Start Here
 
 | If you want to... | Open this page |
 | --- | --- |
-| Deploy the project against a configured Proxmox environment | [Operator Guide](Operator-Guide) |
-| Work on the codebase, run checks, or publish releases | [Developer Guide](Developer-Guide) |
-| Connect Claude Desktop, Open WebUI, or HTTP clients | [Integrations Guide](Integrations-Guide) |
-| Understand auth, command policy, and execution safety | [Security Guide](Security-Guide) |
-| Browse the exact tool surface and prerequisites | [API & Tool Reference](API-&-Tool-Reference) |
-| Debug startup, auth, SSH, `/livez`, or `/health` issues | [Troubleshooting](Troubleshooting) |
+| Install the server in Claude Desktop, Cursor, VS Code, Codex, OpenCode, Open WebUI, or a generic MCP client | [Client Setup](Client-Setup) |
+| Decide between stdio, Streamable HTTP, and OpenAPI | [Operator Guide](Operator-Guide) |
+| Choose the right tool for VM, LXC, snapshot, backup, ISO, command, or job workflows | [Tool Selection Guide](Tool-Selection-Guide) |
+| Understand auth, TLS, command policy, approval tokens, and MCP HTTP Host/Origin controls | [Security Guide](Security-Guide) |
+| Enable SSH-backed LXC command execution | [Container Command Execution](Container-Command-Execution) |
+| Browse exact tool names, inputs, prerequisites, and failure modes | [API & Tool Reference](API-&-Tool-Reference) |
+| Debug startup, auth, SSH, `/livez`, `/readyz`, or `/health` issues | [Troubleshooting](Troubleshooting) |
+| Work on code, run checks, or publish a release | [Developer Guide](Developer-Guide) |
 | Review release history and upgrade notes | [Release & Upgrade Notes](Release-&-Upgrade-Notes) |
+| Improve README, media, docs site, wiki, and docs automation | [Documentation Quality Plan](Documentation-Quality-Plan) |
+
+## Five Minute Path
+
+1. Create `proxmox-config/config.json` from `proxmox-config/config.example.json`.
+2. Add Proxmox API host, user, token name, and token value.
+3. Pick one runtime:
+
+| Runtime | Command | Target |
+| --- | --- | --- |
+| MCP stdio | `uvx proxmox-mcp-plus` | launched by local MCP clients |
+| MCP Streamable HTTP | `docker compose --profile mcp-http up -d proxmox-mcp-http` | `http://<host>:8000/mcp` |
+| OpenAPI | `docker compose up -d` | `http://<host>:8811/docs` |
+
+4. Verify read-only tools first: `get_nodes`, `get_vms`, `get_containers`, and `get_storage`.
+5. Use mutating tools only after checking permissions, target IDs, storage, and safety policy.
 
 ## What The Project Covers
 
@@ -28,32 +47,31 @@ Use the root `README.md` for the fast project overview. Use this wiki when you n
 - ISO and template workflows
 - cluster, node, and storage inspection
 - SSH-backed container command execution
-- persistent job tracking with retry, cancel, and audit history
+- persistent job tracking with retry, cancel, polling, and audit history
 - OpenAPI bridging for the MCP tool surface
+
+## Safety Model Summary
+
+ProxmoxMCP-Plus is not a replacement for Proxmox RBAC or network isolation. It adds an operator-facing control layer:
+
+- Proxmox API token permissions remain the backend source of authority.
+- OpenAPI mode requires `PROXMOX_API_KEY` by default.
+- TLS validation is enforced unless `security.dev_mode=true` is explicitly enabled.
+- `command_policy` and `approval_token` can gate command execution and high-risk operations.
+- MCP HTTP deployments can configure DNS rebinding protection plus Host and Origin allowlists.
+- Logs are designed to avoid leaking command and credential material.
 
 ## Architecture Summary
 
-- `main.py` starts the MCP server entrypoint
-- `src/proxmox_mcp/server.py` registers MCP tools
-- `src/proxmox_mcp/openapi_proxy.py` exposes `/`, `/docs`, `/openapi.json`, `/livez`, `/readyz`, `/health`, `/metrics`, and `/jobs`
-- `src/proxmox_mcp/config/` validates configuration and runtime settings
-- `src/proxmox_mcp/security/command_policy.py` applies allow and deny rules for execution requests
-- `src/proxmox_mcp/services/jobs.py` persists long-running job state in SQLite
-- `docs/container-command-execution.md` explains the SSH-backed LXC command path
+- `main.py` starts the MCP server entrypoint.
+- `src/proxmox_mcp/server.py` initializes the MCP server.
+- `src/proxmox_mcp/services/builtin_tool_plugins.py` registers the built-in tool groups.
+- `src/proxmox_mcp/openapi_proxy.py` exposes `/`, `/docs`, `/openapi.json`, `/livez`, `/readyz`, `/health`, `/metrics`, and `/jobs`.
+- `src/proxmox_mcp/config/` validates configuration and runtime settings.
+- `src/proxmox_mcp/security/command_policy.py` applies allow and deny rules for execution requests.
+- `src/proxmox_mcp/services/jobs.py` persists long-running job state in SQLite.
 
 ## Validation Summary
-
-The repository includes live-environment verification entry points for:
-
-- VM create, start, stop, and delete
-- snapshot create, rollback, and delete
-- backup and restore
-- ISO download and cleanup
-- LXC create, start, stop, and delete
-- container SSH-backed command execution
-- container authorized_keys update
-- local OpenAPI `/livez`, `/readyz`, `/health`, and schema
-- Docker image build and `/livez`
 
 Primary validation entry points:
 
@@ -63,6 +81,8 @@ Primary validation entry points:
 - `pip-audit -r requirements.txt`
 - `tests/integration/test_real_contract.py`
 - `tests/scripts/run_real_e2e.py`
+
+Live-environment validation covers VM, LXC, snapshot, backup, ISO, container command, OpenAPI, and Docker paths when a real Proxmox lab config is available.
 
 ## External References
 

--- a/docs/wiki/Integrations Guide.md
+++ b/docs/wiki/Integrations Guide.md
@@ -2,6 +2,8 @@
 
 This guide covers the main ways to connect clients and platforms to ProxmoxMCP-Plus.
 
+For client-specific install snippets for Claude Desktop, Cursor, VS Code, Codex, OpenCode, Open WebUI, and generic MCP clients, start with [Client Setup](Client-Setup). This page focuses on transport patterns and HTTP integration details.
+
 ## Integration Patterns
 
 - `Direct MCP`: a client launches the server locally and talks over stdio
@@ -124,6 +126,7 @@ After connecting a client, verify:
 
 ## Related Pages
 
+- [Client Setup](Client-Setup)
 - [Operator Guide](Operator-Guide)
 - [Security Guide](Security-Guide)
 - [Troubleshooting](Troubleshooting)

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -5,19 +5,23 @@ This directory contains the markdown files intended for the GitHub Wiki and the 
 ## Documentation Strategy
 
 - `README.md` in the repository root is the conversion-focused homepage
-- `docs/wiki/` holds the longer operator, integration, security, and reference material
+- `docs/wiki/` holds the longer client setup, operator, integration, security, workflow, and reference material
 - page names should stay stable so README links and published wiki URLs do not break
 
 ## Included Pages
 
 - `Home.md`
+- `Client Setup.md`
 - `Operator Guide.md`
+- `Tool Selection Guide.md`
 - `Developer Guide.md`
 - `Security Guide.md`
+- `Container Command Execution.md`
 - `Integrations Guide.md`
 - `API & Tool Reference.md`
 - `Troubleshooting.md`
 - `Release & Upgrade Notes.md`
+- `Documentation Quality Plan.md`
 - `_Sidebar.md`
 
 ## Publishing To GitHub Wiki
@@ -43,4 +47,7 @@ git push
 - Keep titles stable so wiki URLs remain stable
 - Update the root README when adding, removing, or renaming wiki pages
 - Keep the homepage short and move operational detail into wiki pages
+- Keep client install examples in `Client Setup.md`
+- Keep goal-to-tool workflow guidance in `Tool Selection Guide.md`
+- Keep documentation improvement work in `Documentation Quality Plan.md`
 - Do not add placeholders for features that do not exist in the codebase

--- a/docs/wiki/Release & Upgrade Notes.md
+++ b/docs/wiki/Release & Upgrade Notes.md
@@ -18,6 +18,35 @@ Use this page to track version-level behavior changes, upgrade steps, and rollba
 
 ## Release History
 
+### Version `0.5.6`
+
+- Release date: 2026-05-30
+- Summary: documentation experience release that reorganizes the GitHub README and wiki around installation, client setup, tool choice, safety, and release documentation quality.
+- New tools or endpoints:
+  - no new runtime tools or endpoints
+- Changed behavior:
+  - no runtime behavior changes
+- Removed or deprecated behavior:
+  - no removals or deprecations
+- Config changes:
+  - no required config migration
+- Docs updated:
+  - `README.md`
+  - `docs/llms.txt`
+  - `docs/releases/v0.5.6.md`
+  - `docs/wiki/Client Setup.md`
+  - `docs/wiki/Documentation Quality Plan.md`
+  - `docs/wiki/Home.md`
+  - `docs/wiki/Integrations Guide.md`
+  - `docs/wiki/Release & Upgrade Notes.md`
+  - `docs/wiki/Tool Selection Guide.md`
+  - `docs/wiki/_Sidebar.md`
+- Upgrade steps:
+  - no required migration
+  - review the new Client Setup and Tool Selection Guide pages when onboarding new MCP clients
+- Rollback notes:
+  - downgrade to `v0.5.5` only if a deployment needs to stay on the previous package metadata; doing so removes the improved README, wiki routing, and LLM documentation index
+
 ### Version `0.5.5`
 
 - Release date: 2026-05-29

--- a/docs/wiki/Tool Selection Guide.md
+++ b/docs/wiki/Tool Selection Guide.md
@@ -1,0 +1,118 @@
+# Tool Selection Guide
+
+Use this page when you know the operational goal but are not sure which ProxmoxMCP-Plus tool path to use.
+
+## Start With Discovery
+
+Run read-only tools before mutating anything:
+
+| Goal | Read-only tools |
+| --- | --- |
+| Check cluster health | `get_nodes`, `get_cluster_status` |
+| Find VMs | `get_vms`, `get_vm_config` |
+| Find containers | `get_containers`, `get_container_config`, `get_container_ip` |
+| Check storage | `get_storage` |
+| Check snapshots | `list_snapshots` with `vm_type=qemu` or `vm_type=lxc` |
+| Check jobs | `list_jobs`, `get_job` |
+
+Discovery confirms node names, VMIDs, storage IDs, guest status, and whether the tool is visible in the connected client.
+
+## VM Workflows
+
+| Operator goal | Tool sequence | Verify |
+| --- | --- | --- |
+| Create a VM | `get_nodes` -> `get_storage` -> `create_vm` -> `poll_job` | `get_vms` or `get_vm_config` |
+| Start or stop a VM | `get_vms` -> `start_vm` or `stop_vm` -> `poll_job` | `get_vms` |
+| Delete a VM | `get_vms` -> snapshot or backup if needed -> `delete_vm` -> `poll_job` | `get_vms` |
+| Run a guest command | `get_vms` -> `execute_vm_command` | command output and guest-agent status |
+
+VM command execution requires QEMU Guest Agent inside the VM.
+
+## Container Workflows
+
+| Operator goal | Tool sequence | Verify |
+| --- | --- | --- |
+| Create an LXC | `get_nodes` -> `get_storage` -> `create_container` -> `poll_job` | `get_containers` |
+| Start or stop an LXC | `get_containers` -> `start_container` or `stop_container` -> `poll_job` | `get_containers` |
+| Delete an LXC | `get_containers` -> snapshot or backup if needed -> `delete_container` -> `poll_job` | `get_containers` |
+| Execute a command in an LXC | `get_containers` -> `execute_container_command` | command output |
+| Update container SSH keys | `get_containers` -> `update_container_ssh_keys` | inspect authorized keys inside the container |
+
+Container command execution appears only when the config has an `ssh` section. It SSHes to the Proxmox node and uses `pct exec`, so treat it as a separate security decision.
+
+## Snapshot And Rollback Workflows
+
+| Operator goal | Tool sequence | Verify |
+| --- | --- | --- |
+| Prepare for a risky change | `list_snapshots` -> `create_snapshot` -> `poll_job` | `list_snapshots` |
+| Roll back a VM or LXC | `list_snapshots` -> `rollback_snapshot` -> `poll_job` | guest status and `list_snapshots` |
+| Clean old snapshots | `list_snapshots` -> `delete_snapshot` -> `poll_job` | `list_snapshots` |
+
+Use snapshots before testing destructive tool flows in a lab.
+
+## Backup And Restore Workflows
+
+| Operator goal | Tool sequence | Verify |
+| --- | --- | --- |
+| Create a backup | `get_storage` -> `create_backup` -> `poll_job` | backup list or storage contents |
+| Restore a backup | `get_storage` -> select backup artifact -> `restore_backup` -> `poll_job` | VM or LXC status |
+| Delete a backup | inspect backup metadata -> `delete_backup` | backup list |
+
+Backup and restore operations are long-running Proxmox tasks. Use `job_id` for user-facing tracking and `task_id` for Proxmox-level traceability.
+
+## ISO And Template Workflows
+
+| Operator goal | Tool sequence | Verify |
+| --- | --- | --- |
+| Download an ISO | `get_storage` -> `download_iso` -> `poll_job` | storage contents |
+| Delete an ISO | inspect storage contents -> `delete_iso` | storage contents |
+| Create an LXC from template | `get_storage` -> confirm template exists -> `create_container` -> `poll_job` | container status |
+
+Check storage content support before downloading ISOs or using templates.
+
+## Job Tracking Workflows
+
+Most mutating Proxmox operations return:
+
+- `task_id`: the raw Proxmox `UPID`
+- `job_id`: the persistent ProxmoxMCP-Plus job record
+
+Use the job tools this way:
+
+| Situation | Tool |
+| --- | --- |
+| User asks for recent work | `list_jobs` |
+| User asks about one operation | `get_job` |
+| You need fresh Proxmox task status | `poll_job` |
+| A retryable operation failed | inspect `get_job`, then `retry_job` |
+| A running task should stop | `cancel_job` |
+
+Keep `jobs.sqlite_path` on durable storage when the deployment should preserve job history across restarts.
+
+## OpenAPI Workflows
+
+Use OpenAPI when a client cannot speak MCP:
+
+1. Start the OpenAPI bridge.
+2. Check `/livez`.
+3. Send bearer auth to `/health` or `/readyz`.
+4. Inspect `/openapi.json`.
+5. Use generated tool routes and `/jobs` routes from the schema.
+
+The OpenAPI bridge is not the native MCP Streamable HTTP endpoint. MCP HTTP clients should connect to `/mcp` on the service running on port `8000`.
+
+## Safety Checklist Before Mutating
+
+- Confirm the Proxmox API token has the required permissions and no more than necessary.
+- Confirm the node, storage, VMID, and guest status from read-only tools.
+- Confirm TLS verification settings are intentional.
+- Confirm command policy and approval-token settings before using command tools.
+- Confirm a snapshot or backup exists before risky changes.
+- Confirm the user expects a real Proxmox mutation, not a dry-run explanation.
+
+## Related Pages
+
+- [API & Tool Reference](API-&-Tool-Reference)
+- [Operator Guide](Operator-Guide)
+- [Security Guide](Security-Guide)
+- [Troubleshooting](Troubleshooting)

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -1,11 +1,14 @@
 ## ProxmoxMCP-Plus Wiki
 
 - [Home](Home)
+- [Client Setup](Client-Setup)
 - [Operator Guide](Operator-Guide)
-- [Developer Guide](Developer-Guide)
+- [Tool Selection Guide](Tool-Selection-Guide)
 - [Security Guide](Security-Guide)
 - [Container Command Execution](Container-Command-Execution)
 - [Integrations Guide](Integrations-Guide)
 - [API & Tool Reference](API-&-Tool-Reference)
 - [Troubleshooting](Troubleshooting)
+- [Developer Guide](Developer-Guide)
 - [Release & Upgrade Notes](Release-&-Upgrade-Notes)
+- [Documentation Quality Plan](Documentation-Quality-Plan)

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": "0.4",
     "name": "proxmox-mcp-plus",
     "display_name": "ProxmoxMCP-Plus",
-    "version": "0.5.5",
+    "version": "0.5.6",
     "description": "An enhanced MCP server for managing Proxmox virtualization platforms.",
     "long_description": "ProxmoxMCP-Plus is an enhanced Model Context Protocol (MCP) server that provides comprehensive tools for managing Proxmox virtualization environments, including VM lifecycle, container management, snapshot operations, and backup/restore capabilities.",
     "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "proxmox-mcp-plus"
-version = "0.5.5"
+version = "0.5.6"
 description = "Enhanced Proxmox MCP Server"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -18,13 +18,13 @@
     "url": "https://github.com/RekklesNA/ProxmoxMCP-Plus",
     "source": "github"
   },
-  "version": "0.5.5",
+  "version": "0.5.6",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "proxmox-mcp-plus",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="proxmox-mcp-plus",
-    version="0.5.5",
+    version="0.5.6",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     python_requires=">=3.11",

--- a/src/proxmox_mcp/__init__.py
+++ b/src/proxmox_mcp/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .server import ProxmoxMCPServer
 
-__version__ = "0.5.5"
+__version__ = "0.5.6"
 __all__ = ["ProxmoxMCPServer"]
 
 


### PR DESCRIPTION
## Summary
- bump package, manifest, and server metadata to v0.5.6
- reorganize the README around quick-start paths, client install, tool choice, and safety
- add task-oriented wiki pages for client setup, tool selection, and documentation quality
- add docs/llms.txt and v0.5.6 release notes

## Validation
- git diff --check
- markdown relative link check
- JSON snippet parse check with ConvertFrom-Json
- referenced tool-name check against manifest.json
- pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=75
- ruff check .
- mypy src --ignore-missing-imports
- pip-audit -r requirements.txt
- pip-audit -r requirements/runtime.txt
- python -m build --outdir .codex-run\dist-0.5.6
- twine check .codex-run\dist-0.5.6\*