### PR TITLE
Prepare v0.5.10 release

### DIFF
--- a/docs/releases/v0.5.10.md
+++ b/docs/releases/v0.5.10.md
@@ -1,0 +1,36 @@
+# ProxmoxMCP-Plus v0.5.10
+
+Release date: 2026-07-23
+
+## VM and Container Notes
+
+This release adds two MCP tools for managing the Proxmox Notes field:
+
+- `set_vm_description` updates the description of one QEMU virtual machine.
+- `set_container_description` updates the description of one LXC container.
+
+Both tools accept `node`, `vmid`, and `description`, then use the native Proxmox configuration endpoint. The supplied text replaces the existing Notes value; pass an empty string to clear it.
+
+The new tools complement `get_vm_config` and `get_container_config`, which already expose the stored description. They deliberately target one guest at a time and do not add selector or bulk-update behavior.
+
+## Permissions and Safety
+
+The configured Proxmox API token must be allowed to update the target guest configuration. Proxmox remains the authorization boundary; this release does not broaden token permissions.
+
+Descriptions are passed as data to the Proxmox API. They are not executed as commands, written to local files, or included in command logs.
+
+## Compatibility
+
+- Existing MCP tool names and inputs are unchanged.
+- No runtime configuration migration is required.
+- Clients that cache the tool manifest should refresh it to discover the two new tools.
+
+## Validation
+
+The release quality gate covers Python 3.11 and 3.12 tests with coverage enforcement, Ruff, Mypy, CodeQL, dependency auditing, package builds, Twine metadata validation, and runtime-to-manifest parity.
+
+## Upgrade Notes
+
+- Upgrade normally from PyPI, Docker/GHCR, or source.
+- Refresh the MCP client tool list after upgrading.
+- Test description updates on a non-production guest before adopting the tools in automated workflows.

--- a/docs/wiki/API & Tool Reference.md
+++ b/docs/wiki/API & Tool Reference.md
@@ -110,6 +110,7 @@ Selector-based tools fail when no container matches the selector or when a bulk 
 | `delete_vm` | Mutating | `node`, `vmid` | `force=false` | VM exists | running VM without `force`, VM not found |
 | `execute_vm_command` | Mutating | `node`, `vmid`, `command` | `approval_token` | VM running, QEMU Guest Agent installed, policy allows command | guest agent unavailable, VM not running, policy denial |
 | `get_vm_config` | Read-only | `node`, `vmid` | none | VM exists | VM not found, node mismatch |
+| `set_vm_description` | Mutating | `node`, `vmid`, `description` | none | VM exists and API token can update its config | VM not found, node mismatch, insufficient permissions |
 
 ### VM Notes
 
@@ -132,6 +133,7 @@ Selector-based tools fail when no container matches the selector or when a bulk 
 | `execute_container_command` | Mutating | `selector`, `command` | `approval_token` | only registered when `ssh` config exists; container must be running; policy must allow command | tool unavailable without SSH config, no selector match, SSH failure, policy denial |
 | `update_container_ssh_keys` | Mutating/high-risk | `node`, `vmid`, `public_keys` | `mode=append\|replace`, `approval_token` | only registered when `ssh` config exists; target container reachable through configured execution path; high-risk policy must allow the operation | tool unavailable without SSH config, invalid container target, SSH failure, approval required |
 | `get_container_config` | Read-only | `node`, `vmid` | none | target container exists | container not found, node mismatch |
+| `set_container_description` | Mutating | `node`, `vmid`, `description` | none | target container exists and API token can update its config | container not found, node mismatch, insufficient permissions |
 | `get_container_ip` | Read-only | `node`, `vmid` | none | target container exists | container not found, IP information unavailable |
 
 ### Container Notes

--- a/docs/wiki/Release & Upgrade Notes.md
+++ b/docs/wiki/Release & Upgrade Notes.md
@@ -18,6 +18,31 @@ Use this page to track version-level behavior changes, upgrade steps, and rollba
 
 ## Release History
 
+### Version `0.5.10`
+
+- Release date: 2026-07-23
+- Summary: adds first-class MCP tools for setting or clearing the Proxmox Notes field on individual QEMU VMs and LXC containers.
+- New tools or endpoints:
+  - `set_vm_description`
+  - `set_container_description`
+- Changed behavior:
+  - callers can replace a VM or container description through the native Proxmox config endpoint
+  - passing an empty description clears the existing Notes field
+  - each call targets exactly one `node` and `vmid`; no selector or multi-target behavior is introduced
+- Removed or deprecated behavior:
+  - no removals or deprecations
+- Config changes:
+  - no runtime configuration migration
+- Docs updated:
+  - `docs/releases/v0.5.10.md`
+  - `docs/wiki/API & Tool Reference.md`
+  - `docs/wiki/Release & Upgrade Notes.md`
+- Upgrade steps:
+  - no migration is required
+  - ensure the configured Proxmox API token can update the target VM or container configuration before using the new tools
+- Rollback notes:
+  - downgrade to `v0.5.9` only if a client cannot accept the two additional MCP tool definitions
+
 ### Version `0.5.9`
 
 - Release date: 2026-07-16

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": "0.4",
     "name": "proxmox-mcp-plus",
     "display_name": "ProxmoxMCP-Plus",
-    "version": "0.5.9",
+    "version": "0.5.10",
     "description": "An enhanced MCP server for managing Proxmox virtualization platforms.",
     "long_description": "ProxmoxMCP-Plus is an enhanced Model Context Protocol (MCP) server that provides comprehensive tools for managing Proxmox virtualization environments, including VM lifecycle, container management, snapshot operations, and backup/restore capabilities.",
     "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "proxmox-mcp-plus"
-version = "0.5.9"
+version = "0.5.10"
 description = "Enhanced Proxmox MCP Server"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -18,13 +18,13 @@
     "url": "https://github.com/RekklesNA/ProxmoxMCP-Plus",
     "source": "github"
   },
-  "version": "0.5.9",
+  "version": "0.5.10",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "proxmox-mcp-plus",
-      "version": "0.5.9",
+      "version": "0.5.10",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="proxmox-mcp-plus",
-    version="0.5.9",
+    version="0.5.10",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     python_requires=">=3.11",

--- a/src/proxmox_mcp/__init__.py
+++ b/src/proxmox_mcp/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .server import ProxmoxMCPServer
 
-__version__ = "0.5.9"
+__version__ = "0.5.10"
 __all__ = ["ProxmoxMCPServer"]
 
 


### PR DESCRIPTION
## Summary

- bump ProxmoxMCP-Plus to 0.5.10 after merging PR #106
- document `set_vm_description` and `set_container_description`
- add release and upgrade notes

## Validation

- `pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=75`: 193 passed, 1 skipped, 77.03%
- `ruff check .`: passed
- `mypy src --ignore-missing-imports`: passed
- `pip-audit -r requirements.txt`: no known vulnerabilities
- `pip check`: no broken requirements
- package build and `twine check`: passed
- version metadata aligned across pyproject, setup.py, package init, manifest, and server metadata
- manifest parity test: passed