### PR TITLE
Release v0.5.7 architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
   <a href="https://github.com/RekklesNA/ProxmoxMCP-Plus/wiki">Wiki</a>
 </p>
 
-![ProxmoxMCP-Plus architecture and control flow](docs/assets/proxmoxmcp-drawio-hero-main-refresh.svg)
+![ProxmoxMCP-Plus architecture](docs/assets/proxmoxmcp-nature-architecture.svg)
 
 ## Why ProxmoxMCP-Plus
 

--- a/docs/assets/proxmoxmcp-nature-architecture.svg
+++ b/docs/assets/proxmoxmcp-nature-architecture.svg
@@ -1,0 +1,235 @@
+<svg width="1800" height="1200" viewBox="0 0 1800 1200" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">ProxmoxMCP-Plus architecture</title>
+  <desc id="desc">A publication-style architecture diagram showing MCP and OpenAPI clients entering the ProxmoxMCP-Plus service boundary, passing through server, proxy, tool registry, command policy, metrics, and job store components, then reaching Proxmox VE APIs, SSH-backed container execution, QEMU Guest Agent, and persistent SQLite job state.</desc>
+
+  <defs>
+    <linearGradient id="paper" x1="0" y1="0" x2="1" y2="1">
+      <stop stop-color="#FCFBF7"/>
+      <stop offset="1" stop-color="#F5F7FA"/>
+    </linearGradient>
+    <linearGradient id="clientGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop stop-color="#EAF3F5"/>
+      <stop offset="1" stop-color="#D8EAEE"/>
+    </linearGradient>
+    <linearGradient id="serviceGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop stop-color="#EEF1FA"/>
+      <stop offset="1" stop-color="#E1E7F6"/>
+    </linearGradient>
+    <linearGradient id="proxmoxGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop stop-color="#FFF0E7"/>
+      <stop offset="1" stop-color="#FCE1D4"/>
+    </linearGradient>
+    <linearGradient id="stateGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop stop-color="#F0F7EA"/>
+      <stop offset="1" stop-color="#DCEFD7"/>
+    </linearGradient>
+    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="145%">
+      <feDropShadow dx="0" dy="16" stdDeviation="18" flood-color="#17324D" flood-opacity="0.12"/>
+    </filter>
+    <filter id="lightShadow" x="-18%" y="-18%" width="136%" height="140%">
+      <feDropShadow dx="0" dy="8" stdDeviation="10" flood-color="#17324D" flood-opacity="0.10"/>
+    </filter>
+    <marker id="arrowBlue" markerWidth="16" markerHeight="16" refX="13" refY="8" orient="auto" markerUnits="userSpaceOnUse">
+      <path d="M2 2 L14 8 L2 14 Z" fill="#2D5B7C"/>
+    </marker>
+    <marker id="arrowTeal" markerWidth="16" markerHeight="16" refX="13" refY="8" orient="auto" markerUnits="userSpaceOnUse">
+      <path d="M2 2 L14 8 L2 14 Z" fill="#2D7873"/>
+    </marker>
+    <marker id="arrowOrange" markerWidth="16" markerHeight="16" refX="13" refY="8" orient="auto" markerUnits="userSpaceOnUse">
+      <path d="M2 2 L14 8 L2 14 Z" fill="#B2643C"/>
+    </marker>
+    <style>
+      .title { font: 700 44px "Segoe UI", Arial, sans-serif; fill: #17202A; letter-spacing: -0.01em; }
+      .subtitle { font: 400 22px "Segoe UI", Arial, sans-serif; fill: #4F5D6B; }
+      .panel-label { font: 700 28px "Segoe UI", Arial, sans-serif; fill: #17202A; }
+      .panel-title { font: 700 25px "Segoe UI", Arial, sans-serif; fill: #1D2833; }
+      .card-title { font: 700 20px "Segoe UI", Arial, sans-serif; fill: #1F2D3A; }
+      .body { font: 400 16px "Segoe UI", Arial, sans-serif; fill: #40505F; }
+      .small { font: 600 13px "Segoe UI", Arial, sans-serif; fill: #617180; letter-spacing: .08em; text-transform: uppercase; }
+      .mono { font: 700 15px "Consolas", "Courier New", monospace; fill: #243241; }
+      .tag { font: 700 14px "Segoe UI", Arial, sans-serif; fill: #243241; }
+      .invert { fill: #FFFFFF; }
+      .line-blue { stroke: #2D5B7C; stroke-width: 4; stroke-linecap: round; stroke-linejoin: round; marker-end: url(#arrowBlue); }
+      .line-teal { stroke: #2D7873; stroke-width: 4; stroke-linecap: round; stroke-linejoin: round; marker-end: url(#arrowTeal); }
+      .line-orange { stroke: #B2643C; stroke-width: 4; stroke-linecap: round; stroke-linejoin: round; marker-end: url(#arrowOrange); }
+      .line-faint { stroke: #9EACB9; stroke-width: 2.2; stroke-linecap: round; stroke-dasharray: 7 8; }
+      .thin { stroke-width: 2.5; }
+    </style>
+  </defs>
+
+  <rect width="1800" height="1200" rx="30" fill="url(#paper)"/>
+  <path d="M84 118 C230 64 400 58 552 104 C718 154 833 147 985 94 C1160 34 1390 53 1530 143 C1644 216 1715 329 1720 463 C1730 753 1503 1030 1182 1068 C813 1112 551 1000 336 1016 C190 1027 82 962 58 834 C32 696 115 501 94 353 C81 259 25 177 84 118 Z" fill="#FFFFFF" opacity="0.56"/>
+  <path d="M1506 126 C1587 160 1637 224 1639 307 C1641 401 1589 469 1501 491 C1414 514 1328 480 1282 412 C1238 346 1234 259 1292 194 C1346 135 1430 96 1506 126 Z" fill="#E8F0F6" opacity="0.55"/>
+  <path d="M259 942 C344 896 453 904 526 960 C592 1011 612 1091 555 1129 C494 1170 365 1149 281 1105 C202 1063 180 986 259 942 Z" fill="#EEF5EC" opacity="0.64"/>
+
+  <text x="112" y="86" class="small">Figure 1</text>
+  <text x="112" y="137" class="title">ProxmoxMCP-Plus architecture</text>
+  <text x="112" y="174" class="subtitle">A dual-surface control plane that routes LLM, MCP, and HTTP automation into guarded Proxmox VE workflows.</text>
+
+  <g transform="translate(92 230)">
+    <rect x="0" y="0" width="320" height="565" rx="28" fill="url(#clientGrad)" stroke="#9FB7C1" stroke-width="2.5" filter="url(#softShadow)"/>
+    <circle cx="37" cy="39" r="22" fill="#2D7873"/>
+    <text x="30" y="48" class="panel-label invert">A</text>
+    <text x="78" y="45" class="panel-title">Clients</text>
+    <text x="78" y="75" class="small">REQUEST SURFACES</text>
+
+    <rect x="34" y="116" width="252" height="96" rx="18" fill="#FFFFFF" stroke="#B7C9CF" stroke-width="2" filter="url(#lightShadow)"/>
+    <text x="56" y="148" class="card-title">MCP stdio</text>
+    <text x="56" y="175" class="body">Claude Desktop, Cursor,</text>
+    <text x="56" y="200" class="body">VS Code, Codex, OpenCode</text>
+
+    <rect x="34" y="232" width="252" height="82" rx="18" fill="#FFFFFF" stroke="#B7C9CF" stroke-width="2" filter="url(#lightShadow)"/>
+    <text x="56" y="264" class="card-title">MCP Streamable HTTP</text>
+    <text x="56" y="291" class="mono">/mcp</text>
+    <text x="108" y="291" class="body">remote MCP clients</text>
+
+    <rect x="34" y="334" width="252" height="102" rx="18" fill="#FFFFFF" stroke="#B7C9CF" stroke-width="2" filter="url(#lightShadow)"/>
+    <text x="56" y="366" class="card-title">HTTP automation</text>
+    <text x="56" y="393" class="mono">/docs</text>
+    <text x="119" y="393" class="body">Swagger UI</text>
+    <text x="56" y="420" class="mono">/openapi.json</text>
+
+    <rect x="34" y="462" width="252" height="56" rx="18" fill="#F7FBFC" stroke="#B7C9CF" stroke-width="2"/>
+    <text x="56" y="495" class="body">Open WebUI, dashboards, scripts</text>
+  </g>
+
+  <g transform="translate(520 190)">
+    <rect x="0" y="0" width="745" height="690" rx="32" fill="url(#serviceGrad)" stroke="#A7B5D6" stroke-width="2.5" filter="url(#softShadow)"/>
+    <circle cx="39" cy="41" r="22" fill="#435C9B"/>
+    <text x="31" y="51" class="panel-label invert">B</text>
+    <text x="82" y="47" class="panel-title">ProxmoxMCP-Plus service boundary</text>
+    <text x="82" y="78" class="small">MCP SERVER, OPENAPI PROXY, TOOLS, POLICY, JOBS</text>
+
+    <rect x="42" y="116" width="290" height="112" rx="22" fill="#FFFFFF" stroke="#B6C0DF" stroke-width="2" filter="url(#lightShadow)"/>
+    <text x="68" y="151" class="card-title">FastMCP server</text>
+    <text x="68" y="180" class="mono">stdio</text>
+    <text x="131" y="180" class="body">local process transport</text>
+    <text x="68" y="206" class="body">assistant-facing MCP tools</text>
+
+    <rect x="414" y="116" width="290" height="112" rx="22" fill="#FFFFFF" stroke="#B6C0DF" stroke-width="2" filter="url(#lightShadow)"/>
+    <text x="440" y="151" class="card-title">OpenAPI proxy</text>
+    <text x="440" y="180" class="mono">8811</text>
+    <text x="493" y="180" class="body">REST bridge and Swagger UI</text>
+    <text x="440" y="206" class="mono">/health /readyz /metrics</text>
+
+    <rect x="42" y="279" width="662" height="145" rx="24" fill="#FFFFFF" stroke="#B6C0DF" stroke-width="2" filter="url(#lightShadow)"/>
+    <text x="68" y="314" class="card-title">Tool registry and domain tool plugins</text>
+    <text x="68" y="343" class="body">Built-in plugins register the project tool surface onto the MCP server.</text>
+
+    <g transform="translate(68 367)">
+      <rect x="0" y="0" width="88" height="34" rx="17" fill="#EEF3FF" stroke="#B6C0DF"/>
+      <text x="44" y="23" class="tag" text-anchor="middle">Node</text>
+      <rect x="100" y="0" width="74" height="34" rx="17" fill="#EEF3FF" stroke="#B6C0DF"/>
+      <text x="137" y="23" class="tag" text-anchor="middle">VM</text>
+      <rect x="186" y="0" width="118" height="34" rx="17" fill="#EEF3FF" stroke="#B6C0DF"/>
+      <text x="245" y="23" class="tag" text-anchor="middle">Container</text>
+      <rect x="316" y="0" width="112" height="34" rx="17" fill="#EEF3FF" stroke="#B6C0DF"/>
+      <text x="372" y="23" class="tag" text-anchor="middle">Snapshot</text>
+      <rect x="440" y="0" width="78" height="34" rx="17" fill="#EEF3FF" stroke="#B6C0DF"/>
+      <text x="479" y="23" class="tag" text-anchor="middle">ISO</text>
+      <rect x="530" y="0" width="92" height="34" rx="17" fill="#EEF3FF" stroke="#B6C0DF"/>
+      <text x="576" y="23" class="tag" text-anchor="middle">Backup</text>
+    </g>
+
+    <rect x="42" y="480" width="205" height="112" rx="22" fill="#FFFFFF" stroke="#B6C0DF" stroke-width="2" filter="url(#lightShadow)"/>
+    <text x="66" y="514" class="card-title">Config loader</text>
+    <text x="66" y="543" class="body">JSON config + env vars</text>
+    <text x="66" y="569" class="mono">PROXMOX_MCP_CONFIG</text>
+
+    <rect x="270" y="480" width="205" height="112" rx="22" fill="#FFFFFF" stroke="#B6C0DF" stroke-width="2" filter="url(#lightShadow)"/>
+    <text x="294" y="514" class="card-title">Command policy</text>
+    <text x="294" y="543" class="body">deny rules + approval</text>
+    <text x="294" y="569" class="body">high-risk operation gates</text>
+
+    <rect x="498" y="480" width="206" height="112" rx="22" fill="#FFFFFF" stroke="#B6C0DF" stroke-width="2" filter="url(#lightShadow)"/>
+    <text x="522" y="514" class="card-title">Observability</text>
+    <text x="522" y="543" class="body">logs, redaction, metrics</text>
+    <text x="522" y="569" class="mono">/metrics</text>
+
+    <rect x="42" y="625" width="662" height="38" rx="19" fill="#F8FAFF" stroke="#B6C0DF"/>
+    <text x="68" y="649" class="body">Long-running Proxmox tasks return a raw UPID plus a stable ProxmoxMCP-Plus job_id.</text>
+  </g>
+
+  <g transform="translate(1370 230)">
+    <rect x="0" y="0" width="338" height="565" rx="28" fill="url(#proxmoxGrad)" stroke="#E2A384" stroke-width="2.5" filter="url(#softShadow)"/>
+    <circle cx="39" cy="39" r="22" fill="#C45A2A"/>
+    <text x="31" y="49" class="panel-label invert">C</text>
+    <text x="82" y="45" class="panel-title">Proxmox VE</text>
+    <text x="82" y="75" class="small">VIRTUALIZATION CONTROL SURFACES</text>
+
+    <rect x="36" y="116" width="266" height="98" rx="18" fill="#FFFFFF" stroke="#E6B298" stroke-width="2" filter="url(#lightShadow)"/>
+    <text x="60" y="148" class="card-title">PVE REST API</text>
+    <text x="60" y="176" class="body">cluster, node, VM, LXC,</text>
+    <text x="60" y="201" class="body">storage, backup, ISO operations</text>
+
+    <rect x="36" y="242" width="266" height="82" rx="18" fill="#FFFFFF" stroke="#E6B298" stroke-width="2" filter="url(#lightShadow)"/>
+    <text x="60" y="274" class="card-title">QEMU Guest Agent</text>
+    <text x="60" y="302" class="body">VM command execution path</text>
+
+    <rect x="36" y="352" width="266" height="82" rx="18" fill="#FFFFFF" stroke="#E6B298" stroke-width="2" filter="url(#lightShadow)"/>
+    <text x="60" y="384" class="card-title">SSH to Proxmox nodes</text>
+    <text x="60" y="412" class="body">optional pct exec path for LXCs</text>
+
+    <rect x="36" y="462" width="266" height="72" rx="18" fill="#FFF8F4" stroke="#E6B298" stroke-width="2"/>
+    <text x="60" y="494" class="body">VMs, LXCs, snapshots,</text>
+    <text x="60" y="519" class="body">backups, storage and templates</text>
+  </g>
+
+  <g transform="translate(520 950)">
+    <rect x="0" y="0" width="745" height="108" rx="28" fill="url(#stateGrad)" stroke="#9FBE99" stroke-width="2.5" filter="url(#softShadow)"/>
+    <circle cx="39" cy="39" r="22" fill="#5C8F56"/>
+    <text x="30" y="49" class="panel-label invert">D</text>
+    <text x="82" y="45" class="panel-title">Persistent job and audit state</text>
+    <text x="82" y="70" class="body">SQLite-backed JobStore preserves progress, retries,</text>
+    <text x="82" y="94" class="body">results, and audit history across restarts.</text>
+    <rect x="586" y="26" width="112" height="58" rx="18" fill="#FFFFFF" stroke="#9FBE99" stroke-width="2"/>
+    <text x="642" y="50" class="mono" text-anchor="middle">job_id</text>
+    <text x="642" y="74" class="body" text-anchor="middle">stable handle</text>
+  </g>
+
+  <path d="M413 390 C455 390 467 390 511 390" class="line-teal"/>
+  <path d="M413 562 C455 562 467 562 511 562" class="line-teal"/>
+  <path d="M1265 418 C1305 418 1319 418 1358 418" class="line-orange"/>
+  <path d="M1265 551 C1305 551 1319 551 1358 551" class="line-orange"/>
+  <path d="M892 418 C968 418 1007 418 1048 418" class="line-blue thin"/>
+  <path d="M373 545 C373 790 601 833 737 911" class="line-faint"/>
+  <path d="M893 854 C893 892 893 912 893 940" class="line-blue"/>
+  <path d="M1172 590 C1204 716 1320 738 1376 672" class="line-faint"/>
+
+  <g transform="translate(94 858)">
+    <rect x="0" y="0" width="1614" height="64" rx="32" fill="#FFFFFF" stroke="#D3DCE5" stroke-width="2"/>
+    <circle cx="40" cy="32" r="16" fill="#2D7873"/>
+    <text x="40" y="38" class="tag invert" text-anchor="middle">1</text>
+    <text x="70" y="38" class="body">Client intent</text>
+    <path d="M208 32 L312 32" class="line-teal thin"/>
+
+    <circle cx="354" cy="32" r="16" fill="#435C9B"/>
+    <text x="354" y="38" class="tag invert" text-anchor="middle">2</text>
+    <text x="384" y="38" class="body">Registered tool routing</text>
+    <path d="M592 32 L732 32" class="line-blue thin"/>
+
+    <circle cx="774" cy="32" r="16" fill="#435C9B"/>
+    <text x="774" y="38" class="tag invert" text-anchor="middle">3</text>
+    <text x="804" y="38" class="body">Policy and observability</text>
+    <path d="M1048 32 L1272 32" class="line-orange thin"/>
+
+    <circle cx="1314" cy="32" r="16" fill="#C45A2A"/>
+    <text x="1314" y="38" class="tag invert" text-anchor="middle">4</text>
+    <text x="1344" y="38" class="body">Result, UPID, and job_id</text>
+  </g>
+
+  <g transform="translate(114 1102)">
+    <rect x="0" y="0" width="374" height="42" rx="21" fill="#FFFFFF" stroke="#D3DCE5"/>
+    <circle cx="25" cy="21" r="8" fill="#2D7873"/>
+    <text x="44" y="27" class="body">MCP and HTTP client request flow</text>
+    <rect x="420" y="0" width="314" height="42" rx="21" fill="#FFFFFF" stroke="#D3DCE5"/>
+    <circle cx="445" cy="21" r="8" fill="#435C9B"/>
+    <text x="464" y="27" class="body">Internal service routing</text>
+    <rect x="778" y="0" width="310" height="42" rx="21" fill="#FFFFFF" stroke="#D3DCE5"/>
+    <circle cx="803" cy="21" r="8" fill="#C45A2A"/>
+    <text x="822" y="27" class="body">Proxmox VE execution paths</text>
+    <rect x="1132" y="0" width="400" height="42" rx="21" fill="#FFFFFF" stroke="#D3DCE5"/>
+    <line x1="1155" y1="21" x2="1195" y2="21" class="line-faint"/>
+    <text x="1212" y="27" class="body">Persistent state and audit feedback</text>
+  </g>
+</svg>

--- a/docs/releases/v0.5.7.md
+++ b/docs/releases/v0.5.7.md
@@ -1,0 +1,26 @@
+# ProxmoxMCP-Plus v0.5.7
+
+Release date: 2026-05-30
+
+## Visual Documentation Improvements
+
+- Replaced the README hero architecture diagram with a new publication-style SVG.
+- The new diagram is grounded in the actual project architecture:
+  - MCP stdio clients
+  - MCP Streamable HTTP at `/mcp`
+  - OpenAPI automation through `/docs`, `/openapi.json`, `/health`, `/readyz`, and `/metrics`
+  - FastMCP server boundary
+  - OpenAPI proxy
+  - built-in tool registry and domain tool plugins
+  - command policy, config loading, observability, and persistent jobs
+  - Proxmox VE REST API, QEMU Guest Agent, SSH-backed `pct exec`, and SQLite-backed job state
+
+## Runtime Impact
+
+- No runtime tools, endpoints, package dependencies, or configuration requirements changed in this release.
+- No migration is required from `v0.5.6`.
+
+## Upgrade Notes
+
+- Upgrade normally from PyPI, Docker/GHCR, or source.
+- If a downstream documentation renderer cannot display the new SVG, continue using `v0.5.6` or pin the previous README asset in that renderer.

--- a/docs/wiki/Release & Upgrade Notes.md
+++ b/docs/wiki/Release & Upgrade Notes.md
@@ -18,6 +18,28 @@ Use this page to track version-level behavior changes, upgrade steps, and rollba
 
 ## Release History
 
+### Version `0.5.7`
+
+- Release date: 2026-05-30
+- Summary: visual documentation release that replaces the README hero architecture diagram with a publication-style SVG grounded in the actual ProxmoxMCP-Plus runtime architecture.
+- New tools or endpoints:
+  - no new runtime tools or endpoints
+- Changed behavior:
+  - no runtime behavior changes
+- Removed or deprecated behavior:
+  - no removals or deprecations
+- Config changes:
+  - no required config migration
+- Docs updated:
+  - `README.md`
+  - `docs/assets/proxmoxmcp-nature-architecture.svg`
+  - `docs/releases/v0.5.7.md`
+  - `docs/wiki/Release & Upgrade Notes.md`
+- Upgrade steps:
+  - no required migration
+- Rollback notes:
+  - downgrade to `v0.5.6` only if a downstream documentation renderer cannot display the new SVG asset
+
 ### Version `0.5.6`
 
 - Release date: 2026-05-30

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": "0.4",
     "name": "proxmox-mcp-plus",
     "display_name": "ProxmoxMCP-Plus",
-    "version": "0.5.6",
+    "version": "0.5.7",
     "description": "An enhanced MCP server for managing Proxmox virtualization platforms.",
     "long_description": "ProxmoxMCP-Plus is an enhanced Model Context Protocol (MCP) server that provides comprehensive tools for managing Proxmox virtualization environments, including VM lifecycle, container management, snapshot operations, and backup/restore capabilities.",
     "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "proxmox-mcp-plus"
-version = "0.5.6"
+version = "0.5.7"
 description = "Enhanced Proxmox MCP Server"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -18,13 +18,13 @@
     "url": "https://github.com/RekklesNA/ProxmoxMCP-Plus",
     "source": "github"
   },
-  "version": "0.5.6",
+  "version": "0.5.7",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "proxmox-mcp-plus",
-      "version": "0.5.6",
+      "version": "0.5.7",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="proxmox-mcp-plus",
-    version="0.5.6",
+    version="0.5.7",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     python_requires=">=3.11",

--- a/src/proxmox_mcp/__init__.py
+++ b/src/proxmox_mcp/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .server import ProxmoxMCPServer
 
-__version__ = "0.5.6"
+__version__ = "0.5.7"
 __all__ = ["ProxmoxMCPServer"]
 
 


### PR DESCRIPTION
## Summary
- replace the README hero architecture diagram with a publication-style SVG based on the actual ProxmoxMCP-Plus runtime architecture
- bump package, manifest, and server metadata to v0.5.7
- add v0.5.7 release notes

## Validation
- git diff --check
- markdown relative link check
- architecture SVG existence check
- pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=75
- ruff check .
- mypy src --ignore-missing-imports
- pip-audit -r requirements.txt
- pip-audit -r requirements/runtime.txt
- python -m build --outdir .codex-run\dist-0.5.7
- twine check .codex-run\dist-0.5.7\*

Note: pip-audit reported local cache write warnings on Windows, but completed successfully with no known vulnerabilities.