### PR TITLE
docs: add reviewed Jetson community guide

### DIFF
--- a/docs/wiki/Integrations Guide.md
+++ b/docs/wiki/Integrations Guide.md
@@ -127,6 +127,19 @@ After connecting a client, verify:
 - TLS verification disabled in config while `dev_mode` is false
 - assuming `execute_container_command` should exist without an `ssh` section
 
+## Community Deployment Guides
+
+Community guides are hosted separately and may describe version-specific
+behavior that changes over time. Review this project's Operator Guide and
+Security Guide before exposing MCP, OpenAPI, or client endpoints.
+
+- [Jetson Orin Nano with Ollama and Open WebUI](https://github.com/RekklesNA/proxmox-mcp-plus-JetsonOrinNano-setup)
+  — a version-pinned walkthrough for running ProxmoxMCP-Plus with a local
+  7B-class model on an 8GB NVIDIA Jetson Orin Nano. Based on the original
+  community guide by `nroam`, reviewed and maintained by the ProxmoxMCP-Plus
+  maintainer. The original author attribution and MIT License are preserved in
+  the linked repository.
+
 ## Related Pages
 
 - [Client Setup](Client-Setup)


### PR DESCRIPTION
## Summary

- add one Community Deployment Guides entry to the Integrations Guide
- link only the maintainer-reviewed fork of the Jetson Orin Nano, Ollama, and Open WebUI walkthrough
- preserve explicit credit to the original `nroam` guide and its MIT license
- warn that community guidance is version-specific and should be read with the Operator and Security guides

## Validation

- `python -m pytest tests/test_release_metadata.py -q` (5 passed)
- `git diff --check`
- verified the linked fork uses `main`, retains the MIT license, and identifies itself as maintainer-reviewed

Related: #120