### PR TITLE
Add set_container_description / set_vm_description tools

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -111,6 +111,10 @@
             "description": "Get full configuration for a QEMU virtual machine"
         },
         {
+            "name": "set_vm_description",
+            "description": "Set/replace the description (Notes field) of a QEMU virtual machine"
+        },
+        {
             "name": "create_vm",
             "description": "Create a new virtual machine with specified resources"
         },
@@ -209,6 +213,10 @@
         {
             "name": "get_container_config",
             "description": "Get full configuration for an LXC container"
+        },
+        {
+            "name": "set_container_description",
+            "description": "Set/replace the description (Notes field) of an LXC container"
         },
         {
             "name": "get_container_ip",

--- a/src/proxmox_mcp/services/builtin_tool_plugins.py
+++ b/src/proxmox_mcp/services/builtin_tool_plugins.py
@@ -43,6 +43,8 @@ from proxmox_mcp.tools.definitions import (
     RESTORE_BACKUP_DESC,
     RETRY_JOB_DESC,
     ROLLBACK_SNAPSHOT_DESC,
+    SET_CONTAINER_DESCRIPTION_DESC,
+    SET_VM_DESCRIPTION_DESC,
     SHUTDOWN_VM_DESC,
     START_CONTAINER_DESC,
     START_VM_DESC,
@@ -255,6 +257,18 @@ class VMToolsPlugin(RegistryPluginBase):
             return self._wrap_sync(server, "get_vm_config", server.vm_tools.get_vm_config)(
                 node=node,
                 vmid=vmid,
+            )
+
+        @server.mcp.tool(description=SET_VM_DESCRIPTION_DESC)
+        def set_vm_description(
+            node: Annotated[str, Field(description="Host node name (e.g. 'pve')")],
+            vmid: Annotated[str, Field(description="VM ID number (e.g. '100')")],
+            description: Annotated[str, Field(description="New notes text (replaces any existing notes)")],
+        ) -> Any:
+            return self._wrap_sync(server, "set_vm_description", server.vm_tools.set_vm_description)(
+                node=node,
+                vmid=vmid,
+                description=description,
             )
 
         @server.mcp.tool(description=CREATE_VM_DESC)
@@ -551,6 +565,20 @@ class ContainerToolsPlugin(RegistryPluginBase):
             return self._wrap_sync(server, "get_container_config", server.container_tools.get_container_config)(
                 node=node,
                 vmid=vmid,
+            )
+
+        @server.mcp.tool(description=SET_CONTAINER_DESCRIPTION_DESC)
+        def set_container_description(
+            node: Annotated[str, Field(description="Proxmox node name (e.g. 'pve')")],
+            vmid: Annotated[str, Field(description="Container ID (e.g. '101')")],
+            description: Annotated[str, Field(description="New notes text (replaces any existing notes)")],
+        ) -> Any:
+            return self._wrap_sync(
+                server, "set_container_description", server.container_tools.set_container_description
+            )(
+                node=node,
+                vmid=vmid,
+                description=description,
             )
 
         @server.mcp.tool(description=GET_CONTAINER_IP_DESC)

--- a/src/proxmox_mcp/tools/containers.py
+++ b/src/proxmox_mcp/tools/containers.py
@@ -931,6 +931,25 @@ class ContainerTools(ProxmoxTool):
         except Exception as e:
             return self._err("get_container_config", e)
 
+    def set_container_description(
+        self, node: str, vmid: str, description: str
+    ) -> List[Content]:
+        """Set/replace the description (Notes field in the UI) of an LXC container.
+
+        Uses PUT /nodes/{node}/lxc/{vmid}/config. Pass an empty string to clear
+        the notes.
+
+        Parameters:
+            node: Proxmox node name.
+            vmid: Container ID as a string.
+            description: New notes text (replaces any existing notes).
+        """
+        try:
+            self.proxmox.nodes(node).lxc(vmid).config.put(description=description)
+            return self._json_fmt({"vmid": vmid, "node": node, "description": description})
+        except Exception as e:
+            return self._err("set_container_description", e)
+
     def get_container_ip(self, node: str, vmid: str) -> List[Content]:
         """Return the current IP address(es) of a running LXC container.
 

--- a/src/proxmox_mcp/tools/definitions.py
+++ b/src/proxmox_mcp/tools/definitions.py
@@ -61,6 +61,19 @@ vmid* - VM ID number (e.g. '100')
 Example:
 {"vmid": "100", "name": "ubuntu", "cores": 2, "memory": 4096, "scsi0": "local-lvm:vm-100-disk-0,size=20G"}"""
 
+SET_VM_DESCRIPTION_DESC = """Set/replace the description (Notes field in the UI) of a QEMU VM.
+
+Uses PUT /nodes/{node}/qemu/{vmid}/config. Pass an empty string to clear the notes.
+
+Parameters:
+node*        - Host node name (e.g. 'pve')
+vmid*        - VM ID number (e.g. '100')
+description* - New notes text (replaces any existing notes)
+
+Example:
+set_vm_description node='pve' vmid='100' description='Decommissioned - see #123'
+"""
+
 CREATE_VM_DESC = """Create a new virtual machine with specified configuration.
 
 Parameters:
@@ -435,6 +448,19 @@ vmid* - Container ID (e.g. '101')
 
 Example:
 {"vmid": "101", "hostname": "valkey", "cores": 1, "memory": 1024, "net0": "name=eth0,..."}
+"""
+
+SET_CONTAINER_DESCRIPTION_DESC = """Set/replace the description (Notes field in the UI) of an LXC container.
+
+Uses PUT /nodes/{node}/lxc/{vmid}/config. Pass an empty string to clear the notes.
+
+Parameters:
+node*        - Proxmox node name (e.g. 'pve')
+vmid*        - Container ID (e.g. '101')
+description* - New notes text (replaces any existing notes)
+
+Example:
+set_container_description node='pve' vmid='101' description='GitLab Runner host (ct101-alpine)'
 """
 
 GET_CONTAINER_IP_DESC = """Get the current IP address(es) of a running LXC container.

--- a/src/proxmox_mcp/tools/vm.py
+++ b/src/proxmox_mcp/tools/vm.py
@@ -119,6 +119,25 @@ class VMTools(ProxmoxTool):
         except Exception as e:
             return self._err("get_vm_config", e)
 
+    def set_vm_description(
+        self, node: str, vmid: str, description: str
+    ) -> List[Content]:
+        """Set/replace the description (Notes field in the UI) of a QEMU VM.
+
+        Uses PUT /nodes/{node}/qemu/{vmid}/config. Pass an empty string to
+        clear the notes.
+
+        Parameters:
+            node: Proxmox node name.
+            vmid: VM ID as a string.
+            description: New notes text (replaces any existing notes).
+        """
+        try:
+            self.proxmox.nodes(node).qemu(vmid).config.put(description=description)
+            return self._json_fmt({"vmid": vmid, "node": node, "description": description})
+        except Exception as e:
+            return self._err("set_vm_description", e)
+
     def get_vms(self) -> List[Content]:
         """List all virtual machines across the cluster with detailed status.
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -343,9 +343,11 @@ async def test_list_tools(server):
     assert "update_container_ssh_keys" not in tool_names
     # LXC config tools (no SSH required)
     assert "get_container_config" in tool_names
+    assert "set_container_description" in tool_names
     assert "get_container_ip" in tool_names
     # VM config tool
     assert "get_vm_config" in tool_names
+    assert "set_vm_description" in tool_names
 
 
 @pytest.mark.asyncio
@@ -1235,6 +1237,49 @@ async def test_get_container_config_missing_parameters(server):
 
 
 # ---------------------------------------------------------------------------
+# set_container_description
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_set_container_description(server, mock_proxmox):
+    """set_container_description PUTs description and echoes it back."""
+    ct_api = mock_proxmox.return_value.nodes.return_value.lxc.return_value
+    ct_api.config.put.return_value = {}
+
+    response = await server.mcp.call_tool(
+        "set_container_description",
+        {"node": "node1", "vmid": "101", "description": "GitLab Runner host"},
+    )
+    result = json.loads(response[0].text)
+
+    assert result["vmid"] == "101"
+    assert result["node"] == "node1"
+    assert result["description"] == "GitLab Runner host"
+    ct_api.config.put.assert_called_with(description="GitLab Runner host")
+
+
+@pytest.mark.asyncio
+async def test_set_container_description_missing_parameters(server):
+    """set_container_description raises ToolError when required parameters are missing."""
+    with pytest.raises(ToolError):
+        await server.mcp.call_tool("set_container_description", {"node": "node1", "vmid": "101"})
+
+
+@pytest.mark.asyncio
+async def test_set_container_description_api_error(server, mock_proxmox):
+    """set_container_description surfaces Proxmox API errors via RuntimeError consistently."""
+    mock_proxmox.return_value.nodes.return_value.lxc.return_value.config.put.side_effect = (
+        Exception("permission denied")
+    )
+
+    with pytest.raises(ToolError, match="set_container_description"):
+        await server.mcp.call_tool(
+            "set_container_description",
+            {"node": "node1", "vmid": "999", "description": "x"},
+        )
+
+
+# ---------------------------------------------------------------------------
 # get_vm_config
 # ---------------------------------------------------------------------------
 
@@ -1280,6 +1325,49 @@ async def test_get_vm_config_api_error(server, mock_proxmox):
 
     with pytest.raises(ToolError, match="get_vm_config"):
         await server.mcp.call_tool("get_vm_config", {"node": "node1", "vmid": "999"})
+
+
+# ---------------------------------------------------------------------------
+# set_vm_description
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_set_vm_description(server, mock_proxmox):
+    """set_vm_description PUTs description and echoes it back."""
+    vm_api = mock_proxmox.return_value.nodes.return_value.qemu.return_value
+    vm_api.config.put.return_value = {}
+
+    response = await server.mcp.call_tool(
+        "set_vm_description",
+        {"node": "node1", "vmid": "100", "description": "Decommissioned"},
+    )
+    result = json.loads(response[0].text)
+
+    assert result["vmid"] == "100"
+    assert result["node"] == "node1"
+    assert result["description"] == "Decommissioned"
+    vm_api.config.put.assert_called_with(description="Decommissioned")
+
+
+@pytest.mark.asyncio
+async def test_set_vm_description_missing_parameters(server):
+    """set_vm_description raises ToolError when required parameters are missing."""
+    with pytest.raises(ToolError):
+        await server.mcp.call_tool("set_vm_description", {"node": "node1", "vmid": "100"})
+
+
+@pytest.mark.asyncio
+async def test_set_vm_description_api_error(server, mock_proxmox):
+    """set_vm_description surfaces Proxmox API errors via RuntimeError consistently."""
+    mock_proxmox.return_value.nodes.return_value.qemu.return_value.config.put.side_effect = (
+        Exception("VM does not exist")
+    )
+
+    with pytest.raises(ToolError, match="set_vm_description"):
+        await server.mcp.call_tool(
+            "set_vm_description",
+            {"node": "node1", "vmid": "999", "description": "x"},
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

LXC containers and QEMU VMs both have a `description` field in their Proxmox
config (the "Notes" box in the UI), but there was no tool to write it -
`get_container_config`/`get_vm_config` could read it, nothing could set it.

Adds `set_container_description` and `set_vm_description`, mirroring the
existing read tools' shape: single `node`/`vmid` target, `PUT .../config`
with `description=`, JSON echo of what was set. No selector/multi-target
support (unlike `update_container_resources`) since notes are typically
edited one host at a time.

## Changes

- `tools/containers.py`, `tools/vm.py`: the two new methods
- `tools/definitions.py`: MCP-facing tool descriptions
- `services/builtin_tool_plugins.py`: registration, placed right after
  `get_container_config`/`get_vm_config`
- `manifest.json`: declares both new tools (enforced by
  `test_security_hardening.py::test_manifest_declares_all_registered_tools`)
- `tests/test_server.py`: success/missing-params/api-error coverage for
  both, plus the `tool_names` inventory assertions in
  `test_list_tools_with_ssh_config`... actually in the base `test_list_tools`

## Test plan

- [x] Full suite passes: `pytest -q` -> 193 passed, 1 skipped
- [x] `ruff check` clean on all changed files
- [x] `mypy --ignore-missing-imports` clean on `containers.py`/`vm.py`
- [x] Verified live against a real Proxmox cluster: `set_container_description`
      PUT succeeds and the description persists on a subsequent
      `get_container_config` GET