### PR TITLE
fix(stdio): exit without interpreter finalization on SIGTERM/SIGINT

### DIFF
--- a/src/proxmox_mcp/server.py
+++ b/src/proxmox_mcp/server.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import os
 import signal
 import sys
-from typing import Any, Literal, Optional, cast
+from typing import Any, Literal, NoReturn, Optional, cast
 
 from mcp.server.fastmcp import FastMCP
 from proxmox_mcp.config.loader import load_config
@@ -48,6 +48,37 @@ except ImportError:  # pragma: no cover - exercised only with older MCP SDKs
 def _log_safe(value: object, max_length: int = 200) -> str:
     text = str(value).replace("\r", "").replace("\n", "")
     return text[:max_length]
+
+
+def _exit_without_finalization(status: int = 0) -> NoReturn:
+    """Terminate the process without running interpreter finalization.
+
+    Raising ``SystemExit`` from a signal handler is unsafe under the stdio
+    transport. The MCP SDK reads stdin from an AnyIO worker thread, using its
+    own ``TextIOWrapper`` built on ``sys.stdin.buffer``
+    (``mcp.server.stdio.stdio_server``). A signal arriving mid-read leaves that
+    thread blocked inside ``readline()``, owning the lock of the
+    ``BufferedReader`` it shares with ``sys.stdin``.
+
+    ``SystemExit`` would then start interpreter finalization, which clears the
+    ``sys`` module dict, deallocates ``sys.stdin`` and tries to close that same
+    ``BufferedReader``. The lock is never released, so CPython gives up after
+    its one-second grace period and calls ``Py_FatalError``::
+
+        Fatal Python error: _enter_buffered_busy: could not acquire lock for
+        <_io.BufferedReader name='<stdin>'> at interpreter shutdown, possibly
+        due to daemon threads
+
+    which aborts the process with ``SIGABRT``. ``os._exit()`` skips
+    finalization entirely, so the shutdown is clean. Callers are responsible
+    for releasing anything that matters before calling this.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.flush()
+        except Exception:  # pragma: no cover - best effort on a dying process
+            pass
+    os._exit(status)
 
 
 class ProxmoxMCPServer:
@@ -156,16 +187,23 @@ class ProxmoxMCPServer:
         """Start the MCP server with the configured transport."""
         import anyio
 
+        transport = self.config.mcp.transport
+        # Mirrors the dispatch below: anything that is not SSE or STREAMABLE
+        # is served over stdio.
+        uses_stdio = transport not in ("SSE", "STREAMABLE")
+
         def signal_handler(signum: int, frame: object) -> None:
             self.logger.info("Received signal to shutdown...")
             self.close()
-            sys.exit(0)
+            if uses_stdio:
+                _exit_without_finalization()
+            else:
+                sys.exit(0)
 
         signal.signal(signal.SIGINT, signal_handler)
         signal.signal(signal.SIGTERM, signal_handler)
 
         try:
-            transport = self.config.mcp.transport
             self.logger.info("Starting Proxmox MCP Server with transport: %s", transport)
 
             if transport == "STDIO":

--- a/src/proxmox_mcp/server.py
+++ b/src/proxmox_mcp/server.py
@@ -72,12 +72,14 @@ def _exit_without_finalization(status: int = 0) -> NoReturn:
     which aborts the process with ``SIGABRT``. ``os._exit()`` skips
     finalization entirely, so the shutdown is clean. Callers are responsible
     for releasing anything that matters before calling this.
+
+    Standard streams are intentionally not flushed here. The SDK also writes
+    stdout through an AnyIO worker thread and a second ``TextIOWrapper``. If
+    that worker is blocked on a full pipe while holding the shared buffered
+    writer lock, flushing from the signal handler would deadlock before
+    ``os._exit()`` can run. The signal handler calls ``close()`` first to
+    release application-owned resources.
     """
-    for stream in (sys.stdout, sys.stderr):
-        try:
-            stream.flush()
-        except Exception:  # pragma: no cover - best effort on a dying process
-            pass
     os._exit(status)
 
 
@@ -194,10 +196,13 @@ class ProxmoxMCPServer:
 
         def signal_handler(signum: int, frame: object) -> None:
             self.logger.info("Received signal to shutdown...")
-            self.close()
             if uses_stdio:
-                _exit_without_finalization()
+                try:
+                    self.close()
+                finally:
+                    _exit_without_finalization()
             else:
+                self.close()
                 sys.exit(0)
 
         signal.signal(signal.SIGINT, signal_handler)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,6 +4,7 @@ Tests for the Proxmox MCP server.
 
 import os
 import json
+import select
 import signal
 import subprocess
 import sys
@@ -1657,6 +1658,23 @@ def _server_with_transport(tmp_path, transport):
     return ProxmoxMCPServer(str(config_path))
 
 
+def test_exit_without_finalization_does_not_flush_stdio(monkeypatch):
+    """Flushing a stream locked by an SDK worker would deadlock shutdown."""
+    stdout = Mock()
+    stderr = Mock()
+    monkeypatch.setattr(server_module, "sys", Mock(stdout=stdout, stderr=stderr))
+    exit_process = Mock(side_effect=SystemExit(7))
+    monkeypatch.setattr(server_module.os, "_exit", exit_process)
+
+    with pytest.raises(SystemExit) as excinfo:
+        server_module._exit_without_finalization(7)
+
+    assert excinfo.value.code == 7
+    exit_process.assert_called_once_with(7)
+    stdout.flush.assert_not_called()
+    stderr.flush.assert_not_called()
+
+
 @pytest.mark.parametrize("signum", [signal.SIGINT, signal.SIGTERM])
 def test_stdio_signal_handler_exits_without_finalization(
     mock_proxmox, tmp_path, monkeypatch, signum
@@ -1670,20 +1688,43 @@ def test_stdio_signal_handler_exits_without_finalization(
     handlers = _capture_signal_handlers(srv, monkeypatch)
 
     exits: list[int] = []
+    events: list[str] = []
     monkeypatch.setattr(
-        server_module, "_exit_without_finalization", lambda status=0: exits.append(status)
+        server_module,
+        "_exit_without_finalization",
+        lambda status=0: (events.append("exit"), exits.append(status)),
     )
-    srv.close = Mock()
+    srv.close = Mock(side_effect=lambda: events.append("close"))
 
     handlers[signum](signum, None)
 
     assert exits == [0]
+    assert events == ["close", "exit"]
     srv.close.assert_called_once()
 
 
-def test_http_signal_handler_still_raises_system_exit(mock_proxmox, tmp_path, monkeypatch):
+def test_stdio_signal_handler_exits_when_close_fails(mock_proxmox, tmp_path, monkeypatch):
+    """A cleanup error must not fall back to unsafe interpreter finalization."""
+    srv = _server_with_transport(tmp_path, "STDIO")
+    handlers = _capture_signal_handlers(srv, monkeypatch)
+    srv.close = Mock(side_effect=RuntimeError("cleanup failed"))
+    exit_process = Mock(side_effect=SystemExit(0))
+    monkeypatch.setattr(server_module, "_exit_without_finalization", exit_process)
+
+    with pytest.raises(SystemExit) as excinfo:
+        handlers[signal.SIGTERM](signal.SIGTERM, None)
+
+    assert excinfo.value.code == 0
+    srv.close.assert_called_once()
+    exit_process.assert_called_once_with()
+
+
+@pytest.mark.parametrize("transport", ["SSE", "STREAMABLE"])
+def test_http_signal_handler_still_raises_system_exit(
+    mock_proxmox, tmp_path, monkeypatch, transport
+):
     """HTTP transports have no stdin reader thread, so normal unwinding is kept."""
-    srv = _server_with_transport(tmp_path, "SSE")
+    srv = _server_with_transport(tmp_path, transport)
     handlers = _capture_signal_handlers(srv, monkeypatch)
     srv.close = Mock()
 
@@ -1694,6 +1735,10 @@ def test_http_signal_handler_still_raises_system_exit(mock_proxmox, tmp_path, mo
     srv.close.assert_called_once()
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="SIGTERM handler delivery is POSIX-specific",
+)
 def test_stdio_shutdown_does_not_abort_at_interpreter_finalization(tmp_path):
     """End-to-end guard against the SIGABRT regression.
 
@@ -1711,10 +1756,12 @@ def test_stdio_shutdown_does_not_abort_at_interpreter_finalization(tmp_path):
         signal.signal(signal.SIGTERM, lambda *_: _exit_without_finalization())
 
         worker_view = io.TextIOWrapper(sys.stdin.buffer, encoding="utf-8", errors="replace")
-        threading.Thread(target=worker_view.readline, daemon=True).start()
+        reader = threading.Thread(target=worker_view.readline, daemon=True)
+        reader.start()
         time.sleep(0.2)
-        os.kill(os.getpid(), signal.SIGTERM)
-        time.sleep(10)
+        assert reader.is_alive()
+        print("READY", flush=True)
+        time.sleep(30)
         """
     )
     src_dir = os.path.dirname(os.path.dirname(os.path.abspath(server_module.__file__)))
@@ -1729,12 +1776,37 @@ def test_stdio_shutdown_does_not_abort_at_interpreter_finalization(tmp_path):
         env=env,
     )
     try:
-        _, stderr = proc.communicate(timeout=30)
+        assert proc.stdout is not None
+        assert proc.stderr is not None
+        assert proc.stdin is not None
+
+        # Keep stdin open while the reader thread is blocked. communicate()
+        # closes an unused stdin pipe before waiting, which releases the shared
+        # BufferedReader lock and turns this regression guard into a false pass.
+        readable, _, _ = select.select([proc.stdout], [], [], 10)
+        assert readable, "child did not become ready while holding the stdin lock"
+        assert proc.stdout.readline() == b"READY\n"
+        proc.send_signal(signal.SIGTERM)
+        proc.wait(timeout=30)
+        stderr = proc.stderr.read()
     except subprocess.TimeoutExpired:
         proc.kill()
+        proc.wait()
         raise
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait()
+        if proc.stdin is not None:
+            proc.stdin.close()
+        if proc.stdout is not None:
+            proc.stdout.close()
+        if proc.stderr is not None:
+            proc.stderr.close()
 
     assert proc.returncode == 0, (
         f"shutdown aborted instead of exiting cleanly "
         f"(returncode={proc.returncode}): {stderr.decode(errors='replace')}"
     )
+    assert b"Fatal Python error" not in stderr
+    assert b"_enter_buffered_busy" not in stderr

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,6 +4,10 @@ Tests for the Proxmox MCP server.
 
 import os
 import json
+import signal
+import subprocess
+import sys
+import textwrap
 import pytest
 from typing import Any, cast
 from unittest.mock import Mock, patch
@@ -1628,3 +1632,109 @@ async def test_high_risk_job_retry_requires_approval_token(mock_proxmox, tmp_pat
 
     assert payload["upid"] == "UPID:retry-delete"
     retry_factory.assert_called_once()
+
+
+def _capture_signal_handlers(srv, monkeypatch):
+    """Run start() far enough to capture the handlers it installs."""
+    handlers: dict[int, Any] = {}
+    monkeypatch.setattr(
+        server_module.signal, "signal", lambda num, handler: handlers.setdefault(num, handler)
+    )
+    with patch("anyio.run"):
+        srv.start()
+    return handlers
+
+
+def _server_with_transport(tmp_path, transport):
+    config_path = tmp_path / f"config_{transport.lower()}.json"
+    config_path.write_text(json.dumps({
+        "proxmox": {"host": "test.proxmox.com", "port": 8006, "verify_ssl": True, "service": "PVE"},
+        "auth": {"user": "test@pve", "token_name": "test_token", "token_value": "test_value"},
+        "logging": {"level": "INFO"},
+        "mcp": {"host": "127.0.0.1", "port": 8000, "transport": transport},
+        "command_policy": {"mode": "audit_only"},
+    }))
+    return ProxmoxMCPServer(str(config_path))
+
+
+@pytest.mark.parametrize("signum", [signal.SIGINT, signal.SIGTERM])
+def test_stdio_signal_handler_exits_without_finalization(
+    mock_proxmox, tmp_path, monkeypatch, signum
+):
+    """Under stdio, shutdown must skip interpreter finalization.
+
+    Raising SystemExit here aborts the process with SIGABRT when the MCP SDK's
+    stdin reader thread is mid-read; see _exit_without_finalization.
+    """
+    srv = _server_with_transport(tmp_path, "STDIO")
+    handlers = _capture_signal_handlers(srv, monkeypatch)
+
+    exits: list[int] = []
+    monkeypatch.setattr(
+        server_module, "_exit_without_finalization", lambda status=0: exits.append(status)
+    )
+    srv.close = Mock()
+
+    handlers[signum](signum, None)
+
+    assert exits == [0]
+    srv.close.assert_called_once()
+
+
+def test_http_signal_handler_still_raises_system_exit(mock_proxmox, tmp_path, monkeypatch):
+    """HTTP transports have no stdin reader thread, so normal unwinding is kept."""
+    srv = _server_with_transport(tmp_path, "SSE")
+    handlers = _capture_signal_handlers(srv, monkeypatch)
+    srv.close = Mock()
+
+    with pytest.raises(SystemExit) as excinfo:
+        handlers[signal.SIGTERM](signal.SIGTERM, None)
+
+    assert excinfo.value.code == 0
+    srv.close.assert_called_once()
+
+
+def test_stdio_shutdown_does_not_abort_at_interpreter_finalization(tmp_path):
+    """End-to-end guard against the SIGABRT regression.
+
+    Reproduces the shape mcp.server.stdio creates -- a second TextIOWrapper over
+    sys.stdin.buffer, read from a worker thread, so the shared BufferedReader
+    lock is held -- then signals the process. With _exit_without_finalization the
+    process exits 0. If shutdown goes back to raising SystemExit, CPython cannot
+    close sys.stdin at finalization and aborts with SIGABRT (-6 / 134).
+    """
+    script = textwrap.dedent(
+        """
+        import io, os, signal, sys, threading, time
+        from proxmox_mcp.server import _exit_without_finalization
+
+        signal.signal(signal.SIGTERM, lambda *_: _exit_without_finalization())
+
+        worker_view = io.TextIOWrapper(sys.stdin.buffer, encoding="utf-8", errors="replace")
+        threading.Thread(target=worker_view.readline, daemon=True).start()
+        time.sleep(0.2)
+        os.kill(os.getpid(), signal.SIGTERM)
+        time.sleep(10)
+        """
+    )
+    src_dir = os.path.dirname(os.path.dirname(os.path.abspath(server_module.__file__)))
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(filter(None, [src_dir, env.get("PYTHONPATH", "")]))
+
+    proc = subprocess.Popen(
+        [sys.executable, "-c", script],
+        stdin=subprocess.PIPE,      # stays open and empty: the read never completes
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+    try:
+        _, stderr = proc.communicate(timeout=30)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        raise
+
+    assert proc.returncode == 0, (
+        f"shutdown aborted instead of exiting cleanly "
+        f"(returncode={proc.returncode}): {stderr.decode(errors='replace')}"
+    )


### PR DESCRIPTION
Fixes #112.

Under the STDIO transport the server aborts with `SIGABRT` on shutdown instead of exiting cleanly:

```
Fatal Python error: _enter_buffered_busy: could not acquire lock for
<_io.BufferedReader name='<stdin>'> at interpreter shutdown, possibly due to
daemon threads
```

## Cause

`ProxmoxMCPServer.start()` handled SIGINT/SIGTERM with `sys.exit(0)`, which starts interpreter finalization while the MCP SDK can still have an AnyIO worker blocked in `readline()` through a second `TextIOWrapper` over `sys.stdin.buffer`. Finalization then tries to close the same buffered reader and CPython aborts.

## Change

- Add `_exit_without_finalization()`, which calls `os._exit(status)` for STDIO shutdown after application resources are closed.
- Intentionally do **not** flush stdout/stderr in this path. The SDK can also have a worker blocked while holding the shared stdout buffer lock; flushing from the signal handler could deadlock before `os._exit()`.
- Use `try/finally` so a cleanup exception cannot fall back to unsafe interpreter finalization.
- Scope the forced exit to STDIO. SSE and STREAMABLE retain their existing `SystemExit` shutdown behavior.

## Tests

Regression coverage in `tests/test_server.py` verifies:

- SIGINT and SIGTERM route through cleanup and then the no-finalization helper, in that order.
- Cleanup errors still reach the forced-exit path.
- The forced-exit helper never flushes shared standard streams.
- SSE and STREAMABLE keep normal `SystemExit` behavior.
- A POSIX subprocess keeps stdin open, waits for a READY handshake while the reader thread is blocked, then receives SIGTERM and exits 0 without `Fatal Python error` or `_enter_buffered_busy`.
- The POSIX signal-delivery test is skipped on Windows, where `os.kill(..., SIGTERM)` uses `TerminateProcess` rather than invoking Python's handler.

## Verification

- Original contributor reproduced and fixed the crash on CPython 3.13.14 and 3.14.6 and validated against a live Proxmox VE cluster.
- Maintainer hardening was additionally validated on Windows for routing/cleanup behavior; Linux Python 3.11/3.12 validation is performed by this PR's CI matrix.

A standalone stdlib reproduction remains in the linked issue.
