### PR TITLE
feat: add inspection tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Start with read-only discovery, then move to mutating tools only after the targe
 | Roll back risky changes | `list_snapshots` with `vm_type=qemu` or `vm_type=lxc` | `create_snapshot`, `rollback_snapshot`, `delete_snapshot` | Create a snapshot before destructive workflow tests |
 | Run commands inside guests | VM or container status tools | `execute_vm_command`, `execute_container_command` | VM path needs QEMU Guest Agent; LXC path needs SSH to the Proxmox node |
 | Track async work | mutation response with `job_id` | `poll_job`, `get_job`, `list_jobs`, `retry_job`, `cancel_job` | Use `job_id` for agent/user conversations and `task_id` for raw Proxmox traceability |
+| Inspect logs | `get_node_syslog`, `get_cluster_log` | `get_task_log`, `get_node_firewall_log`, `get_guest_firewall_log` | All log tools are read-only; `get_task_log` accepts any Proxmox `UPID` |
 | Automate from HTTP tools | `/openapi.json` | `/jobs`, `/health`, generated tool routes | Use bearer auth and keep CORS restricted outside local development |
 
 For the full tool map, see the [Tool Selection Guide](docs/wiki/Tool%20Selection%20Guide.md) and [API & Tool Reference](docs/wiki/API%20%26%20Tool%20Reference.md).

--- a/docs/wiki/API & Tool Reference.md
+++ b/docs/wiki/API & Tool Reference.md
@@ -214,6 +214,23 @@ Selector-based tools fail when no container matches the selector or when a bulk 
 | `get_storage` | Read-only | none | none | Proxmox API reachable | auth failure, cluster query failure |
 | `get_cluster_status` | Read-only | none | none | Proxmox API reachable | auth failure, cluster query failure |
 
+## Log Inspection Tools
+
+| Tool | Mode | Required Inputs | Optional Inputs | Prerequisites | Common Failures |
+| --- | --- | --- | --- | --- | --- |
+| `get_node_syslog` | Read-only | `node` | `limit=100`, `start`, `since`, `until`, `service` | target node exists | unknown node, auth failure |
+| `get_task_log` | Read-only | `node`, `upid` | `start`, `limit=50` | task exists on the node | unknown `upid`, node mismatch |
+| `get_cluster_log` | Read-only | none | `max_entries=50` | Proxmox API reachable | auth failure, cluster query failure |
+| `get_node_firewall_log` | Read-only | `node` | `limit=100`, `start`, `since`, `until` | target node exists | unknown node, firewall logging disabled yields few or no entries |
+| `get_guest_firewall_log` | Read-only | `node`, `vmid` | `vm_type=qemu\|lxc`, `limit=100`, `start`, `since`, `until` | guest exists on the node | unknown guest, wrong `vm_type`, guest firewall logging disabled |
+
+### Log Inspection Notes
+
+- All tools in this group are read-only and never modify Proxmox state.
+- `get_node_syslog.since`/`until` take date/time strings (`YYYY-MM-DD[ HH:MM[:SS]]`); the firewall variants take UNIX epoch integers.
+- `get_task_log` accepts any Proxmox task `UPID` (for example the Task ID returned by mutating tools), while `poll_job` operates on the persistent job records created by this server's mutating tools.
+- Log content is returned as-is from Proxmox and may include sensitive operational details; scope API token permissions accordingly.
+
 ## Change Checklist For New Tools
 
 When adding or changing a tool, update all of the following:

--- a/docs/wiki/Tool Selection Guide.md
+++ b/docs/wiki/Tool Selection Guide.md
@@ -14,6 +14,7 @@ Run read-only tools before mutating anything:
 | Check storage | `get_storage` |
 | Check snapshots | `list_snapshots` with `vm_type=qemu` or `vm_type=lxc` |
 | Check jobs | `list_jobs`, `get_job` |
+| Check logs | `get_node_syslog`, `get_cluster_log` |
 
 Discovery confirms node names, VMIDs, storage IDs, guest status, and whether the tool is visible in the connected client.
 
@@ -88,6 +89,19 @@ Use the job tools this way:
 | A running task should stop | `cancel_job` |
 
 Keep `jobs.sqlite_path` on durable storage when the deployment should preserve job history across restarts.
+
+## Log Inspection Workflows
+
+All log tools are read-only and safe to run at any time:
+
+| Operator goal | Tool sequence | Verify |
+| --- | --- | --- |
+| Investigate a node problem | `get_node_syslog` with `since`/`until` filters | narrowed log window around the incident |
+| Find out why a task failed | `get_task_log` with the task's `UPID` | task log output and exit status lines |
+| Audit recent cluster activity | `get_cluster_log` | cluster-wide event history |
+| Debug firewall behavior | `get_node_firewall_log` or `get_guest_firewall_log` | ACCEPT/DROP entries for the traffic in question |
+
+`get_task_log` accepts any Proxmox task `UPID`, including tasks started outside this server. Use `poll_job` instead when you are tracking a `job_id` created by a mutating tool.
 
 ## OpenAPI Workflows
 

--- a/manifest.json
+++ b/manifest.json
@@ -269,6 +269,26 @@
         {
             "name": "delete_backup",
             "description": "Delete a specific backup"
+        },
+        {
+            "name": "get_node_syslog",
+            "description": "Read syslog entries from a Proxmox node"
+        },
+        {
+            "name": "get_task_log",
+            "description": "Get the log output of a specific Proxmox task by its UPID"
+        },
+        {
+            "name": "get_cluster_log",
+            "description": "Read recent cluster-wide log entries"
+        },
+        {
+            "name": "get_node_firewall_log",
+            "description": "Read the host firewall log of a Proxmox node"
+        },
+        {
+            "name": "get_guest_firewall_log",
+            "description": "Read the firewall log of a VM (qemu) or container (lxc)"
         }
     ],
     "keywords": [

--- a/src/proxmox_mcp/server.py
+++ b/src/proxmox_mcp/server.py
@@ -25,6 +25,7 @@ from proxmox_mcp.services.builtin_tool_plugins import (
     CoreToolsPlugin,
     ImageToolsPlugin,
     JobsToolsPlugin,
+    LogToolsPlugin,
     SnapshotToolsPlugin,
     VMToolsPlugin,
 )
@@ -33,6 +34,7 @@ from proxmox_mcp.tools.cluster import ClusterTools
 from proxmox_mcp.tools.containers import ContainerTools
 from proxmox_mcp.tools.iso import ISOTools
 from proxmox_mcp.tools.jobs import JobsTools
+from proxmox_mcp.tools.logs import LogTools
 from proxmox_mcp.tools.node import NodeTools
 from proxmox_mcp.tools.snapshots import SnapshotTools
 from proxmox_mcp.tools.storage import StorageTools
@@ -88,6 +90,7 @@ class ProxmoxMCPServer:
         self.iso_tools = ISOTools(self.proxmox, metrics=self.metrics, job_store=self.job_store)
         self.backup_tools = BackupTools(self.proxmox, metrics=self.metrics, job_store=self.job_store)
         self.jobs_tools = JobsTools(self.job_store)
+        self.log_tools = LogTools(self.proxmox, metrics=self.metrics, job_store=self.job_store)
 
         log_level = cast(
             Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
@@ -146,6 +149,7 @@ class ProxmoxMCPServer:
         self.tool_registry.add(SnapshotToolsPlugin())
         self.tool_registry.add(ImageToolsPlugin())
         self.tool_registry.add(BackupToolsPlugin())
+        self.tool_registry.add(LogToolsPlugin())
         self.tool_registry.register_all(self)
 
     def close(self) -> None:

--- a/src/proxmox_mcp/services/__init__.py
+++ b/src/proxmox_mcp/services/__init__.py
@@ -8,6 +8,7 @@ from .builtin_tool_plugins import (
     CoreToolsPlugin,
     ImageToolsPlugin,
     JobsToolsPlugin,
+    LogToolsPlugin,
     SnapshotToolsPlugin,
     VMToolsPlugin,
 )
@@ -23,4 +24,5 @@ __all__ = [
     "SnapshotToolsPlugin",
     "ImageToolsPlugin",
     "BackupToolsPlugin",
+    "LogToolsPlugin",
 ]

--- a/src/proxmox_mcp/services/builtin_tool_plugins.py
+++ b/src/proxmox_mcp/services/builtin_tool_plugins.py
@@ -23,13 +23,18 @@ from proxmox_mcp.tools.definitions import (
     EXECUTE_CONTAINER_COMMAND_DESC,
     EXECUTE_VM_COMMAND_DESC,
     GET_JOB_DESC,
+    GET_CLUSTER_LOG_DESC,
     GET_CLUSTER_STATUS_DESC,
     GET_CONTAINER_CONFIG_DESC,
     GET_CONTAINER_IP_DESC,
     GET_CONTAINERS_DESC,
+    GET_GUEST_FIREWALL_LOG_DESC,
+    GET_NODE_FIREWALL_LOG_DESC,
     GET_NODES_DESC,
     GET_NODE_STATUS_DESC,
+    GET_NODE_SYSLOG_DESC,
     GET_STORAGE_DESC,
+    GET_TASK_LOG_DESC,
     GET_VMS_DESC,
     GET_VM_CONFIG_DESC,
     LIST_JOBS_DESC,
@@ -768,4 +773,134 @@ class BackupToolsPlugin(RegistryPluginBase):
                 storage=storage,
                 volid=volid,
                 approval_token=approval_token,
+            )
+
+
+class LogToolsPlugin(RegistryPluginBase):
+    """Registers read-only log tools: node syslog, task log, cluster log,
+    and node/guest firewall logs."""
+
+    def register(self, server: Any) -> None:
+        @server.mcp.tool(description=GET_NODE_SYSLOG_DESC)
+        def get_node_syslog(
+            node: Annotated[str, Field(description="Node name (e.g. 'pve', 'pve1')")],
+            limit: Annotated[
+                int,
+                Field(description="Maximum number of log lines to return", ge=1, le=1000, default=100),
+            ] = 100,
+            start: Annotated[
+                Optional[int],
+                Field(description="Start line for pagination (0-based)", ge=0, default=None),
+            ] = None,
+            since: Annotated[
+                Optional[str],
+                Field(
+                    description="Show entries from this date/time onward "
+                    "(YYYY-MM-DD or YYYY-MM-DD HH:MM or YYYY-MM-DD HH:MM:SS)",
+                    default=None,
+                ),
+            ] = None,
+            until: Annotated[
+                Optional[str],
+                Field(
+                    description="Show entries up to this date/time (same format as since)",
+                    default=None,
+                ),
+            ] = None,
+            service: Annotated[
+                Optional[str],
+                Field(description="Filter by service name (e.g. 'pvedaemon', 'pveproxy')", default=None),
+            ] = None,
+        ) -> Any:
+            return self._wrap_sync(server, "get_node_syslog", server.log_tools.get_node_syslog)(
+                node=node, limit=limit, start=start, since=since, until=until, service=service
+            )
+
+        @server.mcp.tool(description=GET_TASK_LOG_DESC)
+        def get_task_log(
+            node: Annotated[str, Field(description="Node name that ran the task (e.g. 'pve')")],
+            upid: Annotated[str, Field(description="Unique Process ID (UPID) of the task")],
+            start: Annotated[
+                Optional[int],
+                Field(description="Start line for pagination (0-based)", ge=0, default=None),
+            ] = None,
+            limit: Annotated[
+                int,
+                Field(description="Maximum number of log lines to return", ge=1, le=500, default=50),
+            ] = 50,
+        ) -> Any:
+            return self._wrap_sync(server, "get_task_log", server.log_tools.get_task_log)(
+                node=node, upid=upid, start=start, limit=limit
+            )
+
+        @server.mcp.tool(description=GET_CLUSTER_LOG_DESC)
+        def get_cluster_log(
+            max_entries: Annotated[
+                int,
+                Field(description="Maximum number of cluster log entries to return", ge=1, le=1000, default=50),
+            ] = 50,
+        ) -> Any:
+            return self._wrap_sync(server, "get_cluster_log", server.log_tools.get_cluster_log)(
+                max_entries=max_entries
+            )
+
+        @server.mcp.tool(description=GET_NODE_FIREWALL_LOG_DESC)
+        def get_node_firewall_log(
+            node: Annotated[str, Field(description="Node name (e.g. 'pve', 'pve1')")],
+            limit: Annotated[
+                int,
+                Field(description="Maximum number of log lines to return", ge=1, le=1000, default=100),
+            ] = 100,
+            start: Annotated[
+                Optional[int],
+                Field(description="Start line for pagination (0-based)", ge=0, default=None),
+            ] = None,
+            since: Annotated[
+                Optional[int],
+                Field(description="Show entries since this UNIX epoch timestamp", default=None),
+            ] = None,
+            until: Annotated[
+                Optional[int],
+                Field(description="Show entries until this UNIX epoch timestamp", default=None),
+            ] = None,
+        ) -> Any:
+            return self._wrap_sync(
+                server, "get_node_firewall_log", server.log_tools.get_node_firewall_log
+            )(node=node, limit=limit, start=start, since=since, until=until)
+
+        @server.mcp.tool(description=GET_GUEST_FIREWALL_LOG_DESC)
+        def get_guest_firewall_log(
+            node: Annotated[str, Field(description="Node hosting the guest (e.g. 'pve')")],
+            vmid: Annotated[int, Field(description="VM/container ID (e.g. 100)", ge=100)],
+            vm_type: Annotated[
+                Literal["qemu", "lxc"],
+                Field(description="Guest type: 'qemu' (VM, default) or 'lxc' (container)", default="qemu"),
+            ] = "qemu",
+            limit: Annotated[
+                int,
+                Field(description="Maximum number of log lines to return", ge=1, le=1000, default=100),
+            ] = 100,
+            start: Annotated[
+                Optional[int],
+                Field(description="Start line for pagination (0-based)", ge=0, default=None),
+            ] = None,
+            since: Annotated[
+                Optional[int],
+                Field(description="Show entries since this UNIX epoch timestamp", default=None),
+            ] = None,
+            until: Annotated[
+                Optional[int],
+                Field(description="Show entries until this UNIX epoch timestamp", default=None),
+            ] = None,
+        ) -> Any:
+            return self._wrap_sync(
+                server, "get_guest_firewall_log", server.log_tools.get_guest_firewall_log
+            )(
+                node=node,
+                vmid=vmid,
+                vm_type=vm_type,
+                limit=limit,
+                start=start,
+                since=since,
+                until=until,
             )

--- a/src/proxmox_mcp/tools/definitions.py
+++ b/src/proxmox_mcp/tools/definitions.py
@@ -488,3 +488,71 @@ mode         - 'append' (default) or 'replace'
 Returns:
 {"success": true, "keys_added": 1}
 """
+
+# Log tool descriptions
+GET_NODE_SYSLOG_DESC = """Read syslog entries from a Proxmox node.
+
+Parameters:
+node*   - Node name (e.g. 'pve', 'pve1')
+limit   - Maximum number of log lines to return (default: 100, max: 1000)
+start   - Start line for pagination (0-based, optional)
+since   - Show entries from this date/time onward
+          (format: YYYY-MM-DD or YYYY-MM-DD HH:MM or YYYY-MM-DD HH:MM:SS, optional)
+until   - Show entries up to this date/time (same format as since, optional)
+service - Filter by service name (e.g. 'pvedaemon', 'pveproxy', optional)
+
+Example:
+get_node_syslog node='pve' limit=50 service='pvedaemon'
+"""
+
+GET_TASK_LOG_DESC = """Get the log output of a specific Proxmox task by its UPID.
+
+Parameters:
+node*  - Node name that ran the task (e.g. 'pve')
+upid*  - Unique Process ID of the task (e.g. the Task ID returned by
+         VM/container operations or list_jobs)
+start  - Start line for pagination (0-based, optional)
+limit  - Maximum number of log lines to return (default: 50, max: 500)
+
+Example:
+get_task_log node='pve' upid='UPID:pve:00001234:...' limit=100
+"""
+
+GET_CLUSTER_LOG_DESC = """Read recent cluster-wide log entries.
+
+Parameters:
+max_entries - Maximum number of entries to return (default: 50, max: 1000)
+
+Each entry includes: time, node, user, tag (service), pri (priority), msg.
+
+Example:
+get_cluster_log max_entries=100
+"""
+
+GET_NODE_FIREWALL_LOG_DESC = """Read the host firewall log of a Proxmox node.
+
+Parameters:
+node*  - Node name (e.g. 'pve', 'pve1')
+limit  - Maximum number of log lines to return (default: 100, max: 1000)
+start  - Start line for pagination (0-based, optional)
+since  - Show entries since this UNIX epoch timestamp (optional)
+until  - Show entries until this UNIX epoch timestamp (optional)
+
+Example:
+get_node_firewall_log node='pve' limit=50
+"""
+
+GET_GUEST_FIREWALL_LOG_DESC = """Read the firewall log of a VM (qemu) or container (lxc).
+
+Parameters:
+node*   - Node hosting the guest (e.g. 'pve')
+vmid*   - VM/container ID (e.g. 100)
+vm_type - Guest type: 'qemu' (default) or 'lxc'
+limit   - Maximum number of log lines to return (default: 100, max: 1000)
+start   - Start line for pagination (0-based, optional)
+since   - Show entries since this UNIX epoch timestamp (optional)
+until   - Show entries until this UNIX epoch timestamp (optional)
+
+Example:
+get_guest_firewall_log node='pve' vmid=100 vm_type='qemu' limit=50
+"""

--- a/src/proxmox_mcp/tools/logs.py
+++ b/src/proxmox_mcp/tools/logs.py
@@ -1,0 +1,278 @@
+"""
+Log tools for Proxmox MCP.
+
+Provides MCP tools for reading Proxmox logs:
+- Node syslog   (GET /nodes/{node}/syslog)
+- Task log      (GET /nodes/{node}/tasks/{upid}/log)
+- Cluster log   (GET /cluster/log)
+- Node firewall log  (GET /nodes/{node}/firewall/log)
+- Guest firewall log (GET /nodes/{node}/{qemu|lxc}/{vmid}/firewall/log)
+
+API reference: https://pve.proxmox.com/pve-docs/api-viewer/
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from mcp.types import TextContent as Content
+
+from proxmox_mcp.tools.base import ProxmoxTool
+
+
+def _build_params(**kwargs: Any) -> Dict[str, Any]:
+    """Return a dict of kwargs with None values removed.
+
+    The Proxmox REST API rejects unknown/null parameters, so we only
+    forward values the caller actually supplied.
+    """
+    return {k: v for k, v in kwargs.items() if v is not None}
+
+
+class LogTools(ProxmoxTool):
+    """Tools for reading Proxmox node logs and task output."""
+
+    # ------------------------------------------------------------------
+    # Syslog  —  GET /nodes/{node}/syslog
+    # API params: limit (int), start (int), since (str YYYY-MM-DD[ HH:MM[:SS]]),
+    #             until (str), service (str)
+    # Returns: [{n: int, t: str}]
+    # ------------------------------------------------------------------
+
+    def get_node_syslog(
+        self,
+        node: str,
+        limit: int = 100,
+        start: Optional[int] = None,
+        since: Optional[str] = None,
+        until: Optional[str] = None,
+        service: Optional[str] = None,
+    ) -> List[Content]:
+        """Read syslog entries from a Proxmox node.
+
+        Args:
+            node:    Node name (e.g. 'pve').
+            limit:   Maximum number of lines to return (default 100).
+            start:   Start line for pagination (0-based).
+            since:   Show entries from this date/time onward
+                     (format: YYYY-MM-DD or YYYY-MM-DD HH:MM or YYYY-MM-DD HH:MM:SS).
+            until:   Show entries up to this date/time (same format as since).
+            service: Filter by service name (e.g. 'pvedaemon', 'pveproxy').
+
+        Returns:
+            List of MCP Content objects with plain-text log lines.
+        """
+        try:
+            params = _build_params(
+                limit=limit, start=start, since=since, until=until, service=service
+            )
+            raw = self.proxmox.nodes(node).syslog.get(**params)
+            return [Content(type="text", text=self._format_log_entries(raw, "syslog", node))]
+        except Exception as e:
+            self._handle_error(f"get syslog for node {node}", e)
+
+    # ------------------------------------------------------------------
+    # Task log  —  GET /nodes/{node}/tasks/{upid}/log
+    # API params: start (int, 0-based), limit (int, default 50)
+    # Returns: [{n: int, t: str}]
+    # ------------------------------------------------------------------
+
+    def get_task_log(
+        self,
+        node: str,
+        upid: str,
+        start: Optional[int] = None,
+        limit: int = 50,
+    ) -> List[Content]:
+        """Get the log output of a specific Proxmox task.
+
+        Args:
+            node:  Node that ran the task.
+            upid:  Unique Process ID of the task.
+            start: Start line for pagination (0-based).
+            limit: Maximum number of log lines (default 50).
+
+        Returns:
+            List of MCP Content objects with plain-text task log.
+        """
+        try:
+            params = _build_params(start=start, limit=limit)
+            raw = self.proxmox.nodes(node).tasks(upid).log.get(**params)
+            return [Content(type="text", text=self._format_task_log(raw, upid))]
+        except Exception as e:
+            self._handle_error(f"get log for task {upid} on node {node}", e)
+
+    # ------------------------------------------------------------------
+    # Cluster log  —  GET /cluster/log
+    # API params: max (int, >= 1)
+    # Returns: [{node, user, time (epoch), pri, tag, pid, uid, msg}]
+    # ------------------------------------------------------------------
+
+    def get_cluster_log(self, max_entries: int = 50) -> List[Content]:
+        """Read recent cluster-wide log entries.
+
+        Args:
+            max_entries: Maximum number of entries to return (API param 'max').
+
+        Returns:
+            List of MCP Content objects with plain-text cluster log lines.
+        """
+        try:
+            params = _build_params(max=max_entries)
+            raw = self.proxmox.cluster.log.get(**params)
+            return [Content(type="text", text=self._format_cluster_log(raw))]
+        except Exception as e:
+            self._handle_error("get cluster log", e)
+
+    # ------------------------------------------------------------------
+    # Node firewall log  —  GET /nodes/{node}/firewall/log
+    # API params: limit (int), start (int), since (int epoch), until (int epoch)
+    # Returns: [{n: int, t: str}]
+    # ------------------------------------------------------------------
+
+    def get_node_firewall_log(
+        self,
+        node: str,
+        limit: int = 100,
+        start: Optional[int] = None,
+        since: Optional[int] = None,
+        until: Optional[int] = None,
+    ) -> List[Content]:
+        """Read the host firewall log of a Proxmox node.
+
+        Args:
+            node:  Node name (e.g. 'pve').
+            limit: Maximum number of log lines (default 100).
+            start: Start line for pagination (0-based).
+            since: Show entries since this UNIX epoch timestamp.
+            until: Show entries until this UNIX epoch timestamp.
+
+        Returns:
+            List of MCP Content objects with plain-text firewall log lines.
+        """
+        try:
+            params = _build_params(limit=limit, start=start, since=since, until=until)
+            raw = self.proxmox.nodes(node).firewall.log.get(**params)
+            return [Content(type="text", text=self._format_log_entries(raw, "firewall log", node))]
+        except Exception as e:
+            self._handle_error(f"get firewall log for node {node}", e)
+
+    # ------------------------------------------------------------------
+    # Guest firewall log
+    #   GET /nodes/{node}/qemu/{vmid}/firewall/log
+    #   GET /nodes/{node}/lxc/{vmid}/firewall/log
+    # API params: limit (int), start (int), since (int epoch), until (int epoch)
+    # Returns: [{n: int, t: str}]
+    # ------------------------------------------------------------------
+
+    def get_guest_firewall_log(
+        self,
+        node: str,
+        vmid: int,
+        vm_type: str = "qemu",
+        limit: int = 100,
+        start: Optional[int] = None,
+        since: Optional[int] = None,
+        until: Optional[int] = None,
+    ) -> List[Content]:
+        """Read the firewall log of a VM (qemu) or container (lxc).
+
+        Args:
+            node:    Node hosting the guest.
+            vmid:    VM/container ID.
+            vm_type: Guest type: 'qemu' (default) or 'lxc'.
+            limit:   Maximum number of log lines (default 100).
+            start:   Start line for pagination (0-based).
+            since:   Show entries since this UNIX epoch timestamp.
+            until:   Show entries until this UNIX epoch timestamp.
+
+        Returns:
+            List of MCP Content objects with plain-text firewall log lines.
+        """
+        try:
+            if vm_type not in ("qemu", "lxc"):
+                raise ValueError(f"Invalid vm_type '{vm_type}'. Must be 'qemu' or 'lxc'.")
+            params = _build_params(limit=limit, start=start, since=since, until=until)
+            guest_api = getattr(self.proxmox.nodes(node), vm_type)(vmid)
+            raw = guest_api.firewall.log.get(**params)
+            label = f"firewall log ({vm_type} {vmid})"
+            return [Content(type="text", text=self._format_log_entries(raw, label, node))]
+        except Exception as e:
+            self._handle_error(f"get firewall log for {vm_type} {vmid} on node {node}", e)
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _format_log_entries(self, raw: Any, log_type: str, node: str) -> str:
+        """Render a log API response as readable plain text.
+
+        Syslog and firewall log endpoints return ``[{"n": int, "t": str}]``;
+        plain string lists are handled too.
+        """
+        if not raw:
+            return f"No {log_type} entries found for node '{node}'."
+
+        lines: list[str] = [f"=== {log_type} for node '{node}' ({len(raw)} entries) ===\n"]
+
+        for entry in raw:
+            if isinstance(entry, str):
+                lines.append(entry)
+            elif isinstance(entry, dict):
+                # syslog: {"n": line_number, "t": "log line text"}
+                text = entry.get("t") or entry.get("message") or json.dumps(entry, default=str)
+                lines.append(str(text))
+            else:
+                lines.append(str(entry))
+
+        return "\n".join(lines)
+
+    def _format_cluster_log(self, raw: Any) -> str:
+        """Render a cluster log API response as readable plain text.
+
+        Entries look like ``{node, user, time (epoch), pri, tag, pid, uid, msg}``.
+        """
+        if not raw:
+            return "No cluster log entries found."
+
+        lines: list[str] = [f"=== cluster log ({len(raw)} entries) ===\n"]
+
+        for entry in raw:
+            if isinstance(entry, dict):
+                time_val = entry.get("time")
+                if isinstance(time_val, (int, float)):
+                    stamp = datetime.fromtimestamp(time_val, tz=timezone.utc).strftime(
+                        "%Y-%m-%d %H:%M:%S"
+                    )
+                else:
+                    stamp = str(time_val or "?")
+                node = entry.get("node", "?")
+                user = entry.get("user", "?")
+                tag = entry.get("tag", "?")
+                msg = entry.get("msg", json.dumps(entry, default=str))
+                lines.append(f"[{stamp}] {node} {user} {tag}: {msg}")
+            else:
+                lines.append(str(entry))
+
+        return "\n".join(lines)
+
+    def _format_task_log(self, raw: Any, upid: str) -> str:
+        """Render a task log API response as readable plain text.
+
+        The task log endpoint returns ``[{"n": int, "t": str}]``.
+        """
+        if not raw:
+            return f"No log entries found for task '{upid}'."
+
+        lines: list[str] = [f"=== Task log for {upid} ({len(raw)} lines) ===\n"]
+
+        for entry in raw:
+            if isinstance(entry, str):
+                lines.append(entry)
+            elif isinstance(entry, dict):
+                lines.append(str(entry.get("t", json.dumps(entry, default=str))))
+            else:
+                lines.append(str(entry))
+
+        return "\n".join(lines)

--- a/tests/test_log_tools.py
+++ b/tests/test_log_tools.py
@@ -1,0 +1,439 @@
+"""Unit tests for LogTools.
+
+Follows the same pattern as test_tool_user_paths.py:
+- Build a Mock() proxmox API object
+- Instantiate LogTools directly
+- Assert return type, content, and which API endpoint was called
+- Assert optional params are omitted when not provided (not forwarded as None)
+"""
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from proxmox_mcp.tools.logs import LogTools
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_tools(proxmox: Mock | None = None) -> LogTools:
+    """Return a LogTools instance backed by a Mock Proxmox API."""
+    return LogTools(proxmox or Mock())
+
+
+def _node_api(proxmox: Mock) -> Mock:
+    """Return the mock for the node-scoped API (proxmox.nodes(...))."""
+    return proxmox.nodes.return_value
+
+
+# ---------------------------------------------------------------------------
+# get_node_syslog
+# ---------------------------------------------------------------------------
+
+class TestGetNodeSyslog:
+    def test_returns_content_list(self):
+        proxmox = Mock()
+        _node_api(proxmox).syslog.get.return_value = [
+            {"n": 1, "t": "Jun  1 10:00:01 pve pvedaemon: task started"},
+        ]
+        result = _make_tools(proxmox).get_node_syslog("pve")
+
+        assert len(result) == 1
+        assert result[0].type == "text"
+
+    def test_output_contains_log_line(self):
+        proxmox = Mock()
+        _node_api(proxmox).syslog.get.return_value = [
+            {"n": 1, "t": "pvedaemon: task started"},
+            {"n": 2, "t": "pveproxy: connection from 10.0.0.1"},
+        ]
+        result = _make_tools(proxmox).get_node_syslog("pve")
+
+        assert "pvedaemon: task started" in result[0].text
+        assert "pveproxy: connection from 10.0.0.1" in result[0].text
+
+    def test_header_contains_node_name(self):
+        proxmox = Mock()
+        _node_api(proxmox).syslog.get.return_value = [{"n": 1, "t": "line"}]
+        result = _make_tools(proxmox).get_node_syslog("pve1")
+
+        assert "pve1" in result[0].text
+
+    def test_default_limit_forwarded(self):
+        proxmox = Mock()
+        _node_api(proxmox).syslog.get.return_value = []
+        _make_tools(proxmox).get_node_syslog("pve")
+
+        proxmox.nodes.assert_called_once_with("pve")
+        call_kwargs = _node_api(proxmox).syslog.get.call_args.kwargs
+        assert call_kwargs["limit"] == 100
+
+    def test_custom_limit_forwarded(self):
+        proxmox = Mock()
+        _node_api(proxmox).syslog.get.return_value = []
+        _make_tools(proxmox).get_node_syslog("pve", limit=25)
+
+        call_kwargs = _node_api(proxmox).syslog.get.call_args.kwargs
+        assert call_kwargs["limit"] == 25
+
+    def test_none_optional_params_not_forwarded(self):
+        """start, since, until, service must not appear in the API call when None."""
+        proxmox = Mock()
+        _node_api(proxmox).syslog.get.return_value = []
+        _make_tools(proxmox).get_node_syslog("pve")
+
+        call_kwargs = _node_api(proxmox).syslog.get.call_args.kwargs
+        assert "start" not in call_kwargs
+        assert "since" not in call_kwargs
+        assert "until" not in call_kwargs
+        assert "service" not in call_kwargs
+
+    def test_optional_params_forwarded_when_supplied(self):
+        proxmox = Mock()
+        _node_api(proxmox).syslog.get.return_value = []
+        _make_tools(proxmox).get_node_syslog(
+            "pve", start=10, since="2024-01-01", until="2024-01-31", service="pvedaemon"
+        )
+
+        call_kwargs = _node_api(proxmox).syslog.get.call_args.kwargs
+        assert call_kwargs["start"] == 10
+        assert call_kwargs["since"] == "2024-01-01"
+        assert call_kwargs["until"] == "2024-01-31"
+        assert call_kwargs["service"] == "pvedaemon"
+
+    def test_empty_response_returns_message(self):
+        proxmox = Mock()
+        _node_api(proxmox).syslog.get.return_value = []
+        result = _make_tools(proxmox).get_node_syslog("pve")
+
+        assert "No syslog entries" in result[0].text
+        assert "pve" in result[0].text
+
+    def test_string_entries_rendered_directly(self):
+        """Syslog entries that are plain strings (not dicts) should render fine."""
+        proxmox = Mock()
+        _node_api(proxmox).syslog.get.return_value = ["raw log line"]
+        result = _make_tools(proxmox).get_node_syslog("pve")
+
+        assert "raw log line" in result[0].text
+
+    def test_api_error_propagates(self):
+        proxmox = Mock()
+        _node_api(proxmox).syslog.get.side_effect = RuntimeError("connection refused")
+
+        with pytest.raises(RuntimeError, match="connection refused"):
+            _make_tools(proxmox).get_node_syslog("pve")
+
+
+# ---------------------------------------------------------------------------
+# get_task_log
+# ---------------------------------------------------------------------------
+
+class TestGetTaskLog:
+    _upid = "UPID:pve:00001234:qmstart:100:root@pam:"
+    _sample_log = [
+        {"n": 1, "t": "starting task"},
+        {"n": 2, "t": "task finished successfully"},
+    ]
+
+    def test_returns_content_list(self):
+        proxmox = Mock()
+        proxmox.nodes.return_value.tasks.return_value.log.get.return_value = self._sample_log
+        result = _make_tools(proxmox).get_task_log("pve", self._upid)
+
+        assert len(result) == 1
+        assert result[0].type == "text"
+
+    def test_output_contains_log_lines(self):
+        proxmox = Mock()
+        proxmox.nodes.return_value.tasks.return_value.log.get.return_value = self._sample_log
+        result = _make_tools(proxmox).get_task_log("pve", self._upid)
+
+        assert "starting task" in result[0].text
+        assert "task finished successfully" in result[0].text
+
+    def test_header_contains_upid(self):
+        proxmox = Mock()
+        proxmox.nodes.return_value.tasks.return_value.log.get.return_value = self._sample_log
+        result = _make_tools(proxmox).get_task_log("pve", self._upid)
+
+        assert self._upid in result[0].text
+
+    def test_default_limit_forwarded(self):
+        proxmox = Mock()
+        proxmox.nodes.return_value.tasks.return_value.log.get.return_value = []
+        _make_tools(proxmox).get_task_log("pve", self._upid)
+
+        call_kwargs = proxmox.nodes.return_value.tasks.return_value.log.get.call_args.kwargs
+        assert call_kwargs["limit"] == 50
+
+    def test_start_param_not_forwarded_when_none(self):
+        proxmox = Mock()
+        proxmox.nodes.return_value.tasks.return_value.log.get.return_value = []
+        _make_tools(proxmox).get_task_log("pve", self._upid)
+
+        call_kwargs = proxmox.nodes.return_value.tasks.return_value.log.get.call_args.kwargs
+        assert "start" not in call_kwargs
+
+    def test_start_and_limit_forwarded_when_supplied(self):
+        proxmox = Mock()
+        proxmox.nodes.return_value.tasks.return_value.log.get.return_value = []
+        _make_tools(proxmox).get_task_log("pve", self._upid, start=100, limit=25)
+
+        call_kwargs = proxmox.nodes.return_value.tasks.return_value.log.get.call_args.kwargs
+        assert call_kwargs["start"] == 100
+        assert call_kwargs["limit"] == 25
+
+    def test_correct_node_and_upid_passed(self):
+        proxmox = Mock()
+        proxmox.nodes.return_value.tasks.return_value.log.get.return_value = []
+        _make_tools(proxmox).get_task_log("pve", self._upid)
+
+        proxmox.nodes.assert_called_once_with("pve")
+        proxmox.nodes.return_value.tasks.assert_called_once_with(self._upid)
+
+    def test_empty_response_returns_message(self):
+        proxmox = Mock()
+        proxmox.nodes.return_value.tasks.return_value.log.get.return_value = []
+        result = _make_tools(proxmox).get_task_log("pve", self._upid)
+
+        assert "No log entries" in result[0].text
+        assert self._upid in result[0].text
+
+    def test_string_log_entries_rendered_directly(self):
+        proxmox = Mock()
+        proxmox.nodes.return_value.tasks.return_value.log.get.return_value = ["plain text line"]
+        result = _make_tools(proxmox).get_task_log("pve", self._upid)
+
+        assert "plain text line" in result[0].text
+
+    def test_api_error_propagates(self):
+        proxmox = Mock()
+        proxmox.nodes.return_value.tasks.return_value.log.get.side_effect = RuntimeError(
+            "task not found"
+        )
+
+        with pytest.raises(ValueError, match="task not found"):
+            _make_tools(proxmox).get_task_log("pve", self._upid)
+
+
+# ---------------------------------------------------------------------------
+# get_cluster_log
+# ---------------------------------------------------------------------------
+
+class TestGetClusterLog:
+    _sample_entries = [
+        {
+            "time": 1700000000,
+            "node": "pve",
+            "user": "root@pam",
+            "pri": 6,
+            "tag": "pvedaemon",
+            "msg": "starting task UPID:pve:...",
+        },
+        {
+            "time": 1700000060,
+            "node": "pve2",
+            "user": "user@pve",
+            "pri": 5,
+            "tag": "pveproxy",
+            "msg": "login successful",
+        },
+    ]
+
+    def test_returns_content_list(self):
+        proxmox = Mock()
+        proxmox.cluster.log.get.return_value = self._sample_entries
+        result = _make_tools(proxmox).get_cluster_log()
+
+        assert len(result) == 1
+        assert result[0].type == "text"
+
+    def test_output_contains_entry_fields(self):
+        proxmox = Mock()
+        proxmox.cluster.log.get.return_value = self._sample_entries
+        result = _make_tools(proxmox).get_cluster_log()
+
+        assert "pvedaemon" in result[0].text
+        assert "starting task UPID:pve:..." in result[0].text
+        assert "pve2" in result[0].text
+        assert "login successful" in result[0].text
+
+    def test_default_max_forwarded_as_max(self):
+        """API param is 'max'; the tool arg is max_entries."""
+        proxmox = Mock()
+        proxmox.cluster.log.get.return_value = []
+        _make_tools(proxmox).get_cluster_log()
+
+        call_kwargs = proxmox.cluster.log.get.call_args.kwargs
+        assert call_kwargs["max"] == 50
+        assert "max_entries" not in call_kwargs
+
+    def test_custom_max_forwarded(self):
+        proxmox = Mock()
+        proxmox.cluster.log.get.return_value = []
+        _make_tools(proxmox).get_cluster_log(max_entries=200)
+
+        call_kwargs = proxmox.cluster.log.get.call_args.kwargs
+        assert call_kwargs["max"] == 200
+
+    def test_empty_response_returns_message(self):
+        proxmox = Mock()
+        proxmox.cluster.log.get.return_value = []
+        result = _make_tools(proxmox).get_cluster_log()
+
+        assert "No cluster log entries" in result[0].text
+
+    def test_api_error_propagates(self):
+        proxmox = Mock()
+        proxmox.cluster.log.get.side_effect = RuntimeError("connection refused")
+
+        with pytest.raises(RuntimeError, match="connection refused"):
+            _make_tools(proxmox).get_cluster_log()
+
+
+# ---------------------------------------------------------------------------
+# get_node_firewall_log
+# ---------------------------------------------------------------------------
+
+class TestGetNodeFirewallLog:
+    def test_returns_content_list(self):
+        proxmox = Mock()
+        _node_api(proxmox).firewall.log.get.return_value = [
+            {"n": 1, "t": "0 6 tap100i0-IN 01/Jan/2024 ACCEPT: ..."},
+        ]
+        result = _make_tools(proxmox).get_node_firewall_log("pve")
+
+        assert len(result) == 1
+        assert result[0].type == "text"
+        assert "ACCEPT" in result[0].text
+
+    def test_default_limit_forwarded(self):
+        proxmox = Mock()
+        _node_api(proxmox).firewall.log.get.return_value = []
+        _make_tools(proxmox).get_node_firewall_log("pve")
+
+        proxmox.nodes.assert_called_once_with("pve")
+        call_kwargs = _node_api(proxmox).firewall.log.get.call_args.kwargs
+        assert call_kwargs["limit"] == 100
+
+    def test_none_optional_params_not_forwarded(self):
+        proxmox = Mock()
+        _node_api(proxmox).firewall.log.get.return_value = []
+        _make_tools(proxmox).get_node_firewall_log("pve")
+
+        call_kwargs = _node_api(proxmox).firewall.log.get.call_args.kwargs
+        assert "start" not in call_kwargs
+        assert "since" not in call_kwargs
+        assert "until" not in call_kwargs
+
+    def test_optional_params_forwarded_when_supplied(self):
+        proxmox = Mock()
+        _node_api(proxmox).firewall.log.get.return_value = []
+        _make_tools(proxmox).get_node_firewall_log(
+            "pve", limit=25, start=10, since=1700000000, until=1700003600
+        )
+
+        call_kwargs = _node_api(proxmox).firewall.log.get.call_args.kwargs
+        assert call_kwargs["limit"] == 25
+        assert call_kwargs["start"] == 10
+        assert call_kwargs["since"] == 1700000000
+        assert call_kwargs["until"] == 1700003600
+
+    def test_empty_response_returns_message(self):
+        proxmox = Mock()
+        _node_api(proxmox).firewall.log.get.return_value = []
+        result = _make_tools(proxmox).get_node_firewall_log("pve")
+
+        assert "No firewall log entries" in result[0].text
+
+    def test_api_error_propagates(self):
+        proxmox = Mock()
+        _node_api(proxmox).firewall.log.get.side_effect = RuntimeError("connection refused")
+
+        with pytest.raises(RuntimeError, match="connection refused"):
+            _make_tools(proxmox).get_node_firewall_log("pve")
+
+
+# ---------------------------------------------------------------------------
+# get_guest_firewall_log
+# ---------------------------------------------------------------------------
+
+class TestGetGuestFirewallLog:
+    def test_qemu_path_used_by_default(self):
+        proxmox = Mock()
+        _node_api(proxmox).qemu.return_value.firewall.log.get.return_value = [
+            {"n": 1, "t": "100 6 tap100i0-IN ACCEPT: ..."},
+        ]
+        result = _make_tools(proxmox).get_guest_firewall_log("pve", 100)
+
+        proxmox.nodes.assert_called_once_with("pve")
+        _node_api(proxmox).qemu.assert_called_once_with(100)
+        assert "ACCEPT" in result[0].text
+
+    def test_lxc_path_used_when_requested(self):
+        proxmox = Mock()
+        _node_api(proxmox).lxc.return_value.firewall.log.get.return_value = [
+            {"n": 1, "t": "101 6 veth101i0-IN DROP: ..."},
+        ]
+        result = _make_tools(proxmox).get_guest_firewall_log("pve", 101, vm_type="lxc")
+
+        _node_api(proxmox).lxc.assert_called_once_with(101)
+        _node_api(proxmox).qemu.assert_not_called()
+        assert "DROP" in result[0].text
+
+    def test_invalid_vm_type_raises(self):
+        proxmox = Mock()
+
+        with pytest.raises(ValueError, match="Invalid vm_type"):
+            _make_tools(proxmox).get_guest_firewall_log("pve", 100, vm_type="openvz")
+
+    def test_default_limit_forwarded(self):
+        proxmox = Mock()
+        _node_api(proxmox).qemu.return_value.firewall.log.get.return_value = []
+        _make_tools(proxmox).get_guest_firewall_log("pve", 100)
+
+        call_kwargs = _node_api(proxmox).qemu.return_value.firewall.log.get.call_args.kwargs
+        assert call_kwargs["limit"] == 100
+
+    def test_none_optional_params_not_forwarded(self):
+        proxmox = Mock()
+        _node_api(proxmox).qemu.return_value.firewall.log.get.return_value = []
+        _make_tools(proxmox).get_guest_firewall_log("pve", 100)
+
+        call_kwargs = _node_api(proxmox).qemu.return_value.firewall.log.get.call_args.kwargs
+        assert "start" not in call_kwargs
+        assert "since" not in call_kwargs
+        assert "until" not in call_kwargs
+
+    def test_optional_params_forwarded_when_supplied(self):
+        proxmox = Mock()
+        _node_api(proxmox).qemu.return_value.firewall.log.get.return_value = []
+        _make_tools(proxmox).get_guest_firewall_log(
+            "pve", 100, limit=10, start=5, since=1700000000, until=1700003600
+        )
+
+        call_kwargs = _node_api(proxmox).qemu.return_value.firewall.log.get.call_args.kwargs
+        assert call_kwargs["limit"] == 10
+        assert call_kwargs["start"] == 5
+        assert call_kwargs["since"] == 1700000000
+        assert call_kwargs["until"] == 1700003600
+
+    def test_empty_response_returns_message(self):
+        proxmox = Mock()
+        _node_api(proxmox).qemu.return_value.firewall.log.get.return_value = []
+        result = _make_tools(proxmox).get_guest_firewall_log("pve", 100)
+
+        assert "No firewall log (qemu 100) entries" in result[0].text
+
+    def test_api_error_propagates(self):
+        proxmox = Mock()
+        _node_api(proxmox).qemu.return_value.firewall.log.get.side_effect = RuntimeError(
+            "permission denied"
+        )
+
+        with pytest.raises(ValueError, match="permission denied"):
+            _make_tools(proxmox).get_guest_firewall_log("pve", 100)

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -16,6 +16,7 @@ from proxmox_mcp.services.builtin_tool_plugins import (
     CoreToolsPlugin,
     ImageToolsPlugin,
     JobsToolsPlugin,
+    LogToolsPlugin,
     SnapshotToolsPlugin,
     VMToolsPlugin,
 )
@@ -57,6 +58,7 @@ def test_manifest_declares_all_registered_tools():
         SnapshotToolsPlugin(),
         ImageToolsPlugin(),
         BackupToolsPlugin(),
+        LogToolsPlugin(),
     ):
         plugin.register(fake_server)
 


### PR DESCRIPTION
## Summary
Adds 5 read-only log inspection tools so MCP clients can troubleshoot Proxmox nodes, tasks, and firewall events without leaving the conversation:
- Node logs: `get_node_syslog`
- Task output: `get_task_log`
- Cluster events: `get_cluster_log`
- Firewall: `get_node_firewall_log`, `get_guest_firewall_log` (qemu/lxc)

All tools are strictly read-only (`GET` endpoints only) and mirror the shape of the existing `get_*` read tools: `ProxmoxTool` subclass returning `List[Content]`, errors routed through `_handle_error`, registration via a `RegistryPluginBase` plugin with `Annotated`/`Field` parameter schemas.

## Changes
- `src/proxmox_mcp/tools/logs.py` — new `LogTools` class with the 5 tools and plain-text formatting helpers
- `src/proxmox_mcp/tools/definitions.py` — `*_DESC` constants for each tool
- `src/proxmox_mcp/services/builtin_tool_plugins.py` — new `LogToolsPlugin` with parameter validation (`ge`/`le` bounds, `Literal` enums)
- `src/proxmox_mcp/server.py`, `src/proxmox_mcp/services/__init__.py` — instantiate and register the plugin
- `manifest.json` — declare the 5 new tools
- `tests/test_security_hardening.py` — add `LogToolsPlugin` to the manifest-sync guard so the manifest/tool parity check covers the new plugin
- `tests/test_log_tools.py` — unit tests following the `test_tool_user_paths.py` pattern
- `docs/wiki/API & Tool Reference.md`, `docs/wiki/Tool Selection Guide.md`, `README.md` — document the new tool group and troubleshooting workflows
## Test plan
- [x] `pytest -q` → **236 passed, 1 skipped** (41 new tests in `test_log_tools.py`; no regressions)
- [x] `ruff check .` → clean
- [x] `mypy src --ignore-missing-imports` → clean (43 source files)
- [x] `test_manifest_declares_all_registered_tools` verified to fail when a log tool is missing from `manifest.json`, then pass with the manifest updated
- [x] Live validation against a real Proxmox VE node (single-node lab): tools returned real data; syslog `service` filter, task UPID round-trip (Task ID → `get_task_log`), and firewall logs confirmed working
- [x] Error paths validated in unit tests (`ValueError`/`RuntimeError` mapping from `_handle_error`)

### Sample live outputs

`get_node_syslog(node='proxmox', limit=5)`:

```
=== syslog for node 'proxmox' (5 entries) ===

Aug 09 16:11:32 proxmox kernel: Linux version 7.0.2-6-pve (build@proxmox) (gcc (Debian 14.2.0-19) 14.2.0, GNU ld (GNU Binutils for Debian) 2.44) #1 SMP PREEMPT_DYNAMIC PMX 7.0.2-6 (2026-05-20T08:55Z) ()
Aug 09 16:11:32 proxmox kernel: Command line: BOOT_IMAGE=/boot/vmlinuz-7.0.2-6-pve root=/dev/mapper/pve-root ro quiet
Aug 09 16:11:32 proxmox kernel: KERNEL supported cpus:
Aug 09 16:11:32 proxmox kernel:   Intel GenuineIntel
Aug 09 16:11:32 proxmox kernel:   AMD AuthenticAMD
```

`get_task_log(node='proxmox', upid='UPID:proxmox:00000954:0000706C:6A78AAE5:vncproxy:100:root@pam:')`:

```
=== Task log for UPID:proxmox:00000954:0000706C:6A78AAE5:vncproxy:100:root@pam: (1 lines) ===

TASK OK
```

`get_cluster_log(max_entries=5)`:

```
=== cluster log (5 entries) ===

[2026-08-09 16:29:28] proxmox root@pam pvedaemon: successful auth for user 'root@pam'
[2026-08-09 16:29:28] proxmox root@pam pvedaemon: starting task UPID:proxmox:00000992:00007181:6A78AAE8:vncshell::root@pam:
[2026-08-09 16:29:27] proxmox root@pam pvedaemon: end task UPID:proxmox:00000954:0000706C:6A78AAE5:vncproxy:100:root@pam: OK
[2026-08-09 16:29:25] proxmox root@pam pvedaemon: starting task UPID:proxmox:00000954:0000706C:6A78AAE5:vncproxy:100:root@pam:
[2026-08-09 16:29:13] proxmox root@pam pvedaemon: end task UPID:proxmox:000008EF:000068F7:6A78AAD2:vncshell::root@pam: OK
```

`get_node_firewall_log(node='proxmox', limit=20)`:

```
=== firewall log for node 'proxmox' (14 entries) ===

0 5 - 09/Aug/2026:16:11:34 +0900 starting pvefw logger
0 5 - 09/Aug/2026:18:34:10 +0900 starting pvefw logger
0 5 - 09/Aug/2026:22:11:37 +0900 starting pvefw logger
0 5 - 09/Aug/2026:23:33:00 +0900 starting pvefw logger
0 5 - 10/Aug/2026:01:24:44 +0900 starting pvefw logger
0 5 - 10/Aug/2026:01:29:27 +0900 received terminate request (signal)
0 5 - 10/Aug/2026:01:29:27 +0900 stopping pvefw logger
0 5 - 10/Aug/2026:01:29:28 +0900 starting pvefw logger
101 1 tap101i0-IN 10/Aug/2026:01:29:29 +0900 DROP: IN=fwbr101i0 OUT=fwbr101i0 PHYSIN=fwln101i0 PHYSOUT=tap101i0 MAC=bc:24:11:8c:88:91:00:0c:29:00:f3:8b:08:00 SRC=192.168.73.128 DST=192.168.73.129 LEN=84 TOS=0x00 PREC=0x00 TTL=64 ID=10011 DF PROTO=ICMP TYPE=8 CODE=0 ID=56055 SEQ=1 
101 1 tap101i0-IN 10/Aug/2026:01:29:30 +0900 DROP: IN=fwbr101i0 OUT=fwbr101i0 PHYSIN=fwln101i0 PHYSOUT=tap101i0 MAC=bc:24:11:8c:88:91:00:0c:29:00:f3:8b:08:00 SRC=192.168.73.128 DST=192.168.73.129 LEN=84 TOS=0x00 PREC=0x00 TTL=64 ID=10306 DF PROTO=ICMP TYPE=8 CODE=0 ID=56055 SEQ=2 
... (4 more lines omitted)
```

`get_guest_firewall_log(node='proxmox', vmid=101, vm_type='qemu', limit=20)`:

```
=== firewall log (qemu 101) for node 'proxmox' (6 entries) ===

101 1 tap101i0-IN 10/Aug/2026:01:29:29 +0900 DROP: IN=fwbr101i0 OUT=fwbr101i0 PHYSIN=fwln101i0 PHYSOUT=tap101i0 MAC=bc:24:11:8c:88:91:00:0c:29:00:f3:8b:08:00 SRC=192.168.73.128 DST=192.168.73.129 LEN=84 TOS=0x00 PREC=0x00 TTL=64 ID=10011 DF PROTO=ICMP TYPE=8 CODE=0 ID=56055 SEQ=1 
101 1 tap101i0-IN 10/Aug/2026:01:29:30 +0900 DROP: IN=fwbr101i0 OUT=fwbr101i0 PHYSIN=fwln101i0 PHYSOUT=tap101i0 MAC=bc:24:11:8c:88:91:00:0c:29:00:f3:8b:08:00 SRC=192.168.73.128 DST=192.168.73.129 LEN=84 TOS=0x00 PREC=0x00 TTL=64 ID=10306 DF PROTO=ICMP TYPE=8 CODE=0 ID=56055 SEQ=2 
101 1 tap101i0-IN 10/Aug/2026:01:29:31 +0900 DROP: IN=fwbr101i0 OUT=fwbr101i0 PHYSIN=fwln101i0 PHYSOUT=tap101i0 MAC=bc:24:11:8c:88:91:00:0c:29:00:f3:8b:08:00 SRC=192.168.73.128 DST=192.168.73.129 LEN=84 TOS=0x00 PREC=0x00 TTL=64 ID=10770 DF PROTO=ICMP TYPE=8 CODE=0 ID=56055 SEQ=3 
101 1 tap101i0-IN 10/Aug/2026:01:29:32 +0900 DROP: IN=fwbr101i0 OUT=fwbr101i0 PHYSIN=fwln101i0 PHYSOUT=tap101i0 MAC=bc:24:11:8c:88:91:00:0c:29:00:f3:8b:08:00 SRC=192.168.73.128 DST=192.168.73.129 LEN=84 TOS=0x00 PREC=0x00 TTL=64 ID=10969 DF PROTO=ICMP TYPE=8 CODE=0 ID=56055 SEQ=4 
101 1 tap101i0-IN 10/Aug/2026:01:29:33 +0900 DROP: IN=fwbr101i0 OUT=fwbr101i0 PHYSIN=fwln101i0 PHYSOUT=tap101i0 MAC=bc:24:11:8c:88:91:00:0c:29:00:f3:8b:08:00 SRC=192.168.73.128 DST=192.168.73.129 LEN=84 TOS=0x00 PREC=0x00 TTL=64 ID=11574 DF PROTO=ICMP TYPE=8 CODE=0 ID=56055 SEQ=5 
101 1 tap101i0-IN 10/Aug/2026:01:29:34 +0900 DROP: IN=fwbr101i0 OUT=fwbr101i0 PHYSIN=fwln101i0 PHYSOUT=tap101i0 MAC=bc:24:11:8c:88:91:00:0c:29:00:f3:8b:08:00 SRC=192.168.73.128 DST=192.168.73.129 LEN=84 TOS=0x00 PREC=0x00 TTL=64 ID=12206 DF PROTO=ICMP TYPE=8 CODE=0 ID=56055 SEQ=6 
```

---
Thank you for developing this MCP; I truly appreciate your work.