### PR TITLE
Release v0.5.11 with native ARM64 container images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,9 @@
 .git
 .github
+.agents
+.codex
+.codex-run
+.playwright-cli
 .venv
 .mypy_cache
 .pytest_cache
@@ -14,5 +18,10 @@ assets
 proxmox_mcp.log
 *.log
 *.sqlite3
-proxmox-config/config.json
-proxmox-config/config.live.json
+.env
+.env.*
+*.key
+*.pem
+proxmox-config/*.json
+!proxmox-config/config.example.json
+!proxmox-config/config.live.example.json

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -12,11 +12,22 @@ env:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    outputs:
+      image_ref: ${{ steps.image.outputs.ref }}
     permissions:
       contents: read
       packages: write
     steps:
     - uses: actions/checkout@v6
+
+    - name: Set up QEMU for ARM64
+      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4.2.0
+      with:
+        image: docker.io/tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
+        platforms: arm64
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
 
     - name: Log in to GHCR
       uses: docker/login-action@v4
@@ -37,10 +48,87 @@ jobs:
           type=semver,pattern={{version}},value=${{ github.event.release.tag_name }}
           type=semver,pattern={{major}}.{{minor}},value=${{ github.event.release.tag_name }}
 
+    - name: Select image tag for verification
+      id: image
+      shell: bash
+      env:
+        IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
+      run: |
+        image_ref="$(printf '%s\n' "$IMAGE_TAGS" | head -n 1)"
+        test -n "$image_ref"
+        echo "ref=$image_ref" >> "$GITHUB_OUTPUT"
+
     - name: Build and push image
       uses: docker/build-push-action@v7
       with:
         context: .
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+
+  verify-arm64:
+    name: Verify published ARM64 image
+    needs: publish
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: read
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Log in to GHCR
+      shell: bash
+      env:
+        GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: echo "$GHCR_TOKEN" | docker login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
+
+    - name: Pull and verify the published image
+      shell: bash
+      env:
+        IMAGE_REF: ${{ needs.publish.outputs.image_ref }}
+      run: |
+        set -euo pipefail
+        docker pull --platform linux/arm64 "$IMAGE_REF"
+        test "$(docker image inspect "$IMAGE_REF" --format '{{.Architecture}}')" = "arm64"
+
+        docker buildx imagetools inspect --raw "$IMAGE_REF" > "$RUNNER_TEMP/image-manifest.json"
+        jq -e '
+          [.manifests[].platform
+            | select(.os == "linux")
+            | "\(.os)/\(.architecture)"]
+          | index("linux/amd64") != null
+            and index("linux/arm64") != null
+        ' "$RUNNER_TEMP/image-manifest.json"
+
+    - name: Run the ARM64 application health check
+      shell: bash
+      env:
+        IMAGE_REF: ${{ needs.publish.outputs.image_ref }}
+      run: |
+        set -euo pipefail
+        container_name="proxmox-mcp-arm64-release-smoke"
+        trap 'docker logs "$container_name" || true; docker rm -f "$container_name" || true' EXIT
+
+        docker run --detach \
+          --name "$container_name" \
+          --platform linux/arm64 \
+          --publish 127.0.0.1:18811:8811 \
+          --volume "$PWD/proxmox-config/config.example.json:/app/proxmox-config/config.json:ro" \
+          --env PROXMOX_API_KEY=release-smoke-check \
+          "$IMAGE_REF"
+
+        for attempt in {1..30}; do
+          if curl --fail --silent --show-error http://127.0.0.1:18811/livez > livez.json; then
+            break
+          fi
+          if test "$(docker inspect "$container_name" --format '{{.State.Running}}')" != "true"; then
+            exit 1
+          fi
+          sleep 2
+        done
+
+        curl --fail --silent --show-error http://127.0.0.1:18811/livez | jq -e '.status == "ok"'
+        test "$(docker exec "$container_name" uname -m)" = "aarch64"
+        test "$(docker exec "$container_name" id -u)" != "0"
+        docker exec "$container_name" sh -c 'test ! -e /usr/local/bin/pip && ! python -m pip --version >/dev/null 2>&1'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.11-slim@sha256:db3ff2e1800a8581e2c48a27c3995339d47bdf046da21c7627accd3d51053a93
 
 WORKDIR /app
 
@@ -11,7 +11,8 @@ COPY pyproject.toml setup.py README.md LICENSE ./
 COPY src ./src
 
 RUN python -m pip install --no-cache-dir --upgrade pip \
-    && python -m pip install --no-cache-dir .
+    && python -m pip install --no-cache-dir . \
+    && python -m pip uninstall --yes pip setuptools wheel
 
 COPY . .
 

--- a/docs/releases/v0.5.11.md
+++ b/docs/releases/v0.5.11.md
@@ -1,0 +1,50 @@
+# ProxmoxMCP-Plus v0.5.11
+
+Release date: 2026-07-29
+
+## Native ARM64 Container Image
+
+This release publishes the GHCR container for both `linux/amd64` and `linux/arm64` under the same image tags.
+
+Docker now selects the native image automatically on Apple Silicon and other ARM64 hosts. These systems no longer need to run the AMD64 image through QEMU emulation when pulling the published image.
+
+## Release Pipeline Safety
+
+The release workflow uses Docker Buildx to publish one multi-architecture manifest. QEMU registration is limited to ARM64, the only additional target. The newly introduced QEMU and Buildx actions are pinned to reviewed full commit SHAs, and the QEMU helper image is pinned by OCI digest.
+
+The Docker build context now excludes local agent/tool state, environment files, private-key file patterns, and non-example Proxmox JSON configuration files. This prevents local development credentials or runtime configuration from being copied into image layers by `COPY . .`.
+
+Python packaging tools (`pip`, `setuptools`, and `wheel`) are removed after the application is installed because they are not required at runtime. This reduces the final image attack surface and prevents vulnerabilities in dormant build-only code from shipping with the service.
+
+The multi-architecture Python base image is pinned by OCI digest. Regression tests verify that both architectures remain configured, the new third-party actions remain immutable, the sensitive build-context exclusions remain present, the base image remains immutable, and the runtime packaging toolchain remains removed.
+
+After publication, a native GitHub-hosted ARM64 runner pulls the published image, verifies that the tag contains both Linux architectures, starts the ARM64 container, checks `/livez`, confirms `uname -m` reports `aarch64`, and confirms the process is not running as root. The GHCR workflow does not pass unless this post-publication check succeeds.
+
+## Container Vulnerability Review
+
+Docker Scout analysis removed two high-severity findings by removing the dormant Python packaging toolchain. The remaining findings are in Debian Trixie's essential `perl-base` package:
+
+- `CVE-2026-12087`
+- `CVE-2026-48959`
+- `CVE-2026-48962`
+
+Debian classifies these as minor `no-dsa` issues for Trixie, and the current Trixie repository does not provide a fixed package. Their vulnerable paths require an application to invoke Perl Socket or Perl archive-processing APIs with attacker-controlled inputs. ProxmoxMCP-Plus does not invoke Perl or expose those APIs. Removing the essential package would make the base system unsafe, so the residual base-image advisories are documented rather than hidden or bypassed.
+
+## Compatibility
+
+- Existing AMD64 deployments continue to receive a native AMD64 image.
+- ARM64 hosts receive a native ARM64 image from the same tag.
+- Image names, ports, environment variables, transports, and MCP tools are unchanged.
+- No runtime configuration migration is required.
+
+## Validation
+
+The release quality gate covers Python 3.11 and 3.12 tests with coverage enforcement, Ruff, Mypy, CodeQL, dependency auditing, package builds, Twine metadata validation, runtime-to-manifest parity, multi-architecture workflow regression checks, and Docker build-context safety checks.
+
+The published `0.5.11` and `latest` tags must expose both `linux/amd64` and `linux/arm64`. The ARM64 image is pulled explicitly on a native ARM64 runner and its application health endpoint is checked before issue #109 is closed.
+
+## Upgrade Notes
+
+- Pull `ghcr.io/rekklesna/proxmoxmcp-plus:0.5.11` or `latest` normally.
+- Docker automatically selects the correct architecture.
+- No Compose or MCP client changes are required.

--- a/docs/wiki/Release & Upgrade Notes.md
+++ b/docs/wiki/Release & Upgrade Notes.md
@@ -18,6 +18,33 @@ Use this page to track version-level behavior changes, upgrade steps, and rollba
 
 ## Release History
 
+### Version `0.5.11`
+
+- Release date: 2026-07-29
+- Summary: publishes the GHCR container as a native multi-architecture image for AMD64 and ARM64 hosts (closes issue #109).
+- New tools or endpoints:
+  - no new runtime tools or endpoints
+- Changed behavior:
+  - GHCR release tags now contain native `linux/amd64` and `linux/arm64` images under one multi-architecture manifest
+  - Docker automatically selects the matching image on Apple Silicon and other ARM64 hosts instead of falling back to AMD64 emulation
+  - the release workflow limits QEMU registration to ARM64, pins the new QEMU and Buildx actions to reviewed commit SHAs, and pins the QEMU helper image by OCI digest
+  - Docker build contexts exclude local tool state, environment files, private-key patterns, and non-example Proxmox JSON configuration files
+  - the final runtime image removes `pip`, `setuptools`, and `wheel` after installation to reduce dormant build-tool attack surface
+  - the multi-architecture Python base image is pinned by OCI digest
+  - a native ARM64 release job pulls the published image and verifies its manifest, architecture, non-root runtime, and `/livez` endpoint
+- Removed or deprecated behavior:
+  - no removals or deprecations
+- Config changes:
+  - no runtime configuration migration
+- Docs updated:
+  - `docs/releases/v0.5.11.md`
+  - `docs/wiki/Release & Upgrade Notes.md`
+- Upgrade steps:
+  - pull `ghcr.io/rekklesna/proxmoxmcp-plus:0.5.11` or `latest` normally; Docker selects the host architecture automatically
+  - no Compose or MCP client configuration change is required
+- Rollback notes:
+  - use `v0.5.10` if a registry or Docker installation cannot consume a multi-architecture manifest
+
 ### Version `0.5.10`
 
 - Release date: 2026-07-23

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": "0.4",
     "name": "proxmox-mcp-plus",
     "display_name": "ProxmoxMCP-Plus",
-    "version": "0.5.10",
+    "version": "0.5.11",
     "description": "An enhanced MCP server for managing Proxmox virtualization platforms.",
     "long_description": "ProxmoxMCP-Plus is an enhanced Model Context Protocol (MCP) server that provides comprehensive tools for managing Proxmox virtualization environments, including VM lifecycle, container management, snapshot operations, and backup/restore capabilities.",
     "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "proxmox-mcp-plus"
-version = "0.5.10"
+version = "0.5.11"
 description = "Enhanced Proxmox MCP Server"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -18,13 +18,13 @@
     "url": "https://github.com/RekklesNA/ProxmoxMCP-Plus",
     "source": "github"
   },
-  "version": "0.5.10",
+  "version": "0.5.11",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "proxmox-mcp-plus",
-      "version": "0.5.10",
+      "version": "0.5.11",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="proxmox-mcp-plus",
-    version="0.5.10",
+    version="0.5.11",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     python_requires=">=3.11",

--- a/src/proxmox_mcp/__init__.py
+++ b/src/proxmox_mcp/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .server import ProxmoxMCPServer
 
-__version__ = "0.5.10"
+__version__ = "0.5.11"
 __all__ = ["ProxmoxMCPServer"]
 
 

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -1,5 +1,6 @@
 import ast
 import json
+import re
 import tomllib
 from pathlib import Path
 
@@ -52,3 +53,41 @@ def test_setup_metadata_tracks_pyproject_runtime_contract():
     assert set(setup_kwargs["entry_points"]["console_scripts"]) == {
         f"{name}={target}" for name, target in pyproject["project"]["scripts"].items()
     }
+
+
+def test_ghcr_release_builds_pinned_multi_arch_images():
+    workflow = (ROOT / ".github/workflows/publish-ghcr.yml").read_text(encoding="utf-8")
+
+    assert re.search(r"uses: docker/setup-qemu-action@[0-9a-f]{40}\s+# v4\.2\.0", workflow)
+    assert re.search(r"uses: docker/setup-buildx-action@[0-9a-f]{40}\s+# v4\.2\.0", workflow)
+    assert re.search(r"image: docker\.io/tonistiigi/binfmt@sha256:[0-9a-f]{64}", workflow)
+    assert "platforms: arm64" in workflow
+    assert "platforms: linux/amd64,linux/arm64" in workflow
+    assert "runs-on: ubuntu-24.04-arm" in workflow
+    assert "docker pull --platform linux/arm64" in workflow
+    assert "http://127.0.0.1:18811/livez" in workflow
+    assert 'test "$(docker exec "$container_name" uname -m)" = "aarch64"' in workflow
+    assert "test ! -e /usr/local/bin/pip" in workflow
+
+
+def test_docker_context_excludes_local_secrets_and_tool_state():
+    patterns = {
+        line.strip()
+        for line in (ROOT / ".dockerignore").read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+
+    assert {".agents", ".codex", ".codex-run", ".playwright-cli"} <= patterns
+    assert {".env", ".env.*", "*.key", "*.pem", "proxmox-config/*.json"} <= patterns
+    assert {
+        "!proxmox-config/config.example.json",
+        "!proxmox-config/config.live.example.json",
+    } <= patterns
+
+
+def test_runtime_image_removes_python_packaging_toolchain():
+    dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+
+    assert re.search(r"^FROM python:3\.11-slim@sha256:[0-9a-f]{64}$", dockerfile, re.MULTILINE)
+    assert "python -m pip install --no-cache-dir ." in dockerfile
+    assert "python -m pip uninstall --yes pip setuptools wheel" in dockerfile


### PR DESCRIPTION
## Summary

- publish GHCR images for both `linux/amd64` and `linux/arm64`
- verify the published ARM64 image on a native GitHub-hosted ARM64 runner, including manifest platforms, `/livez`, `aarch64`, non-root execution, and removal of runtime packaging tools
- pin the new QEMU/Buildx actions, QEMU helper image, and Python base image to immutable revisions
- exclude local tool state, environment files, private-key patterns, and non-example Proxmox configuration from Docker build contexts
- align release metadata and documentation for v0.5.11

Addresses #109. The issue will remain open until the released image has been pulled and the native ARM64 health check has passed.

## Root cause

The GHCR workflow built on an AMD64 runner without configuring Buildx platforms, so each published tag contained only a `linux/amd64` manifest.

## Security review

The final image removes `pip`, `setuptools`, and `wheel` after installation. Docker Scout no longer reports the two high-severity build-tool findings. Remaining Debian Trixie `perl-base` advisories are documented in the release notes; Debian marks them as minor `no-dsa` issues, the current repository has no fixed package, and the application does not invoke the affected Perl APIs.

## Validation

- 196 passed, 1 skipped; 77.03% coverage
- Ruff and Mypy passed
- pip check and pip-audit passed with no known Python dependency vulnerabilities
- package build and Twine metadata checks passed
- actionlint passed for the GHCR workflow
- local AMD64 container returned `{"status":"ok"}` from `/livez` as UID 1000
- local ARM64 image built successfully with native aarch64 wheels
- image filesystem inspection found no local secret/tool-state files