### PR TITLE
release: publish v0.5.12 with immutable Docker Action pins

### DIFF
--- a/docs/releases/v0.5.12.md
+++ b/docs/releases/v0.5.12.md
@@ -1,0 +1,39 @@
+# ProxmoxMCP-Plus v0.5.12
+
+Release date: 2026-07-29
+
+## Immutable Docker Release Actions
+
+This release completes the supply-chain hardening of the GHCR publication workflow by pinning every third-party Docker Action to a reviewed full commit SHA:
+
+- `docker/login-action` v4.6.0
+- `docker/metadata-action` v6.2.0
+- `docker/build-push-action` v7.3.0
+- `docker/setup-qemu-action` v4.2.0
+- `docker/setup-buildx-action` v4.2.0
+
+The login-action pin was refreshed from v4.4.0 during review to include the v4.5 and v4.6 dependency updates and scoped-config path hardening. All five pinned commits were resolved against their official Docker Action repositories before release.
+
+Thanks to `mirkosalvato1-ctrl` for opening PR #108 and proposing the original pinning change.
+
+## Regression Protection
+
+The release metadata tests now enumerate every `docker/*` Action reference in the GHCR workflow and require each reference to be a lowercase 40-character commit SHA. Adding a mutable major tag such as `@v4` will fail CI.
+
+The Python base image and QEMU helper image remain pinned by OCI digest.
+
+## Compatibility
+
+- MCP tools, schemas, ports, transports, and runtime configuration are unchanged.
+- The native `linux/amd64` and `linux/arm64` images introduced in v0.5.11 remain available under the same GHCR tags.
+- The native ARM64 post-publication pull and `/livez` health check remains a required GHCR release gate.
+- No migration is required.
+
+## Validation
+
+The release quality gate covers Python 3.11 and 3.12 tests with coverage enforcement, Ruff, Mypy, CodeQL, dependency auditing, package builds, Twine metadata validation, runtime-to-manifest parity, actionlint, immutable Action reference checks, multi-architecture publication, and native ARM64 post-publication runtime validation.
+
+## Upgrade Notes
+
+- Upgrade normally from PyPI, GHCR, or source.
+- No application or Docker configuration changes are required.

--- a/docs/wiki/Release & Upgrade Notes.md
+++ b/docs/wiki/Release & Upgrade Notes.md
@@ -18,6 +18,31 @@ Use this page to track version-level behavior changes, upgrade steps, and rollba
 
 ## Release History
 
+### Version `0.5.12`
+
+- Release date: 2026-07-29
+- Summary: pins every third-party Docker Action used by the GHCR release workflow to a reviewed immutable commit SHA.
+- New tools or endpoints:
+  - no new runtime tools or endpoints
+- Changed behavior:
+  - `docker/login-action` is pinned to the signed v4.6.0 commit
+  - `docker/metadata-action` is pinned to the signed v6.2.0 commit
+  - `docker/build-push-action` is pinned to the signed v7.3.0 commit
+  - a regression test rejects mutable refs for every `docker/*` Action in the container release workflow
+  - the v0.5.11 native AMD64/ARM64 build and post-publication ARM64 health gate remain unchanged
+- Removed or deprecated behavior:
+  - no removals or deprecations
+- Config changes:
+  - no runtime configuration migration
+- Docs updated:
+  - `docs/releases/v0.5.12.md`
+  - `docs/wiki/Release & Upgrade Notes.md`
+- Upgrade steps:
+  - upgrade normally from PyPI, GHCR, or source
+  - no application or Docker configuration change is required
+- Rollback notes:
+  - downgrade to `v0.5.11` only if the pinned release workflow is incompatible with a repository-specific Actions policy
+
 ### Version `0.5.11`
 
 - Release date: 2026-07-29

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": "0.4",
     "name": "proxmox-mcp-plus",
     "display_name": "ProxmoxMCP-Plus",
-    "version": "0.5.11",
+    "version": "0.5.12",
     "description": "An enhanced MCP server for managing Proxmox virtualization platforms.",
     "long_description": "ProxmoxMCP-Plus is an enhanced Model Context Protocol (MCP) server that provides comprehensive tools for managing Proxmox virtualization environments, including VM lifecycle, container management, snapshot operations, and backup/restore capabilities.",
     "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "proxmox-mcp-plus"
-version = "0.5.11"
+version = "0.5.12"
 description = "Enhanced Proxmox MCP Server"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -18,13 +18,13 @@
     "url": "https://github.com/RekklesNA/ProxmoxMCP-Plus",
     "source": "github"
   },
-  "version": "0.5.11",
+  "version": "0.5.12",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "proxmox-mcp-plus",
-      "version": "0.5.11",
+      "version": "0.5.12",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="proxmox-mcp-plus",
-    version="0.5.11",
+    version="0.5.12",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     python_requires=">=3.11",

--- a/src/proxmox_mcp/__init__.py
+++ b/src/proxmox_mcp/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .server import ProxmoxMCPServer
 
-__version__ = "0.5.11"
+__version__ = "0.5.12"
 __all__ = ["ProxmoxMCPServer"]
 
 

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -57,9 +57,22 @@ def test_setup_metadata_tracks_pyproject_runtime_contract():
 
 def test_ghcr_release_builds_pinned_multi_arch_images():
     workflow = (ROOT / ".github/workflows/publish-ghcr.yml").read_text(encoding="utf-8")
+    docker_actions = re.findall(
+        r"^\s*uses:\s+(docker/[^@\s]+)@([^\s#]+)",
+        workflow,
+        re.MULTILINE,
+    )
 
     assert re.search(r"uses: docker/setup-qemu-action@[0-9a-f]{40}\s+# v4\.2\.0", workflow)
     assert re.search(r"uses: docker/setup-buildx-action@[0-9a-f]{40}\s+# v4\.2\.0", workflow)
+    assert {name for name, _ in docker_actions} == {
+        "docker/setup-qemu-action",
+        "docker/setup-buildx-action",
+        "docker/login-action",
+        "docker/metadata-action",
+        "docker/build-push-action",
+    }
+    assert all(re.fullmatch(r"[0-9a-f]{40}", ref) for _, ref in docker_actions)
     assert re.search(r"image: docker\.io/tonistiigi/binfmt@sha256:[0-9a-f]{64}", workflow)
     assert "platforms: arm64" in workflow
     assert "platforms: linux/amd64,linux/arm64" in workflow


### PR DESCRIPTION
## Summary

- bump all release metadata from 0.5.11 to 0.5.12
- add release notes for the immutable Docker Action pins merged in #108
- add a regression check that enumerates every `docker/*` Action in the GHCR workflow and requires a lowercase 40-character commit SHA
- retain the native AMD64/ARM64 publication and ARM64 post-publication health gate from v0.5.11

## Supply-chain review

The five Docker Action references resolve to reviewed full commit SHAs. During review of #108, `docker/login-action` was refreshed from v4.4.0 to signed v4.6.0; `docker/metadata-action` remains v6.2.0 and `docker/build-push-action` remains v7.3.0.

Thanks to @mirkosalvato1-ctrl for the original pinning contribution in #108.

## Local validation

- 196 passed, 1 skipped; coverage 77.03%
- Ruff, Mypy, `pip check`, and `pip-audit` passed
- wheel and sdist built; Twine validation passed
- actionlint and `git diff --check` passed
- local AMD64 image built successfully
- `/livez` returned `ok`, architecture was `x86_64`, runtime UID was 1000, and the pip build toolchain was absent

This PR is intentionally limited to release metadata, documentation, and the immutable-reference regression test.