### PR TITLE
release: v0.5.15 named targets and tool filtering

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,7 +17,7 @@ dist
 assets
 proxmox_mcp.log
 *.log
-*.sqlite3
+*.sqlite3*
 .env
 .env.*
 *.key

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -6,8 +6,8 @@ This project currently provides security fixes for the latest release line only.
 
 | Version | Supported |
 | --- | --- |
-| `0.3.x` | Yes |
-| `< 0.4.1` | No |
+| Latest published release | Yes |
+| Older releases | No |
 
 The `main` branch may contain changes that have not been released yet. For production use, prefer the latest tagged release and upgrade within the current supported release line.
 

--- a/.gitignore
+++ b/.gitignore
@@ -64,9 +64,7 @@ coverage.xml
 config/config.json
 proxmox-config/config.json
 proxmox-config/config.live.json
-proxmox-jobs.sqlite3
-proxmox-jobs.sqlite3-shm
-proxmox-jobs.sqlite3-wal
+*.sqlite3*
 **/config.json
 
 # MCP Bundle artifacts

--- a/docs/releases/v0.5.15.md
+++ b/docs/releases/v0.5.15.md
@@ -1,0 +1,80 @@
+# ProxmoxMCP-Plus v0.5.15
+
+Release date: 2026-09-04
+
+## Named Proxmox targets
+
+Configure multiple Proxmox environments in a `targets` map and select the destination
+with the `target` tool argument. `list_targets` provides credential-free discovery.
+Each target has its own API/SSH configuration, job database, read-only setting, and
+command policy. Requests must select a target when the configuration is ambiguous.
+
+Named targets work in stdio, native MCP HTTP, and OpenAPI, including the default Docker
+runtime. Direct OpenAPI `/jobs` routes accept `target` as a query parameter and enforce
+the selected target's read-only and retry-approval policies. The MCP subprocess owns
+managed API tunnels; the OpenAPI process reuses the endpoint without taking ownership.
+
+## Optional tool filtering — #102
+
+Use JSON configuration:
+
+```json
+{
+  "mcp": {
+    "tool_allowlist": ["list_targets", "get_nodes", "get_vms", "get_storage"]
+  }
+}
+```
+
+Or set a comma-separated environment variable:
+
+```bash
+MCP_TOOL_ALLOWLIST=list_targets,get_nodes,get_vms,get_storage
+```
+
+`tool_denylist` and `MCP_TOOL_DENYLIST` are supported as the alternative mode. Do not
+configure both modes. An environment filter replaces the file-level filter mode.
+Explicitly empty allowlists expose no tools; empty denylists hide none. Unknown names,
+malformed names, and empty CSV entries such as `,` or `get_nodes,` stop startup.
+
+Filtering happens before registration: hidden schemas do not appear in MCP `tools/list`
+or generated OpenAPI tool routes, and hidden MCP tools cannot be invoked. The full
+catalog contains 50 tools; capability checks still apply. Filtering does not disable
+direct operational OpenAPI routes or replace authentication and Proxmox RBAC.
+
+## Safety and compatibility
+
+- Legacy single-target configuration and unfiltered tool schemas are preserved.
+- Existing untargeted jobs remain accessible when using legacy configuration.
+- Named targets do not inherit another target's jobs, SSH connection, or command policy.
+- Ambiguous global/target settings and conflicting tunnel endpoints are rejected.
+- External tunnels are never started or stopped by the server, including when their listener is unavailable.
+- Credential redaction handles quoted values, whitespace, and escaped quotes without the earlier pathological regular-expression slowdown.
+- Named-target SQLite databases and their WAL/SHM files are excluded from Git and Docker build contexts.
+- Persisted retry recipes remain credential-free; retries needing secrets may require a new invocation after a restart.
+
+## Documentation — #120
+
+The Integrations Guide includes a maintainer-reviewed fork of the Jetson Orin Nano,
+Ollama, and Open WebUI community guide. The guide preserves `nroam`'s attribution and
+MIT License and documents its tested versions, credential boundaries, read-only RBAC,
+TLS verification, and loopback network bindings. It remains a version-specific
+community resource rather than a claim of new live deployment validation.
+
+## Upgrade and validation
+
+Upgrade with `pip install --upgrade proxmox-mcp-plus==0.5.15` or the GHCR `0.5.15` image.
+Back up configuration and job databases, then restart the server and reconnect clients
+to refresh cached schemas. Keep authentication, TLS, ingress restrictions, and Proxmox
+permissions in place when narrowing the exposed tool set.
+
+Validation covers Python 3.11/3.12 CI, the unchanged 75% coverage gate, Ruff, mypy,
+CodeQL, dependency auditing, build/metadata checks, real stdio tool discovery, and local
+OpenAPI-to-MCP subprocess checks with target selection and read-only enforcement.
+The local protocol checks use non-live targets and do not mutate Proxmox infrastructure.
+Publication additionally verifies PyPI, the MCP Registry, multi-architecture GHCR images,
+and native ARM64 application health.
+
+To roll back to `0.5.14`, restore a legacy single-target configuration: that version
+does not understand named targets or tool filters. Preserve database backups and retain
+external access restrictions before removing these application-level controls.

--- a/docs/wiki/API & Tool Reference.md
+++ b/docs/wiki/API & Tool Reference.md
@@ -41,9 +41,22 @@ When the OpenAPI wrapper is enabled, the primary endpoints are:
 
 ## Global Behavior And Constraints
 
+### Target Selection and Tool Exposure
+
+`list_targets` discovers configured targets without returning credentials. All other
+tools accept an optional `target` argument; it is required when multiple targets exist.
+Target configuration owns the API/SSH connections, job store, read-only setting, and
+command policy. Direct OpenAPI `/jobs` routes use the `target` query parameter.
+
+The complete catalog has 50 tools. Optional `mcp.tool_allowlist` / `mcp.tool_denylist`
+settings filter tools before MCP registration and OpenAPI route generation, including
+`list_targets`. The default exposes every available tool; SSH-only tools still require
+SSH configuration. Filtering does not disable direct operational OpenAPI routes or
+replace Proxmox RBAC. See the [Operator Guide](Operator-Guide) for exact configuration.
+
 ### Authentication and Authorization
 
-- Proxmox API access requires a valid `proxmox` and `auth` configuration.
+- Proxmox API access requires valid legacy `proxmox` and `auth` sections or a named `targets` configuration.
 - Native MCP Streamable HTTP access optionally requires `Authorization: Bearer <MCP_API_KEY>` when `MCP_API_KEY` is configured.
 - OpenAPI access requires `Authorization: Bearer <PROXMOX_API_KEY>` by default. Startup without an API key requires the explicit local-development override `PROXMOX_ALLOW_NO_AUTH=true`.
 - SSH-backed container command workflows require a valid `ssh` configuration.

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -49,6 +49,8 @@ Use the root `README.md` for the fast project overview. Use this wiki when you n
 - SSH-backed container command execution
 - persistent job tracking with retry, cancel, polling, and audit history
 - OpenAPI bridging for the MCP tool surface
+- named Proxmox targets with isolated connections, jobs, and safety policies
+- opt-in MCP tool allowlists and denylists to reduce client schema exposure
 
 ## Safety Model Summary
 

--- a/docs/wiki/Release & Upgrade Notes.md
+++ b/docs/wiki/Release & Upgrade Notes.md
@@ -18,6 +18,19 @@ Use this page to track version-level behavior changes, upgrade steps, and rollba
 
 ## Release History
 
+### Version `0.5.15`
+
+- Release date: 2026-09-04
+- Summary: named Proxmox targets, opt-in tool filtering, and target/job safety hardening.
+- New tools: `list_targets`; the complete catalog contains 50 tools, subject to capability and exposure filters.
+- Configuration: optional `targets`, `mcp.tool_allowlist`, `mcp.tool_denylist`, `MCP_TOOL_ALLOWLIST`, and `MCP_TOOL_DENYLIST`.
+- Compatibility: legacy single-target configuration and unfiltered tool schemas remain available unchanged.
+- Safety: target-isolated jobs and policies, explicit multi-target selection, credential redaction, external tunnel ownership, and rejection of malformed filters.
+- Packaging: named-target SQLite databases and their WAL/SHM files are excluded from Git and Docker contexts.
+- Documentation: the Integrations Guide links the attributed, maintainer-reviewed Jetson community guide.
+- Upgrade: install `proxmox-mcp-plus==0.5.15` or pull GHCR `0.5.15`, then restart/reconnect clients. See the detailed release notes in `docs/releases/v0.5.15.md`.
+- Rollback: keep configuration/database backups. Version `0.5.14` does not support named targets or tool filtering; restore a legacy single-target configuration and external access restrictions before rolling back.
+
 ### Version `0.5.14`
 
 - Release date: 2026-08-11

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": "0.4",
     "name": "proxmox-mcp-plus",
     "display_name": "ProxmoxMCP-Plus",
-    "version": "0.5.14",
+    "version": "0.5.15",
     "description": "An enhanced MCP server for managing Proxmox virtualization platforms.",
     "long_description": "ProxmoxMCP-Plus is an enhanced Model Context Protocol (MCP) server that provides comprehensive tools for managing Proxmox virtualization environments, including VM lifecycle, container management, snapshot operations, and backup/restore capabilities.",
     "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "proxmox-mcp-plus"
-version = "0.5.14"
+version = "0.5.15"
 description = "Enhanced Proxmox MCP Server"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -18,13 +18,13 @@
     "url": "https://github.com/RekklesNA/ProxmoxMCP-Plus",
     "source": "github"
   },
-  "version": "0.5.14",
+  "version": "0.5.15",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "proxmox-mcp-plus",
-      "version": "0.5.14",
+      "version": "0.5.15",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="proxmox-mcp-plus",
-    version="0.5.14",
+    version="0.5.15",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     python_requires=">=3.11",

--- a/src/proxmox_mcp/__init__.py
+++ b/src/proxmox_mcp/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .server import ProxmoxMCPServer
 
-__version__ = "0.5.14"
+__version__ = "0.5.15"
 __all__ = ["ProxmoxMCPServer"]
 
 

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -1,4 +1,5 @@
 import ast
+import fnmatch
 import json
 import re
 import tomllib
@@ -96,6 +97,18 @@ def test_docker_context_excludes_local_secrets_and_tool_state():
         "!proxmox-config/config.example.json",
         "!proxmox-config/config.live.example.json",
     } <= patterns
+
+    git_patterns = (ROOT / ".gitignore").read_text(encoding="utf-8").splitlines()
+    for database in (
+        "proxmox-jobs.sqlite3",
+        "proxmox-jobs.sqlite3-wal",
+        "proxmox-jobs.sqlite3-shm",
+        "proxmox-jobs.sqlite3.target-lab",
+        "proxmox-jobs.sqlite3.target-lab-wal",
+        "proxmox-jobs.sqlite3.target-lab-shm",
+    ):
+        assert any(fnmatch.fnmatchcase(database, pattern) for pattern in patterns)
+        assert any(fnmatch.fnmatchcase(database, pattern) for pattern in git_patterns)
 
 
 def test_runtime_image_removes_python_packaging_toolchain():


### PR DESCRIPTION
## Summary

Prepare v0.5.15 with the merged named-target support (#121), opt-in tool filtering (#122, addressing #102), and the maintainer-reviewed community guide linked for #120.

Align all package, manifest, and MCP Registry versions; add upgrade and rollback notes; document target selection and filtering; and correct the outdated supported-version table. Exclude all SQLite job databases and sidecars from Git and Docker build contexts, including the new `.sqlite3.target-<name>` files.

## Validation

- The implementation merged through #122 passed Python 3.11/3.12 CI: 359 passed, 1 skipped, 80.07% coverage; CodeQL reported zero findings.
- Local release metadata and database-exclusion checks: 5 passed. Ruff, dependency audit, wheel/sdist build, and Twine checks passed.
- Real stdio protocol comparison confirmed unchanged default schemas (48 tools without SSH) and an allowlist exposing only 2 selected tools. Hidden-tool invocation was rejected.
- Local OpenAPI-to-MCP startup verified authenticated health, filtered generated routes, target-aware schemas, HTTP 400 for ambiguous job queries, and HTTP 403 for read-only job mutations. No live Proxmox infrastructure was contacted.
- Docker Action SHA pins were checked against their upstream release tags.

After the release PR and merged-main checks pass, publish the tag and verify PyPI, GHCR amd64/arm64, native ARM64 health, and MCP Registry metadata before closing #102 and #120 with English completion notes.
