### PR TITLE
release: v0.5.13

### DIFF
--- a/docs/releases/v0.5.13.md
+++ b/docs/releases/v0.5.13.md
@@ -1,0 +1,42 @@
+# ProxmoxMCP-Plus v0.5.13
+
+Release date: 2026-08-10
+
+## Read-only log inspection
+
+This release adds five read-only MCP tools for investigating Proxmox nodes, tasks, cluster events, and firewall activity without leaving the MCP client:
+
+- `get_node_syslog`
+- `get_task_log`
+- `get_cluster_log`
+- `get_node_firewall_log`
+- `get_guest_firewall_log` for QEMU VMs and LXC containers
+
+All five tools use Proxmox `GET` endpoints and do not change cluster state. Access remains subject to Proxmox permissions. Depending on the requested log and its owner, the configured user or API token may need `Sys.Syslog`, `Sys.Audit`, or `VM.Console` on the relevant cluster, node, or guest path. Firewall logging must also be enabled for traffic entries to appear.
+
+Logs can contain usernames, task identifiers, IP addresses, service names, and other sensitive operational details. Grant only the permissions needed and avoid sharing returned logs without review.
+
+Thanks to `DevLeti` for contributing the inspection tools in PR #116.
+
+## Reliable STDIO shutdown
+
+STDIO servers now exit cleanly when they receive SIGINT or SIGTERM, avoiding the CPython `_enter_buffered_busy` abort that could occur while an MCP SDK reader thread still owned the shared standard-input buffer. Application resources are closed before the process exits, and the shutdown path deliberately avoids high-level standard-stream flushing that could deadlock behind an SDK writer.
+
+SSE and Streamable HTTP retain their existing graceful `SystemExit` behavior. Thanks to `scottrus` for diagnosing and contributing the original fix in PR #113.
+
+## Compatibility
+
+- No configuration migration is required.
+- Existing tools, schemas, ports, and transport configuration remain compatible.
+- The new inspection tools are additive and read-only.
+- MCP clients that cache tool definitions may need to reconnect or refresh their tool list after upgrading.
+
+## Validation
+
+The release quality gate covers Python 3.11 and 3.12 tests with coverage enforcement, Ruff, Mypy, CodeQL, dependency auditing, package builds, Twine metadata validation, runtime-to-manifest parity, and multi-architecture container publication checks.
+
+## Upgrade and rollback
+
+- Upgrade normally from PyPI, GHCR, or source, then reconnect the MCP client if the new tools are not immediately visible.
+- No application, Docker, or Proxmox configuration change is required solely for this release.
+- To roll back, pin PyPI or source installs to `0.5.12`, or use the GHCR tag `0.5.12`.

--- a/docs/wiki/Release & Upgrade Notes.md
+++ b/docs/wiki/Release & Upgrade Notes.md
@@ -18,6 +18,38 @@ Use this page to track version-level behavior changes, upgrade steps, and rollba
 
 ## Release History
 
+### Version `0.5.13`
+
+- Release date: 2026-08-10
+- Summary: adds five read-only Proxmox log inspection tools and prevents CPython finalization aborts during STDIO signal shutdown.
+- New tools or endpoints:
+  - `get_node_syslog`
+  - `get_task_log`
+  - `get_cluster_log`
+  - `get_node_firewall_log`
+  - `get_guest_firewall_log` for QEMU VMs and LXC containers
+- Changed behavior:
+  - STDIO now closes application resources and exits without interpreter finalization when SIGINT or SIGTERM is received
+  - SSE and Streamable HTTP retain their existing `SystemExit` shutdown behavior
+  - log access remains governed by Proxmox permissions; the user or API token may need `Sys.Syslog`, `Sys.Audit`, or `VM.Console` depending on the endpoint and target
+  - returned logs may include sensitive operational details and should be shared only after review
+- Removed or deprecated behavior:
+  - no removals or deprecations
+- Config changes:
+  - no runtime configuration migration
+- Docs updated:
+  - `README.md`
+  - `docs/releases/v0.5.13.md`
+  - `docs/wiki/API & Tool Reference.md`
+  - `docs/wiki/Tool Selection Guide.md`
+  - `docs/wiki/Release & Upgrade Notes.md`
+- Upgrade steps:
+  - upgrade normally from PyPI, GHCR, or source
+  - reconnect or refresh the MCP client if it caches the server's tool list
+  - grant only the Proxmox log permissions required by the inspection workflow
+- Rollback notes:
+  - pin PyPI or source installs to `0.5.12`, or use the GHCR tag `0.5.12`
+
 ### Version `0.5.12`
 
 - Release date: 2026-07-29

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": "0.4",
     "name": "proxmox-mcp-plus",
     "display_name": "ProxmoxMCP-Plus",
-    "version": "0.5.12",
+    "version": "0.5.13",
     "description": "An enhanced MCP server for managing Proxmox virtualization platforms.",
     "long_description": "ProxmoxMCP-Plus is an enhanced Model Context Protocol (MCP) server that provides comprehensive tools for managing Proxmox virtualization environments, including VM lifecycle, container management, snapshot operations, and backup/restore capabilities.",
     "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "proxmox-mcp-plus"
-version = "0.5.12"
+version = "0.5.13"
 description = "Enhanced Proxmox MCP Server"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -18,13 +18,13 @@
     "url": "https://github.com/RekklesNA/ProxmoxMCP-Plus",
     "source": "github"
   },
-  "version": "0.5.12",
+  "version": "0.5.13",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "proxmox-mcp-plus",
-      "version": "0.5.12",
+      "version": "0.5.13",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="proxmox-mcp-plus",
-    version="0.5.12",
+    version="0.5.13",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     python_requires=">=3.11",

--- a/src/proxmox_mcp/__init__.py
+++ b/src/proxmox_mcp/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .server import ProxmoxMCPServer
 
-__version__ = "0.5.12"
+__version__ = "0.5.13"
 __all__ = ["ProxmoxMCPServer"]
 
 


### PR DESCRIPTION
## Summary

Prepare ProxmoxMCP-Plus v0.5.13 after merging PR #116 and PR #113.

- bump all runtime, packaging, manifest, and MCP Registry versions to `0.5.13`
- add release notes for the five read-only log inspection tools
- document the STDIO SIGINT/SIGTERM finalization-abort fix
- document permissions, sensitive-log handling, client refresh, compatibility, and rollback guidance
- credit `DevLeti` and `scottrus`

## Validation

- `python -m pytest -q --cov=proxmox_mcp --cov-report=term-missing --cov-fail-under=75` — 242 passed, 2 skipped, 78.10%
- release metadata, manifest parity, log-tool, and server tests — 130 passed, 1 skipped
- Ruff — passed
- Mypy — passed
- pip-audit — no known vulnerabilities
- fresh wheel and sdist build — passed
- Twine metadata checks — passed
- clean wheel install — distribution/runtime version `0.5.13`, `LogTools` present, `pip check` clean

No runtime configuration migration is required.