### PR TITLE
Release v0.5.9: resource pool-scoped guest creation

### DIFF
--- a/docs/releases/v0.5.9.md
+++ b/docs/releases/v0.5.9.md
@@ -1,0 +1,41 @@
+# ProxmoxMCP-Plus v0.5.9
+
+Release date: 2026-07-16
+
+## Resource-Pool-Scoped VM and LXC Creation (Issue #104)
+
+This release adds an optional `pool` argument to the existing `create_vm` and `create_container` MCP tools. The value is passed directly to the native Proxmox QEMU or LXC creation endpoint so operators can create new guests inside a dedicated Proxmox resource pool.
+
+This enables a privilege-separated API token to use a resource pool as the security boundary for AI-driven provisioning. For example, an operator can grant VM allocation and configuration privileges on `/pool/claude-lab` without granting global allocation privileges across production guests.
+
+`pool` means a Proxmox resource pool. It is separate from the `storage` argument used for VM disks and LXC root filesystems.
+
+## Backward Compatibility
+
+- `pool` is optional on both tools.
+- When `pool` is omitted or empty, the Proxmox request payload is unchanged from v0.5.8.
+- Existing positional and keyword callers remain compatible because the new argument is appended to each public Python method signature.
+- No runtime configuration migration is required.
+
+## Permissions
+
+The configured Proxmox API token must have the VM permissions required for creation and `Pool.Allocate` on the target resource pool. Permission assignment remains an operator responsibility; ProxmoxMCP-Plus does not broaden token privileges or fall back to global allocation.
+
+## Test Client Dependency
+
+Development and test installs now include `httpx2>=2.0.0,<3.0.0`, which is the supported client backend for current Starlette `TestClient`. This removes the deprecated fallback to the legacy `httpx` backend without changing runtime dependencies.
+
+The development test stack also moves to `pytest>=9.0.3,<10.0.0` and `pytest-asyncio>=1.4.0,<2.0.0`. This excludes pytest versions affected by `PYSEC-2026-1845` instead of suppressing the dependency-audit result.
+
+## Validation
+
+- Added MCP-level regression tests proving `pool` reaches both native Proxmox create requests.
+- Added compatibility assertions proving omitted `pool` values do not alter existing request payloads.
+- Treating `StarletteDeprecationWarning` as an error passes for the complete OpenAPI proxy test module.
+- The full release quality gate covers tests with coverage enforcement, Ruff, Mypy, dependency audit, package build, metadata validation, and distribution checks.
+
+## Upgrade Notes
+
+- Upgrade normally from PyPI, Docker/GHCR, or source.
+- Existing calls require no changes.
+- To opt in, pass `pool="claude-lab"` (or another Proxmox resource-pool name) to `create_vm` or `create_container`.

--- a/docs/wiki/API & Tool Reference.md
+++ b/docs/wiki/API & Tool Reference.md
@@ -101,7 +101,7 @@ Selector-based tools fail when no container matches the selector or when a bulk 
 | Tool | Mode | Required Inputs | Optional Inputs | Prerequisites | Common Failures |
 | --- | --- | --- | --- | --- | --- |
 | `get_vms` | Read-only | none | none | Proxmox API reachable | partial node-query failures may reduce returned coverage |
-| `create_vm` | Mutating | `node`, `vmid`, `name`, `cpus`, `memory`, `disk_size` | `storage`, `ostype`, `network_bridge` | target node exists and selected storage is valid | duplicate `vmid`, invalid storage, insufficient resources |
+| `create_vm` | Mutating | `node`, `vmid`, `name`, `cpus`, `memory`, `disk_size` | `storage`, `ostype`, `network_bridge`, `pool` | target node exists and selected storage is valid | duplicate `vmid`, invalid storage or resource pool, insufficient permissions or resources |
 | `clone_vm` | Mutating | `node`, `source_vmid`, `target_vmid` | `name`, `target_node`, `full=true`, `storage`, `pool`, `snapname` | source VM exists and target VM ID is free | duplicate target VM ID, clone permission failure, invalid storage or snapshot |
 | `start_vm` | Mutating | `node`, `vmid` | none | VM exists | VM not found, node mismatch |
 | `stop_vm` | Mutating | `node`, `vmid` | none | VM exists | VM not found, stop failure from Proxmox |
@@ -115,6 +115,7 @@ Selector-based tools fail when no container matches the selector or when a bulk 
 
 - `stop_vm` is the force-stop path. Use `shutdown_vm` for graceful guest shutdown when supported.
 - `execute_vm_command` is not a generic SSH shell. It is mediated through QEMU Guest Agent and command-policy checks.
+- `create_vm.pool` is an optional Proxmox resource pool, not a storage pool. Pool-scoped API tokens also need `Pool.Allocate` on the target pool.
 - `create_vm`, `clone_vm`, `start_vm`, `stop_vm`, `shutdown_vm`, `reset_vm`, and `delete_vm` register persistent jobs when they return asynchronous Proxmox tasks.
 
 ## Container Tools
@@ -126,7 +127,7 @@ Selector-based tools fail when no container matches the selector or when a bulk 
 | `stop_container` | Mutating | `selector` | `graceful=true`, `timeout_seconds=10`, `format_style=pretty\|json` | selector resolves to one or more containers | no selector match, timeout on graceful shutdown, container already stopped |
 | `restart_container` | Mutating | `selector` | `timeout_seconds=10`, `format_style=pretty\|json` | selector resolves to one or more containers | no selector match, reboot failure |
 | `update_container_resources` | Mutating | `selector` | `cores`, `memory`, `swap`, `disk_gb`, `disk=rootfs`, `format_style=pretty\|json` | selector resolves to one or more containers | no selector match, invalid resize target, resource update rejected |
-| `create_container` | Mutating | `node`, `vmid`, `ostemplate` | `hostname`, `cores=1`, `memory=512`, `swap=512`, `disk_size=8`, `storage`, `password`, `ssh_public_keys`, `network_bridge=vmbr0`, `start_after_create=false`, `onboot=false`, `nesting=false`, `unprivileged=true` | target node exists, template path valid, target storage valid | duplicate `vmid`, missing template, invalid storage or bridge |
+| `create_container` | Mutating | `node`, `vmid`, `ostemplate` | `hostname`, `cores=1`, `memory=512`, `swap=512`, `disk_size=8`, `storage`, `password`, `ssh_public_keys`, `network_bridge=vmbr0`, `start_after_create=false`, `onboot=false`, `nesting=false`, `unprivileged=true`, `pool` | target node exists, template path valid, target storage valid | duplicate `vmid`, missing template, invalid storage, resource pool, or bridge |
 | `delete_container` | Mutating | `selector` | `force=false`, `format_style=pretty\|json` | selector resolves to one or more containers | no selector match, running container without `force`, delete failure |
 | `execute_container_command` | Mutating | `selector`, `command` | `approval_token` | only registered when `ssh` config exists; container must be running; policy must allow command | tool unavailable without SSH config, no selector match, SSH failure, policy denial |
 | `update_container_ssh_keys` | Mutating/high-risk | `node`, `vmid`, `public_keys` | `mode=append\|replace`, `approval_token` | only registered when `ssh` config exists; target container reachable through configured execution path; high-risk policy must allow the operation | tool unavailable without SSH config, invalid container target, SSH failure, approval required |
@@ -139,6 +140,7 @@ Selector-based tools fail when no container matches the selector or when a bulk 
 - `update_container_resources.disk_gb` is an additional resize amount for the selected disk, not a full replacement size target.
 - `create_container.start_after_create` controls immediate startup after provisioning.
 - `create_container.nesting` and `create_container.unprivileged` change container execution characteristics and should match your Proxmox policy.
+- `create_container.pool` is an optional Proxmox resource pool, not the `storage` used for `rootfs`. Pool-scoped API tokens also need `Pool.Allocate` on the target pool.
 - `create_container`, `start_container`, `stop_container`, `restart_container`, and `delete_container` create persistent job records for asynchronous task tracking.
 
 ## Snapshot Tools

--- a/docs/wiki/Release & Upgrade Notes.md
+++ b/docs/wiki/Release & Upgrade Notes.md
@@ -18,6 +18,34 @@ Use this page to track version-level behavior changes, upgrade steps, and rollba
 
 ## Release History
 
+### Version `0.5.9`
+
+- Release date: 2026-07-16
+- Summary: adds optional Proxmox resource-pool targeting to VM and LXC creation, enabling pool-scoped API-token security boundaries (closes issue #104).
+- New tools or endpoints:
+  - no new runtime tools or endpoints
+- Changed behavior:
+  - `create_vm` accepts an optional `pool` argument and forwards it to `POST /nodes/{node}/qemu`
+  - `create_container` accepts an optional `pool` argument and forwards it to `POST /nodes/{node}/lxc`
+  - omitting `pool` preserves the previous request payload and behavior
+  - tests use Starlette's supported `httpx2` client path, eliminating the deprecated `httpx` fallback warning
+  - the development test stack now requires `pytest>=9.0.3` and `pytest-asyncio>=1.4.0`, removing the vulnerable pytest versions reported as `PYSEC-2026-1845`
+- Removed or deprecated behavior:
+  - no removals or deprecations
+- Config changes:
+  - no required runtime config migration
+  - development/test installs now include `httpx2>=2.0.0,<3.0.0`, `pytest>=9.0.3,<10.0.0`, and `pytest-asyncio>=1.4.0,<2.0.0`
+- Docs updated:
+  - `docs/releases/v0.5.9.md`
+  - `docs/wiki/API & Tool Reference.md`
+  - `docs/wiki/Release & Upgrade Notes.md`
+- Upgrade steps:
+  - no required migration
+  - pass `pool=<resource-pool-name>` only when VM/LXC creation should be scoped to a Proxmox resource pool
+  - grant `Pool.Allocate` on the target pool in addition to the required VM permissions
+- Rollback notes:
+  - downgrade to `v0.5.8` only if a client cannot accept the two new optional schema fields; omitting them is already backward compatible
+
 ### Version `0.5.8`
 
 - Release date: 2026-06-07

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": "0.4",
     "name": "proxmox-mcp-plus",
     "display_name": "ProxmoxMCP-Plus",
-    "version": "0.5.8",
+    "version": "0.5.9",
     "description": "An enhanced MCP server for managing Proxmox virtualization platforms.",
     "long_description": "ProxmoxMCP-Plus is an enhanced Model Context Protocol (MCP) server that provides comprehensive tools for managing Proxmox virtualization environments, including VM lifecycle, container management, snapshot operations, and backup/restore capabilities.",
     "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "proxmox-mcp-plus"
-version = "0.5.8"
+version = "0.5.9"
 description = "Enhanced Proxmox MCP Server"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -33,9 +33,10 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=7.0.0,<8.0.0",
-    "pytest-asyncio>=0.21.0,<0.22.0",
+    "pytest>=9.0.3,<10.0.0",
+    "pytest-asyncio>=1.4.0,<2.0.0",
     "pytest-cov>=4.1.0,<7.0.0",
+    "httpx2>=2.0.0,<3.0.0",
     "black>=24.3.0,<27.0.0",
     "mypy>=1.0.0,<2.0.0",
     "ruff>=0.1.0,<0.2.0",

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -2,9 +2,10 @@
 -r base.in
 
 # Testing
-pytest>=7.0.0,<8.0.0
-pytest-asyncio>=0.21.0,<0.22.0
+pytest>=9.0.3,<10.0.0
+pytest-asyncio>=1.4.0,<2.0.0
 pytest-cov>=4.1.0,<7.0.0
+httpx2>=2.0.0,<3.0.0
 
 # Code quality
 black>=24.3.0,<27.0.0

--- a/server.json
+++ b/server.json
@@ -18,13 +18,13 @@
     "url": "https://github.com/RekklesNA/ProxmoxMCP-Plus",
     "source": "github"
   },
-  "version": "0.5.8",
+  "version": "0.5.9",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "proxmox-mcp-plus",
-      "version": "0.5.8",
+      "version": "0.5.9",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="proxmox-mcp-plus",
-    version="0.5.8",
+    version="0.5.9",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     python_requires=">=3.11",
@@ -28,11 +28,12 @@ setup(
     ],
     extras_require={
         "dev": [
-            "pytest>=7.0.0,<8.0.0",
+            "pytest>=9.0.3,<10.0.0",
             "pytest-cov>=4.1.0,<7.0.0",
+            "httpx2>=2.0.0,<3.0.0",
             "black>=24.3.0,<27.0.0",
             "mypy>=1.0.0,<2.0.0",
-            "pytest-asyncio>=0.21.0,<0.22.0",
+            "pytest-asyncio>=1.4.0,<2.0.0",
             "ruff>=0.1.0,<0.2.0",
             "build>=1.2.0,<2.0.0",
             "types-paramiko>=4.0.0.20260508,<5.0.0",

--- a/src/proxmox_mcp/__init__.py
+++ b/src/proxmox_mcp/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .server import ProxmoxMCPServer
 
-__version__ = "0.5.8"
+__version__ = "0.5.9"
 __all__ = ["ProxmoxMCPServer"]
 
 

--- a/src/proxmox_mcp/services/builtin_tool_plugins.py
+++ b/src/proxmox_mcp/services/builtin_tool_plugins.py
@@ -268,6 +268,7 @@ class VMToolsPlugin(RegistryPluginBase):
             storage: Annotated[Optional[str], Field(description="Storage name (optional, will auto-detect)", default=None)] = None,
             ostype: Annotated[Optional[str], Field(description="OS type (optional, default: 'l26' for Linux)", default=None)] = None,
             network_bridge: Annotated[Optional[str], Field(description="Network bridge name (optional, default: 'vmbr0')", default=None)] = None,
+            pool: Annotated[Optional[str], Field(description="Target Proxmox resource pool (optional)", default=None)] = None,
         ) -> Any:
             return self._wrap_sync(server, "create_vm", server.vm_tools.create_vm)(
                 node,
@@ -279,6 +280,7 @@ class VMToolsPlugin(RegistryPluginBase):
                 storage,
                 ostype,
                 network_bridge,
+                pool,
             )
 
         @server.mcp.tool(description=CLONE_VM_DESC)
@@ -464,6 +466,7 @@ class ContainerToolsPlugin(RegistryPluginBase):
             onboot: Annotated[bool, Field(description="Start container automatically when node boots", default=False)] = False,
             nesting: Annotated[bool, Field(description="Enable LXC nesting (features: nesting=1)", default=False)] = False,
             unprivileged: Annotated[bool, Field(description="Create unprivileged container", default=True)] = True,
+            pool: Annotated[Optional[str], Field(description="Target Proxmox resource pool (optional)", default=None)] = None,
         ) -> Any:
             return self._wrap_sync(server, "create_container", server.container_tools.create_container)(
                 node=node,
@@ -482,6 +485,7 @@ class ContainerToolsPlugin(RegistryPluginBase):
                 onboot=onboot,
                 nesting=nesting,
                 unprivileged=unprivileged,
+                pool=pool,
             )
 
         @server.mcp.tool(description=DELETE_CONTAINER_DESC)

--- a/src/proxmox_mcp/tools/containers.py
+++ b/src/proxmox_mcp/tools/containers.py
@@ -635,6 +635,7 @@ class ContainerTools(ProxmoxTool):
         onboot: bool = False,
         nesting: bool = False,
         unprivileged: bool = True,
+        pool: Optional[str] = None,
     ) -> List[Content]:
         """Create a new LXC container.
 
@@ -655,6 +656,7 @@ class ContainerTools(ProxmoxTool):
             onboot: Start container automatically when node boots (default: False)
             nesting: Enable LXC nesting feature (default: False)
             unprivileged: Create unprivileged container (default: True)
+            pool: Proxmox resource pool to create the container in (optional)
 
         Returns:
             List[Content] with creation result
@@ -723,6 +725,8 @@ class ContainerTools(ProxmoxTool):
                 ct_config["ssh-public-keys"] = ssh_public_keys
             if nesting:
                 ct_config["features"] = "nesting=1"
+            if pool:
+                ct_config["pool"] = pool
 
             # Create the container
             result = self.proxmox.nodes(node).lxc.create(**ct_config)

--- a/src/proxmox_mcp/tools/definitions.py
+++ b/src/proxmox_mcp/tools/definitions.py
@@ -73,6 +73,7 @@ disk_size* - Disk size in GB (e.g. 10, 20, 50)
 storage - Storage name (optional, will auto-detect if not specified)
 ostype - OS type (optional, default: 'l26' for Linux)
 network_bridge - Network bridge name (optional, default: 'vmbr0')
+pool - Target Proxmox resource pool (optional)
 
 Examples:
 - Create VM with 1 CPU, 2GB RAM, 10GB disk: node='pve', vmid='200', name='test-vm', cpus=1, memory=2048, disk_size=10
@@ -218,6 +219,7 @@ start_after_create - Start container after creation (optional, default: false)
 onboot - Start container automatically on host boot (optional, default: false)
 nesting - Enable LXC nesting (optional, sets features='nesting=1', default: false)
 unprivileged - Create unprivileged container (optional, default: true)
+pool - Target Proxmox resource pool (optional)
 
 Examples:
 - Create Alpine container: node='pveZ3', vmid='200', ostemplate='local:vztmpl/alpine-3.19-default_20240207_amd64.tar.xz'

--- a/src/proxmox_mcp/tools/vm.py
+++ b/src/proxmox_mcp/tools/vm.py
@@ -222,6 +222,7 @@ class VMTools(ProxmoxTool):
         storage: Optional[str] = None,
         ostype: Optional[str] = None,
         network_bridge: Optional[str] = None,
+        pool: Optional[str] = None,
     ) -> List[Content]:
         """Create a new virtual machine with specified configuration.
         
@@ -235,6 +236,7 @@ class VMTools(ProxmoxTool):
             storage: Storage name (e.g., 'local-lvm', 'vm-storage'). If None, will auto-detect
             ostype: OS type (e.g., 'l26' for Linux, 'win10' for Windows). Default: 'l26'
             network_bridge: Network bridge name (e.g., 'vmbr0'). If None, defaults to 'vmbr0'
+            pool: Proxmox resource pool to create the VM in. If None, no pool is specified
             
         Returns:
             List of Content objects containing creation result
@@ -333,6 +335,9 @@ class VMTools(ProxmoxTool):
             
             # Add storage configuration
             vm_config.update(vm_config_storage)
+
+            if pool:
+                vm_config["pool"] = pool
             
             # Create the VM
             task_result = self.proxmox.nodes(node).qemu.create(**vm_config)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -570,6 +570,33 @@ async def test_get_vms_skips_offline_node(server, mock_proxmox):
     assert "node1" in text
     assert "node2" not in text
 
+
+@pytest.mark.asyncio
+async def test_create_vm_passes_resource_pool_to_proxmox(server, mock_proxmox):
+    """create_vm should expose and forward the optional Proxmox resource pool."""
+    proxmox = mock_proxmox.return_value
+    node_api = proxmox.nodes.return_value
+    node_api.qemu.return_value.config.get.side_effect = RuntimeError("does not exist")
+    node_api.storage.get.return_value = [
+        {"storage": "local-lvm", "content": "images,rootdir", "type": "lvmthin"},
+    ]
+    node_api.qemu.create.return_value = "UPID:vm-create-pool"
+
+    await server.mcp.call_tool(
+        "create_vm",
+        {
+            "node": "node1",
+            "vmid": "210",
+            "name": "pool-vm",
+            "cpus": 2,
+            "memory": 2048,
+            "disk_size": 20,
+            "pool": "claude-lab",
+        },
+    )
+
+    assert node_api.qemu.create.call_args.kwargs["pool"] == "claude-lab"
+
 @pytest.mark.asyncio
 async def test_get_containers(server, mock_proxmox):
     """Test get_containers tool."""
@@ -734,6 +761,28 @@ async def test_create_container_with_lxc_options(server, mock_proxmox):
     )
     assert "Start on boot: Yes" in text
     assert "Nesting enabled: Yes" in text
+
+
+@pytest.mark.asyncio
+async def test_create_container_passes_resource_pool_to_proxmox(server, mock_proxmox):
+    """create_container should expose and forward the optional Proxmox resource pool."""
+    proxmox = mock_proxmox.return_value
+    proxmox.nodes.get.return_value = [{"node": "node1", "status": "online"}]
+    proxmox.nodes.return_value.lxc.get.return_value = []
+    proxmox.storage.get.return_value = [{"storage": "local-lvm", "content": "rootdir"}]
+    proxmox.nodes.return_value.lxc.create.return_value = "UPID:ct-create-pool"
+
+    await server.mcp.call_tool(
+        "create_container",
+        {
+            "node": "node1",
+            "vmid": "211",
+            "ostemplate": "local:vztmpl/debian-12-standard.tar.zst",
+            "pool": "claude-lab",
+        },
+    )
+
+    assert proxmox.nodes.return_value.lxc.create.call_args.kwargs["pool"] == "claude-lab"
 
 @pytest.mark.asyncio
 async def test_create_container_default_lxc_options(server, mock_proxmox):

--- a/tests/test_tool_user_paths.py
+++ b/tests/test_tool_user_paths.py
@@ -61,6 +61,7 @@ def test_create_vm_auto_detects_lvm_storage_and_registers_job():
     created = node_api.qemu.create.call_args.kwargs
     assert created["scsi0"] == "local-lvm:20,format=raw"
     assert created["net0"] == "virtio,bridge=vmbr0"
+    assert "pool" not in created
     assert "Job ID: job-1" in response[0].text
     assert job_store.registered[0]["retry_spec"]["kind"] == "vm.create"
 
@@ -114,6 +115,7 @@ def test_create_container_auto_detects_storage_and_omits_secret_retry_spec():
     assert created["rootfs"] == "local-lvm:8"
     assert created["features"] == "nesting=1"
     assert created["onboot"] == 1
+    assert "pool" not in created
     assert job_store.registered[0]["retry_spec"] is None
     assert "Job ID: job-1" in response[0].text
 


### PR DESCRIPTION
## Summary
- add optional Proxmox resource-pool targeting to `create_vm` and `create_container`
- preserve the existing creation payload when `pool` is omitted and add MCP-level regression coverage
- move Starlette tests to the supported `httpx2` backend and upgrade the pytest toolchain past PYSEC-2026-1845
- align release metadata and documentation for v0.5.9

## Validation
- `python -m pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=75 -W error::starlette.exceptions.StarletteDeprecationWarning` (187 passed, 1 skipped; 76.87%)
- `python -m ruff check .`
- `python -m mypy src --ignore-missing-imports`
- `python -m pip_audit -r requirements.txt`
- `python -m pip_audit -r requirements/dev.in`
- `python -m build --outdir .codex-run/dist-v0.5.9-20260716`
- `python -m twine check .codex-run/dist-v0.5.9-20260716/*`

Addresses #104. The issue will be closed after the release artifacts are published and verified.