### PR TITLE
Harden SSH host key verification for pct exec container command execution

### DIFF
--- a/docs/container-command-execution.md
+++ b/docs/container-command-execution.md
@@ -89,10 +89,21 @@ which is the same surface that already exists if an attacker compromises a conta
 
 ### SSH host key checking
 
-The implementation uses `paramiko.AutoAddPolicy`, which accepts host keys on first connect
-(trust-on-first-use). This is appropriate for use within a private cluster network. If your
-security requirements demand strict host key pinning, you can pre-populate `~/.ssh/known_hosts`
-on the MCP VM for each Proxmox node before starting the server.
+The implementation loads host keys from the MCP VM's `~/.ssh/known_hosts` (via
+`paramiko.SSHClient.load_system_host_keys`) and rejects any host whose key isn't already known
+(`paramiko.RejectPolicy`) — unknown or mismatched host keys fail loudly instead of being trusted
+silently. Before first use, connect once via a normal `ssh` client to each Proxmox node (or its
+`host_overrides` address) from the MCP VM, verify the fingerprint, and accept it so it's recorded
+in `known_hosts`:
+
+```bash
+ssh mcp-agent@pve1 "echo host key recorded"
+```
+
+If you keep host keys in a different file, point to it with `known_hosts_file` in the `ssh`
+config section. If a node's host key changes (e.g. after a legitimate reinstall), the connection
+will fail with a clear error — verify the new fingerprint out-of-band, run
+`ssh-keygen -R <host>`, and reconnect once via `ssh` to re-pin it.
 
 ### Key management
 
@@ -244,6 +255,11 @@ the sudoers rule on that node.
 - `key_file` is the path to the **private** key on the MCP VM (no `.pub` extension).
 - `use_sudo: true` tells the MCP server to prefix the `pct exec` call with `sudo`, required
   because `mcp-agent` is not root.
+
+The manual SSH test in Step 6 also serves a second purpose: it records each node's host key in
+`~/.ssh/known_hosts` on the MCP VM, which the server requires (see
+[SSH host key checking](#ssh-host-key-checking) above). If you keep known hosts in a non-default
+file, set `known_hosts_file` in this section to point to it.
 
 **Optional — if Proxmox node names don't resolve via DNS from the MCP VM**, add `host_overrides`
 to map node names to IPs directly:

--- a/src/proxmox_mcp/config/models.py
+++ b/src/proxmox_mcp/config/models.py
@@ -79,6 +79,7 @@ class SSHConfig(BaseModel):
     password: Optional[str] = None   # fallback if no key_file
     host_overrides: Dict[str, str] = Field(default_factory=dict)
     use_sudo: bool = False  # prefix pct with sudo (for non-root SSH users)
+    known_hosts_file: Optional[str] = None  # path to known_hosts; defaults to ~/.ssh/known_hosts
 
 class MCPConfig(BaseModel):
     """Model for MCP server configuration.

--- a/src/proxmox_mcp/tools/console/container_manager.py
+++ b/src/proxmox_mcp/tools/console/container_manager.py
@@ -52,11 +52,16 @@ class ContainerConsoleManager:
         self.logger.info("Executing on CT %s@%s: %s", vmid, node, command)
 
         # 3. SSH to node and run command
+        ssh_host = self._ssh_host(node)
         client = paramiko.SSHClient()
-        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        client.load_system_host_keys()
+        known_hosts_file = getattr(self.ssh_cfg, "known_hosts_file", None)
+        if known_hosts_file:
+            client.load_host_keys(os.path.expanduser(known_hosts_file))
+        client.set_missing_host_key_policy(paramiko.RejectPolicy())
 
         connect_kwargs: Dict[str, Any] = dict(
-            hostname=self._ssh_host(node),
+            hostname=ssh_host,
             port=self.ssh_cfg.port,
             username=self.ssh_cfg.user,
             timeout=10,
@@ -78,8 +83,23 @@ class ContainerConsoleManager:
                 "error": err,
                 "exit_code": exit_code,
             }
+        except paramiko.BadHostKeyException as e:
+            self.logger.error("SSH host key MISMATCH for %s (%s): %s", node, ssh_host, e)
+            raise RuntimeError(
+                f"SSH host key verification failed for node {node} ({ssh_host}): the key "
+                f"presented by the server does not match the one recorded in known_hosts. "
+                f"This could mean the host key was legitimately rotated, or it could indicate "
+                f"a man-in-the-middle attack. Verify the new fingerprint out-of-band, then run "
+                f"`ssh-keygen -R {ssh_host}` and reconnect once via a normal `ssh` client to "
+                f"record the new key before retrying."
+            ) from e
         except paramiko.SSHException as e:
-            self.logger.error("SSH error connecting to %s: %s", node, e)
-            raise RuntimeError(f"SSH error connecting to node {node}: {e}") from e
+            self.logger.error("SSH error connecting to %s (%s): %s", node, ssh_host, e)
+            raise RuntimeError(
+                f"SSH error connecting to node {node} ({ssh_host}): {e}. If this is an "
+                f"unrecognized-host-key error, connect once via a normal `ssh` client to "
+                f"{ssh_host} to verify and record its host key in ~/.ssh/known_hosts "
+                f"(or the file configured via ssh.known_hosts_file), then retry."
+            ) from e
         finally:
             client.close()

--- a/tests/test_container_console.py
+++ b/tests/test_container_console.py
@@ -2,6 +2,8 @@
 Tests for LXC container console operations via SSH + pct exec.
 """
 
+import os
+
 import pytest
 from unittest.mock import MagicMock, patch, PropertyMock
 
@@ -20,6 +22,7 @@ class _SSHConfig:
     password = None
     host_overrides: dict = {}
     use_sudo = False
+    known_hosts_file = None
 
 
 @pytest.fixture
@@ -116,6 +119,65 @@ def test_execute_command_ssh_failure(MockSSHClient, manager):
 
     with pytest.raises(RuntimeError, match="SSH error"):
         manager.execute_command("pve1", "101", "uname -a")
+
+
+@patch("proxmox_mcp.tools.console.container_manager.paramiko.SSHClient")
+def test_unknown_host_key_is_rejected_not_trusted(MockSSHClient, manager):
+    """Unknown-host-key failures (RejectPolicy) surface a clear, actionable error."""
+    import paramiko
+    mock_client = MagicMock()
+    mock_client.connect.side_effect = paramiko.SSHException(
+        "Server 'pve1' not found in known_hosts"
+    )
+    MockSSHClient.return_value = mock_client
+
+    with pytest.raises(RuntimeError, match="known_hosts"):
+        manager.execute_command("pve1", "101", "uname -a")
+
+
+@patch("proxmox_mcp.tools.console.container_manager.paramiko.SSHClient")
+def test_host_key_mismatch_raises_clear_error(MockSSHClient, manager):
+    """A changed/spoofed host key (BadHostKeyException) fails loudly with guidance."""
+    import paramiko
+    mock_client = MagicMock()
+    bad_key = MagicMock()
+    mock_client.connect.side_effect = paramiko.BadHostKeyException(
+        "pve1", bad_key, bad_key
+    )
+    MockSSHClient.return_value = mock_client
+
+    with pytest.raises(RuntimeError, match="host key verification failed"):
+        manager.execute_command("pve1", "101", "uname -a")
+
+
+@patch("proxmox_mcp.tools.console.container_manager.paramiko.SSHClient")
+def test_uses_reject_policy_and_system_host_keys(MockSSHClient, manager):
+    """Host keys must come from known_hosts and unknown hosts must be rejected,
+    never silently auto-trusted."""
+    import paramiko
+    mock_client = _make_ssh_client(stdout_data=b"ok\n", exit_code=0)
+    MockSSHClient.return_value = mock_client
+
+    manager.execute_command("pve1", "101", "echo ok")
+
+    assert mock_client.load_system_host_keys.called
+    policy_arg = mock_client.set_missing_host_key_policy.call_args[0][0]
+    assert isinstance(policy_arg, paramiko.RejectPolicy)
+    assert not mock_client.load_host_keys.called
+
+
+@patch("proxmox_mcp.tools.console.container_manager.paramiko.SSHClient")
+def test_custom_known_hosts_file_is_loaded(MockSSHClient, manager, ssh_cfg):
+    """A configured known_hosts_file is loaded in addition to the system default."""
+    ssh_cfg.known_hosts_file = "~/.ssh/proxmox_known_hosts"
+    mock_client = _make_ssh_client(stdout_data=b"ok\n", exit_code=0)
+    MockSSHClient.return_value = mock_client
+
+    manager.execute_command("pve1", "101", "echo ok")
+
+    mock_client.load_host_keys.assert_called_once_with(
+        os.path.expanduser("~/.ssh/proxmox_known_hosts")
+    )
 
 
 @patch("proxmox_mcp.tools.console.container_manager.paramiko.SSHClient")


### PR DESCRIPTION
## Summary
- `ContainerConsoleManager.execute_command` used `paramiko.AutoAddPolicy`, which silently trusts and stores any unknown SSH host key on first connect — a real MITM exposure for this SSH path (root-equivalent `pct exec` access to LXC containers).
- Switched to `client.load_system_host_keys()` (reads `~/.ssh/known_hosts`) plus an optional configurable `ssh.known_hosts_file`, combined with `paramiko.RejectPolicy()` so unknown hosts are rejected instead of auto-trusted.
- Added clear, actionable `RuntimeError` messages that distinguish an unrecognized host (`SSHException` from `RejectPolicy`) from a changed/mismatched host key (`BadHostKeyException`, possible MITM or legitimate key rotation), each with concrete next steps.
- Updated `docs/container-command-execution.md` to explain the new behavior and note that the existing manual SSH smoke test in setup Step 6 doubles as the step that populates `known_hosts`.

## Test plan
- [x] `pytest tests/test_container_console.py` — 11 tests pass, including 4 new tests covering: `RejectPolicy`/`load_system_host_keys` usage, loading a custom `known_hosts_file`, unknown-host-key rejection error message, and host-key-mismatch (`BadHostKeyException`) error message.
- [x] Full `pytest tests/` suite (45 tests) passes.