### PR TITLE
release: v0.5.14 MCP HTTP bearer authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,13 @@ Use this path when the MCP client launches a local stdio server.
 Use this path when a remote MCP client supports Streamable HTTP:
 
 ```bash
+export MCP_API_KEY="$(openssl rand -hex 32)"
 docker run --rm -p 8000:8000 \
   -e PROXMOX_MCP_MODE=mcp-http \
   -e MCP_HOST=0.0.0.0 \
   -e MCP_PORT=8000 \
   -e MCP_TRANSPORT=STREAMABLE_HTTP \
+  -e MCP_API_KEY="$MCP_API_KEY" \
   -v "$(pwd)/proxmox-config/config.json:/app/proxmox-config/config.json:ro" \
   ghcr.io/rekklesna/proxmoxmcp-plus:latest
 ```
@@ -135,6 +137,11 @@ Point MCP clients at:
 http://<docker-host>:8000/mcp
 ```
 
+Send `Authorization: Bearer <MCP_API_KEY>` with every MCP HTTP request. `MCP_API_KEY`
+is deliberately separate from the OpenAPI-only `PROXMOX_API_KEY`, so the two surfaces
+can be rotated independently. If `MCP_API_KEY` is unset, Streamable HTTP remains
+unauthenticated for backward compatibility and logs a security warning at startup.
+
 When serving MCP HTTP behind a reverse proxy, keep DNS rebinding protection enabled and allow only the hostnames you expect:
 
 ```bash
@@ -143,6 +150,7 @@ docker run --rm -p 8000:8000 \
   -e MCP_HOST=0.0.0.0 \
   -e MCP_PORT=8000 \
   -e MCP_TRANSPORT=STREAMABLE_HTTP \
+  -e MCP_API_KEY="$MCP_API_KEY" \
   -e MCP_DNS_REBINDING_PROTECTION=true \
   -e MCP_ALLOWED_HOSTS=mcp.example.com:*,localhost:* \
   -e MCP_ALLOWED_ORIGINS=https://mcp.example.com \
@@ -263,6 +271,7 @@ The project gives operators several control points:
 
 - Proxmox API tokens decide what the backend can do.
 - `PROXMOX_API_KEY` protects the OpenAPI bridge by default.
+- `MCP_API_KEY` optionally protects the native Streamable HTTP `/mcp` endpoint with Bearer authentication.
 - TLS verification is enforced unless development mode is explicitly enabled.
 - `command_policy` controls command execution and high-risk operations.
 - `approval_token` can gate command execution and high-risk mutating actions.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,8 @@ services:
       - MCP_HOST=0.0.0.0
       - MCP_PORT=8000
       - MCP_TRANSPORT=STREAMABLE_HTTP
+      # Optional but strongly recommended for every remotely reachable deployment.
+      - MCP_API_KEY=${MCP_API_KEY:-}
       # For reverse proxy deployments, set explicit Host/Origin allowlists.
       # - MCP_DNS_REBINDING_PROTECTION=true
       # - MCP_ALLOWED_HOSTS=mcp.example.com:*,localhost:*

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -18,7 +18,7 @@ Important operating notes:
 
 - Use read-only tools such as `get_nodes`, `get_vms`, `get_containers`, and `get_storage` before mutating Proxmox resources.
 - Use `job_id` for ProxmoxMCP-Plus job tracking and `task_id` for raw Proxmox `UPID` traceability.
-- MCP Streamable HTTP clients should connect to `/mcp` on the service running on port `8000`.
+- MCP Streamable HTTP clients should connect to `/mcp` on port `8000` and send `Authorization: Bearer <MCP_API_KEY>` when native authentication is configured.
 - OpenAPI clients should use the service on port `8811` and send `Authorization: Bearer <PROXMOX_API_KEY>`.
 - Container command execution appears only when the config includes an `ssh` section.
 - TLS verification should remain enabled outside explicit local development mode.

--- a/docs/releases/v0.5.14.md
+++ b/docs/releases/v0.5.14.md
@@ -1,0 +1,58 @@
+# ProxmoxMCP-Plus v0.5.14
+
+Release date: 2026-08-11
+
+## Optional Bearer authentication for native MCP HTTP
+
+Native Streamable HTTP deployments can now set `MCP_API_KEY` to protect the `/mcp`
+endpoint with application-level Bearer authentication. Requests that omit the header,
+use another authentication scheme, or provide the wrong token receive `401 Unauthorized`
+with `WWW-Authenticate: Bearer`.
+
+The new token is deliberately independent of `PROXMOX_API_KEY`, which continues to
+protect only the OpenAPI bridge on port `8811`. This allows operators to expose and rotate
+the two surfaces independently.
+
+Authentication uses constant-time token comparison. The middleware is implemented as a
+direct ASGI pass-through: successful Streamable HTTP and `text/event-stream` responses
+are not collected or buffered.
+
+## Compatibility
+
+- `MCP_API_KEY` is optional and affects only native Streamable HTTP mode.
+- STDIO and SSE transports are unchanged.
+- Existing unauthenticated Streamable HTTP deployments continue to start, but now emit a
+  security warning explaining that reachable clients can invoke MCP tools.
+- Existing `PROXMOX_API_KEY` and `PROXMOX_ALLOW_NO_AUTH` behavior for OpenAPI is unchanged.
+
+## Upgrade
+
+Generate a separate secret before starting a remotely reachable native MCP HTTP service:
+
+```bash
+export MCP_API_KEY="$(openssl rand -hex 32)"
+docker compose --profile mcp-http up -d proxmox-mcp-http
+```
+
+Configure the MCP client to send:
+
+```text
+Authorization: Bearer <MCP_API_KEY>
+```
+
+Continue to use TLS termination, network ingress restrictions, DNS rebinding protection,
+and explicit Host/Origin allowlists. These controls address different threats and do not
+replace caller authentication.
+
+## Validation
+
+The release gate covers missing, malformed, incorrect, and matching credentials;
+constant-time comparison; unchanged lifespan handling; unbuffered multi-chunk SSE event
+forwarding; the unauthenticated compatibility path; Python 3.11 and 3.12 CI; Ruff; Mypy;
+CodeQL; dependency auditing; package metadata; and multi-architecture container checks.
+
+## Rollback
+
+Pin PyPI or source installs to `0.5.13`, or use the GHCR tag `0.5.13`. Rolling back removes
+native `/mcp` Bearer enforcement, so retain a reverse proxy or network-level authentication
+control until the deployment is upgraded again.

--- a/docs/wiki/API & Tool Reference.md
+++ b/docs/wiki/API & Tool Reference.md
@@ -21,6 +21,8 @@ When `mcp.transport` is `STREAMABLE_HTTP` or `STREAMABLE`, the server exposes th
 | `/mcp` | MCP Streamable HTTP endpoint | use this for remote MCP clients that support Streamable HTTP |
 
 The Docker Compose `mcp-http` profile exposes this endpoint on port `8000`.
+When `MCP_API_KEY` is set, callers must send `Authorization: Bearer <MCP_API_KEY>`.
+Missing or incorrect credentials return `401` with `WWW-Authenticate: Bearer`.
 
 ## OpenAPI Service Endpoints
 
@@ -42,6 +44,7 @@ When the OpenAPI wrapper is enabled, the primary endpoints are:
 ### Authentication and Authorization
 
 - Proxmox API access requires a valid `proxmox` and `auth` configuration.
+- Native MCP Streamable HTTP access optionally requires `Authorization: Bearer <MCP_API_KEY>` when `MCP_API_KEY` is configured.
 - OpenAPI access requires `Authorization: Bearer <PROXMOX_API_KEY>` by default. Startup without an API key requires the explicit local-development override `PROXMOX_ALLOW_NO_AUTH=true`.
 - SSH-backed container command workflows require a valid `ssh` configuration.
 - Command-execution tools are subject to command-policy checks. Depending on policy, a request can be allowed, denied, or require an `approval_token`.

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -56,6 +56,7 @@ ProxmoxMCP-Plus is not a replacement for Proxmox RBAC or network isolation. It a
 
 - Proxmox API token permissions remain the backend source of authority.
 - OpenAPI mode requires `PROXMOX_API_KEY` by default.
+- Native MCP HTTP mode can require a separate `MCP_API_KEY` Bearer token.
 - TLS validation is enforced unless `security.dev_mode=true` is explicitly enabled.
 - `command_policy` and `approval_token` can gate command execution and high-risk operations.
 - MCP HTTP deployments can configure DNS rebinding protection plus Host and Origin allowlists.

--- a/docs/wiki/Integrations Guide.md
+++ b/docs/wiki/Integrations Guide.md
@@ -56,6 +56,7 @@ Typical requirements:
 For remote MCP clients, run the native MCP HTTP Docker mode:
 
 ```bash
+export MCP_API_KEY="${MCP_API_KEY:-$(openssl rand -hex 32)}"
 docker compose --profile mcp-http up -d proxmox-mcp-http
 ```
 
@@ -66,6 +67,8 @@ http://<docker-host>:8000/mcp
 ```
 
 The default OpenAPI service on port `8811` is not an MCP Streamable HTTP endpoint; MCP HTTP clients should use `/mcp` on the native MCP service.
+Configure the client to send `Authorization: Bearer <MCP_API_KEY>`. The native token is
+separate from `PROXMOX_API_KEY`, which applies only to the OpenAPI service.
 
 If the MCP HTTP service is reached through a reverse proxy or gateway, configure the expected external Host header:
 

--- a/docs/wiki/Operator Guide.md
+++ b/docs/wiki/Operator Guide.md
@@ -85,7 +85,9 @@ If startup succeeds, the server stays attached to stdio and waits for MCP client
 Set the MCP transport to `STREAMABLE_HTTP` and bind to an address reachable by the client:
 
 ```bash
-MCP_HOST=0.0.0.0 MCP_PORT=8000 MCP_TRANSPORT=STREAMABLE_HTTP python -m proxmox_mcp.server
+MCP_API_KEY="$(openssl rand -hex 32)" \
+MCP_HOST=0.0.0.0 MCP_PORT=8000 MCP_TRANSPORT=STREAMABLE_HTTP \
+python -m proxmox_mcp.server
 ```
 
 The MCP endpoint is:
@@ -96,12 +98,17 @@ http://<host>:8000/mcp
 
 This is the correct target for MCP clients that support Streamable HTTP. It is separate from the OpenAPI service on port `8811`.
 
+Clients should send `Authorization: Bearer <MCP_API_KEY>`. If `MCP_API_KEY` is unset,
+the endpoint remains unauthenticated for backward compatibility and the server logs a
+security warning. `PROXMOX_API_KEY` does not protect this endpoint.
+
 For reverse proxy deployments, configure the external hostnames explicitly instead of disabling DNS rebinding protection:
 
 ```bash
 MCP_HOST=0.0.0.0 \
 MCP_PORT=8000 \
 MCP_TRANSPORT=STREAMABLE_HTTP \
+MCP_API_KEY="$MCP_API_KEY" \
 MCP_DNS_REBINDING_PROTECTION=true \
 MCP_ALLOWED_HOSTS=mcp.example.com:*,localhost:* \
 MCP_ALLOWED_ORIGINS=https://mcp.example.com \
@@ -156,10 +163,12 @@ docker compose up -d --build
 To run the native MCP Streamable HTTP service from Docker Compose:
 
 ```bash
+export MCP_API_KEY="${MCP_API_KEY:-$(openssl rand -hex 32)}"
 docker compose --profile mcp-http up -d proxmox-mcp-http
 ```
 
-Then connect Streamable HTTP MCP clients to `http://<docker-host>:8000/mcp`.
+Then connect Streamable HTTP MCP clients to `http://<docker-host>:8000/mcp` and send
+`Authorization: Bearer <MCP_API_KEY>`.
 
 The same image can also be run directly:
 
@@ -169,6 +178,7 @@ docker run --rm -p 8000:8000 \
   -e MCP_HOST=0.0.0.0 \
   -e MCP_PORT=8000 \
   -e MCP_TRANSPORT=STREAMABLE_HTTP \
+  -e MCP_API_KEY="$MCP_API_KEY" \
   -v "$(pwd)/proxmox-config/config.json:/app/proxmox-config/config.json:ro" \
   ghcr.io/rekklesna/proxmoxmcp-plus:latest
 ```
@@ -181,6 +191,7 @@ Before exposing the service to users:
 - Keep `proxmox.verify_ssl=true` unless you are explicitly in development mode
 - Keep `security.dev_mode=false` outside local testing
 - Set `PROXMOX_API_KEY` for OpenAPI mode; only use `PROXMOX_ALLOW_NO_AUTH=true` for local unauthenticated development
+- Set `MCP_API_KEY` for every remotely reachable native MCP HTTP deployment
 - For MCP HTTP behind a proxy, keep `MCP_DNS_REBINDING_PROTECTION=true` and set `MCP_ALLOWED_HOSTS` to the exact public hostnames
 - Restrict ingress to networks you control
 - Monitor `/livez` for process liveness and authenticated `/health` or `/readyz` for backend readiness

--- a/docs/wiki/Release & Upgrade Notes.md
+++ b/docs/wiki/Release & Upgrade Notes.md
@@ -18,6 +18,41 @@ Use this page to track version-level behavior changes, upgrade steps, and rollba
 
 ## Release History
 
+### Version `0.5.14`
+
+- Release date: 2026-08-11
+- Summary: adds optional Bearer authentication for the native Streamable HTTP `/mcp` endpoint.
+- New tools or endpoints:
+  - no new tools or endpoint paths
+- Changed behavior:
+  - setting `MCP_API_KEY` requires `Authorization: Bearer <MCP_API_KEY>` for native `/mcp` requests
+  - missing, malformed, or incorrect credentials return `401` with `WWW-Authenticate: Bearer`
+  - unauthenticated Streamable HTTP remains available for backward compatibility but logs a security warning
+  - successful SSE responses pass through the authentication layer without buffering
+- Removed or deprecated behavior:
+  - no removals or deprecations
+- Config changes:
+  - optional `MCP_API_KEY` environment variable for native Streamable HTTP only
+  - `PROXMOX_API_KEY` remains exclusive to the OpenAPI bridge
+- Docs updated:
+  - `README.md`
+  - `docs/releases/v0.5.14.md`
+  - `docs/wiki/API & Tool Reference.md`
+  - `docs/wiki/Home.md`
+  - `docs/wiki/Integrations Guide.md`
+  - `docs/wiki/Operator Guide.md`
+  - `docs/wiki/Security Guide.md`
+  - `docs/wiki/Troubleshooting.md`
+  - `docs/wiki/Release & Upgrade Notes.md`
+  - `docs/llms.txt`
+- Upgrade steps:
+  - generate a separate `MCP_API_KEY` for every remotely reachable native MCP HTTP deployment
+  - configure clients to send the Bearer header on every `/mcp` request
+  - retain TLS, ingress controls, and Host/Origin validation alongside caller authentication
+- Rollback notes:
+  - pin PyPI or source installs to `0.5.13`, or use the GHCR tag `0.5.13`
+  - retain external authentication when rolling back because `0.5.13` does not enforce `MCP_API_KEY`
+
 ### Version `0.5.13`
 
 - Release date: 2026-08-10

--- a/docs/wiki/Security Guide.md
+++ b/docs/wiki/Security Guide.md
@@ -9,6 +9,7 @@ ProxmoxMCP-Plus sits between clients and the Proxmox API. The main controls are:
 - Proxmox API token authentication
 - TLS verification for Proxmox API connections
 - required API key protection for OpenAPI exposure, unless `PROXMOX_ALLOW_NO_AUTH=true` is explicitly set for local development
+- optional `MCP_API_KEY` Bearer protection for native Streamable HTTP exposure
 - MCP transport DNS rebinding protection and Host/Origin allowlists for Streamable HTTP deployments
 - command policy checks for `execute_*` tools
 - optional SSH configuration for container command execution
@@ -19,6 +20,7 @@ ProxmoxMCP-Plus sits between clients and the Proxmox API. The main controls are:
 - Keep `proxmox.verify_ssl=true`
 - Only use `security.dev_mode=true` for local development
 - Set `PROXMOX_API_KEY` before starting OpenAPI mode
+- Set a separate `MCP_API_KEY` before exposing native Streamable HTTP beyond a trusted local environment
 - Keep MCP DNS rebinding protection enabled when exposing Streamable HTTP through a reverse proxy
 - Restrict who can reach the OpenAPI endpoint
 - Keep logs for sensitive operations
@@ -86,6 +88,15 @@ If you run the OpenAPI proxy:
 
 Native Streamable HTTP MCP deployments can configure DNS rebinding protection through the `mcp` config section or environment variables.
 
+Set `MCP_API_KEY` to require `Authorization: Bearer <MCP_API_KEY>` on the native
+`/mcp` endpoint. Missing, malformed, or incorrect credentials receive `401 Unauthorized`
+with `WWW-Authenticate: Bearer`. The token is compared in constant time. This setting is
+independent of `PROXMOX_API_KEY`, which protects only the OpenAPI service on port `8811`.
+
+For backward compatibility, leaving `MCP_API_KEY` unset keeps the native endpoint
+unauthenticated and emits a startup warning. Do not rely on Host or Origin validation as
+caller authentication: those settings mitigate DNS rebinding but do not identify clients.
+
 Recommended reverse proxy settings:
 
 ```json
@@ -103,9 +114,14 @@ Recommended reverse proxy settings:
 
 If these fields are omitted, ProxmoxMCP-Plus leaves transport-security defaults to the installed MCP SDK. Set `dns_rebinding_protection=false` only for a trusted local development setup.
 
+When Caddy or another reverse proxy is used, disable response buffering for
+`text/event-stream` traffic. For Caddy, `flush_interval -1` prevents Streamable HTTP SSE
+responses from being delayed behind the proxy buffer.
+
 ## Credential Handling
 
 - Keep Proxmox API tokens out of committed source files
+- Keep `MCP_API_KEY` and `PROXMOX_API_KEY` out of committed source files and rotate them independently
 - Use a dedicated config file or environment variables per environment
 - If using SSH for container execution, use a dedicated keypair for this service
 - Rotate API tokens and SSH keys on a schedule that fits your environment
@@ -113,6 +129,7 @@ If these fields are omitted, ProxmoxMCP-Plus leaves transport-security defaults 
 ## Hardening Checklist
 
 - Restrict ingress to networks you control
+- Require `MCP_API_KEY` for every remotely reachable native `/mcp` endpoint
 - Keep OpenAPI behind a reverse proxy you manage
 - Use per-environment credentials
 - Keep `dev_mode` off outside local testing

--- a/docs/wiki/Troubleshooting.md
+++ b/docs/wiki/Troubleshooting.md
@@ -55,6 +55,21 @@ Check:
 
 Use `/livez` for unauthenticated liveness checks. Use authenticated `/readyz` or `/health` for backend readiness.
 
+## Native `/mcp` Returns `401`
+
+Native Streamable HTTP authentication is enabled when `MCP_API_KEY` is present in the
+server environment.
+
+Check:
+
+- the client sends `Authorization: Bearer <MCP_API_KEY>` on every `/mcp` request
+- the client and server use the same value without added quotes or whitespace
+- Docker Compose received `MCP_API_KEY` from the shell or `.env` file
+- `MCP_API_KEY` was not confused with the OpenAPI-only `PROXMOX_API_KEY`
+
+If the variable is deliberately omitted for trusted local development, startup logs a
+warning and `/mcp` retains its backward-compatible unauthenticated behavior.
+
 ## OpenAPI `/docs` Works But Tool Calls Fail
 
 Check:

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": "0.4",
     "name": "proxmox-mcp-plus",
     "display_name": "ProxmoxMCP-Plus",
-    "version": "0.5.13",
+    "version": "0.5.14",
     "description": "An enhanced MCP server for managing Proxmox virtualization platforms.",
     "long_description": "ProxmoxMCP-Plus is an enhanced Model Context Protocol (MCP) server that provides comprehensive tools for managing Proxmox virtualization environments, including VM lifecycle, container management, snapshot operations, and backup/restore capabilities.",
     "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "proxmox-mcp-plus"
-version = "0.5.13"
+version = "0.5.14"
 description = "Enhanced Proxmox MCP Server"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -18,13 +18,13 @@
     "url": "https://github.com/RekklesNA/ProxmoxMCP-Plus",
     "source": "github"
   },
-  "version": "0.5.13",
+  "version": "0.5.14",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "proxmox-mcp-plus",
-      "version": "0.5.13",
+      "version": "0.5.14",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="proxmox-mcp-plus",
-    version="0.5.13",
+    version="0.5.14",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     python_requires=">=3.11",

--- a/src/proxmox_mcp/__init__.py
+++ b/src/proxmox_mcp/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .server import ProxmoxMCPServer
 
-__version__ = "0.5.13"
+__version__ = "0.5.14"
 __all__ = ["ProxmoxMCPServer"]
 
 

--- a/src/proxmox_mcp/mcp_http_auth.py
+++ b/src/proxmox_mcp/mcp_http_auth.py
@@ -1,0 +1,48 @@
+"""Authentication helpers for the native MCP Streamable HTTP transport."""
+
+from __future__ import annotations
+
+import hmac
+
+from starlette.datastructures import Headers
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+
+class MCPBearerAuthMiddleware:
+    """Require one configured Bearer token without buffering HTTP responses."""
+
+    def __init__(self, app: ASGIApp, *, api_key: str) -> None:
+        if not api_key or not api_key.isascii() or any(char.isspace() for char in api_key):
+            raise ValueError("MCP_API_KEY must be non-empty ASCII without whitespace")
+        self.app = app
+        self._expected_key = api_key.encode("utf-8")
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        authorization = Headers(scope=scope).get("authorization")
+        authenticated = False
+        if authorization:
+            scheme, separator, credentials = authorization.partition(" ")
+            if separator and scheme.lower() == "bearer":
+                authenticated = hmac.compare_digest(
+                    credentials.encode("utf-8"),
+                    self._expected_key,
+                )
+
+        if not authenticated:
+            response = JSONResponse(
+                {"detail": "Unauthorized"},
+                status_code=401,
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+            await response(scope, receive, send)
+            return
+
+        # Pass the ASGI exchange through directly. In particular, do not wrap
+        # ``send`` or collect response body events: Streamable HTTP may return
+        # text/event-stream and every chunk must reach the client immediately.
+        await self.app(scope, receive, send)

--- a/src/proxmox_mcp/server.py
+++ b/src/proxmox_mcp/server.py
@@ -16,6 +16,7 @@ from mcp.server.fastmcp import FastMCP
 from proxmox_mcp.config.loader import load_config
 from proxmox_mcp.core.logging import setup_logging
 from proxmox_mcp.core.proxmox import ProxmoxManager
+from proxmox_mcp.mcp_http_auth import MCPBearerAuthMiddleware
 from proxmox_mcp.observability import ToolMetrics
 from proxmox_mcp.security import CommandPolicyGate
 from proxmox_mcp.services import JobStore, ToolRegistry
@@ -189,6 +190,29 @@ class ProxmoxMCPServer:
         self.job_store.close()
         self.proxmox_manager.close()
 
+    async def _run_streamable_http_async(self) -> None:
+        """Run Streamable HTTP with optional inbound Bearer authentication."""
+        import uvicorn
+
+        app: Any = self.mcp.streamable_http_app()
+        api_key = os.getenv("MCP_API_KEY")
+        if api_key:
+            app = MCPBearerAuthMiddleware(app, api_key=api_key)
+            self.logger.info("MCP Streamable HTTP bearer authentication is enabled")
+        else:
+            self.logger.warning(
+                "MCP Streamable HTTP is running without MCP_API_KEY; "
+                "any client that can reach the endpoint may invoke MCP tools"
+            )
+
+        config = uvicorn.Config(
+            app,
+            host=self.mcp.settings.host,
+            port=self.mcp.settings.port,
+            log_level=self.mcp.settings.log_level.lower(),
+        )
+        await uvicorn.Server(config).serve()
+
     def start(self) -> None:
         """Start the MCP server with the configured transport."""
         import anyio
@@ -221,7 +245,7 @@ class ProxmoxMCPServer:
                 anyio.run(self.mcp.run_sse_async)
             elif transport == "STREAMABLE":
                 try:
-                    anyio.run(self.mcp.run_streamable_http_async)
+                    anyio.run(self._run_streamable_http_async)
                 except AttributeError:
                     anyio.run(self.mcp.run_sse_async)
             else:

--- a/tests/test_mcp_http_auth.py
+++ b/tests/test_mcp_http_auth.py
@@ -1,0 +1,164 @@
+"""Tests for native MCP Streamable HTTP Bearer authentication."""
+
+import asyncio
+from unittest.mock import patch
+
+from mcp.server.fastmcp import FastMCP
+import pytest
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from proxmox_mcp.mcp_http_auth import MCPBearerAuthMiddleware
+
+
+async def _ok(request):
+    return JSONResponse({"status": "ok"})
+
+
+def _client(api_key: str = "correct-secret") -> TestClient:
+    app = Starlette(routes=[Route("/mcp", endpoint=_ok, methods=["POST"])])
+    return TestClient(MCPBearerAuthMiddleware(app, api_key=api_key))
+
+
+@pytest.mark.parametrize("api_key", ["", " ", "leading-space ", "non-ascii-密钥"])
+def test_api_key_must_be_visible_ascii_without_whitespace(api_key):
+    with pytest.raises(ValueError, match="non-empty ASCII without whitespace"):
+        MCPBearerAuthMiddleware(Starlette(), api_key=api_key)
+
+
+def test_missing_authorization_is_rejected_with_bearer_challenge():
+    with _client() as client:
+        response = client.post("/mcp")
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Unauthorized"}
+    assert response.headers["WWW-Authenticate"] == "Bearer"
+
+
+def test_wrong_bearer_token_is_rejected_with_constant_time_comparison():
+    with patch(
+        "proxmox_mcp.mcp_http_auth.hmac.compare_digest",
+        return_value=False,
+    ) as compare_digest:
+        with _client() as client:
+            response = client.post(
+                "/mcp",
+                headers={"Authorization": "Bearer wrong-secret"},
+            )
+
+    assert response.status_code == 401
+    assert response.headers["WWW-Authenticate"] == "Bearer"
+    compare_digest.assert_called_once_with(b"wrong-secret", b"correct-secret")
+
+
+def test_non_bearer_authorization_is_rejected():
+    with _client() as client:
+        response = client.post(
+            "/mcp",
+            headers={"Authorization": "Basic YW55OnNlY3JldA=="},
+        )
+
+    assert response.status_code == 401
+
+
+def test_matching_bearer_token_is_accepted_case_insensitively():
+    with _client() as client:
+        response = client.post(
+            "/mcp",
+            headers={"Authorization": "bearer correct-secret"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_matching_bearer_reaches_native_streamable_http_initialize():
+    mcp = FastMCP("auth-test", json_response=True, stateless_http=True)
+    app = MCPBearerAuthMiddleware(mcp.streamable_http_app(), api_key="secret")
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "pytest", "version": "1"},
+        },
+    }
+
+    with TestClient(app, base_url="http://localhost:8000") as client:
+        response = client.post(
+            "/mcp",
+            headers={
+                "Authorization": "Bearer secret",
+                "Accept": "application/json, text/event-stream",
+            },
+            json=payload,
+        )
+
+    assert response.status_code == 200
+    assert response.json()["result"]["serverInfo"]["name"] == "auth-test"
+
+
+def test_successful_streaming_response_events_are_forwarded_unchanged():
+    expected_events = [
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [(b"content-type", b"text/event-stream")],
+        },
+        {
+            "type": "http.response.body",
+            "body": b"event: message\ndata: one\n\n",
+            "more_body": True,
+        },
+        {
+            "type": "http.response.body",
+            "body": b"event: message\ndata: two\n\n",
+            "more_body": False,
+        },
+    ]
+
+    async def streaming_app(scope, receive, send):
+        for event in expected_events:
+            await send(event)
+
+    middleware = MCPBearerAuthMiddleware(streaming_app, api_key="secret")
+    actual_events = []
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(event):
+        actual_events.append(event)
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/mcp",
+        "headers": [(b"authorization", b"Bearer secret")],
+    }
+    asyncio.run(middleware(scope, receive, send))
+
+    assert actual_events == expected_events
+
+
+def test_lifespan_scope_passes_through_to_wrapped_app():
+    seen_scopes = []
+
+    async def app(scope, receive, send):
+        seen_scopes.append(scope["type"])
+
+    middleware = MCPBearerAuthMiddleware(app, api_key="secret")
+
+    async def receive():
+        return {"type": "lifespan.shutdown"}
+
+    async def send(event):
+        return None
+
+    asyncio.run(middleware({"type": "lifespan"}, receive, send))
+
+    assert seen_scopes == ["lifespan"]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,6 +2,7 @@
 Tests for the Proxmox MCP server.
 """
 
+import asyncio
 import os
 import json
 import select
@@ -11,12 +12,13 @@ import sys
 import textwrap
 import pytest
 from typing import Any, cast
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from mcp.server.fastmcp.exceptions import ToolError
 
 import proxmox_mcp.server as server_module
 from proxmox_mcp.config.loader import load_config
+from proxmox_mcp.mcp_http_auth import MCPBearerAuthMiddleware
 from proxmox_mcp.server import ProxmoxMCPServer
 
 
@@ -105,6 +107,37 @@ def test_server_close_releases_job_store_and_proxmox_manager(server):
 
     server.job_store.close.assert_called_once()
     server.proxmox_manager.close.assert_called_once()
+
+
+def test_streamable_http_runner_wraps_app_when_api_key_is_set(server, monkeypatch):
+    base_app = Mock()
+    server.mcp.streamable_http_app = Mock(return_value=base_app)
+    monkeypatch.setenv("MCP_API_KEY", "mcp-secret")
+
+    with patch("uvicorn.Config") as config:
+        with patch("uvicorn.Server") as uvicorn_server:
+            uvicorn_server.return_value.serve = AsyncMock()
+            asyncio.run(server._run_streamable_http_async())
+
+    wrapped_app = config.call_args.args[0]
+    assert isinstance(wrapped_app, MCPBearerAuthMiddleware)
+    assert wrapped_app.app is base_app
+    uvicorn_server.return_value.serve.assert_awaited_once()
+
+
+def test_streamable_http_runner_preserves_no_auth_compatibility(server, monkeypatch, caplog):
+    base_app = Mock()
+    server.mcp.streamable_http_app = Mock(return_value=base_app)
+    monkeypatch.delenv("MCP_API_KEY", raising=False)
+
+    with patch("uvicorn.Config") as config:
+        with patch("uvicorn.Server") as uvicorn_server:
+            uvicorn_server.return_value.serve = AsyncMock()
+            asyncio.run(server._run_streamable_http_async())
+
+    assert config.call_args.args[0] is base_app
+    assert "running without MCP_API_KEY" in caplog.text
+    uvicorn_server.return_value.serve.assert_awaited_once()
 
 
 def test_server_applies_configured_http_host_and_port(mock_proxmox, tmp_path):


### PR DESCRIPTION
## Summary

- add optional `MCP_API_KEY` Bearer authentication to the native Streamable HTTP `/mcp` endpoint
- reject missing, malformed, and incorrect credentials with `401` and `WWW-Authenticate: Bearer`
- preserve unbuffered SSE delivery with a direct ASGI pass-through middleware
- keep STDIO, SSE, OpenAPI authentication, and unauthenticated Streamable HTTP compatibility unchanged
- publish aligned v0.5.14 metadata, release notes, Docker configuration, and operator/security documentation

Addresses #118.

## Security design

- `MCP_API_KEY` is independent of the OpenAPI-only `PROXMOX_API_KEY`
- token comparison uses `hmac.compare_digest`
- configured keys must be non-empty ASCII without whitespace
- credentials are never written to logs
- successful ASGI response events are forwarded directly without buffering

## Validation

- `python -m pytest -q` — 255 passed, 2 skipped
- `python -m ruff check .`
- `python -m mypy src --ignore-missing-imports`
- `python -m pip_audit -r requirements.txt` — no known vulnerabilities
- `git diff --check`
- fresh wheel and sdist build in `.codex-run/dist-v0.5.14-final`
- Twine 7 metadata checks passed in an isolated environment
- clean install/import from the v0.5.14 wheel confirmed the version and new auth module